### PR TITLE
fixes for usage of params and dependecy cycles

### DIFF
--- a/manifests/userparameters.pp
+++ b/manifests/userparameters.pp
@@ -43,8 +43,6 @@ define zabbix::userparameters (
       group   => 'zabbix',
       mode    => '0755',
       source  => $source,
-      notify  => Service['zabbix-agent'],
-      require => Service['zabbix-agent'],
     }
   }
 
@@ -55,8 +53,6 @@ define zabbix::userparameters (
       group   => 'zabbix',
       mode    => '0755',
       content => $content,
-      notify  => Service['zabbix-agent'],
-      require => Service['zabbix-agent'],
     }
   }
 }


### PR DESCRIPTION
puppet agent --test was complaining about:

Error: Could not apply complete catalog: Found 1 dependency cycle:
(File[/mysql.conf.conf] => Service[zabbix-agent] => File[/mysql.conf.conf]

Those two changes are fixing lack of correct path in File[/mysql.conf.conf] and dependecy cycle
