### PR TITLE
added support for Scientific Linux

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -44,7 +44,7 @@ class zabbix::repo(
   }
 
   case $::operatingsystem {
-    'centos','redhat','oraclelinux' : {
+    'centos','scientific','redhat','oraclelinux' : {
       yumrepo { 'zabbix':
         name     => "Zabbix_${majorrelease}_${::architecture}",
         descr    => "Zabbix_${majorrelease}_${::architecture}",


### PR DESCRIPTION
Simple addition of 'scientific' to repo $::operatingsystem case to support Scientific Linux
