### PR TITLE
Added XenServer 6.2 support

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -44,7 +44,7 @@ class zabbix::repo(
   }
 
   case $::operatingsystem {
-    'centos','scientific','redhat','oraclelinux','XenServer' : {
+    'centos','scientific','redhat','oraclelinux' : {
       yumrepo { 'zabbix':
         name     => "Zabbix_${majorrelease}_${::architecture}",
         descr    => "Zabbix_${majorrelease}_${::architecture}",
@@ -63,6 +63,25 @@ class zabbix::repo(
       }
 
     } # END 'centos','redhat','oraclelinux'
+    'XenServer' : {
+      yumrepo { 'zabbix':
+        name     => "Zabbix_${majorrelease}_${::architecture}",
+        descr    => "Zabbix_${majorrelease}_${::architecture}",
+        baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/5/${::architecture}/",
+        gpgcheck => '1',
+        gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+        priority => '1',
+      }
+      yumrepo { 'zabbix-nonsupported':
+        name     => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
+        descr    => "Zabbix_nonsupported_${majorrelease}_${::architecture}",
+        baseurl  => "http://repo.zabbix.com/non-supported/rhel/5/${::architecture}/",
+        gpgcheck => '1',
+        gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+        priority => '1',
+      }
+
+    } # END 'XenServer'
     'debian' : {
       apt::source { 'zabbix':
         location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/debian/",


### PR DESCRIPTION
Xenserver 6.2 is based on RedHat/Centos 5, so adding repo for those system will work.
Tested on XenServer 6.2
