### PR TITLE
Attempt to fix #13 in code rather than documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ You can use userparameter files (or specific entries) to install it into the age
 The following will provide an basic usage of the zabbix components.
 ###Usage zabbix-server
 ```ruby
-class { 'apache':
-    mpm_module => 'prefork',
-}
-include apache::mod::php
 
 class { 'postgresql::server': }
 #class { 'mysql::server': }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -519,7 +519,10 @@ class zabbix::server (
 
   # Is set to true, it will create the apache vhost.
   if $manage_vhost {
-    include apache
+    class { 'apache':
+      mpm_module => 'prefork',
+    }
+    include apache::mod::php
     # Check if we use ssl. If so, we also create an non ssl
     # vhost for redirect traffic from non ssl to ssl site.
     if $apache_use_ssl {


### PR DESCRIPTION
Moving the code for mod::php from the README into the puppet code makes it easier to use the module and means less documentation to read.

The README was originally added to address issue #13.
