### PR TITLE
Add repository for debian running on a raspberry pi

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -87,12 +87,23 @@ class zabbix::repo(
 
     } # END 'XenServer'
     'debian' : {
-      apt::source { 'zabbix':
-        location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/debian/",
-        release    => $debian,
-        repos      => 'main',
-        key        => '79EA5ED4',
-        key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
+      if ($::architecture == 'armv6l') {
+        apt::source { 'zabbix':
+          location    => "http://naizvoru.com/raspbian/zabbix",
+          release     => $debian,
+          repos       => 'main',
+          key         => 'D54A213C80E871A7',
+          key_source  => 'http://naizvoru.com/raspbian/zabbix/conf/boris@steki.net.gpg.key',
+          include_src => false,
+        }
+      } else {
+        apt::source { 'zabbix':
+          location   => "http://repo.zabbix.com/zabbix/${zabbix_version}/debian/",
+          release    => $debian,
+          repos      => 'main',
+          key        => '79EA5ED4',
+          key_source => 'http://repo.zabbix.com/zabbix-official-repo.key',
+        }
       }
     } # END 'debian'
     'ubuntu' : {


### PR DESCRIPTION
The standard zabbix repository doesn't support raspberry pi's architecture.
http://www.zabbix.org/wiki/Rpi_wheezy_2.0.9 suggests using this alternate repository.
