### PR TITLE
Wrong name in zabbix::userparameters resource example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ class { 'zabbix::proxy':
 Using an 'source' file:
 
 ```ruby
-zabbix::userparameters { 'mysql.conf':
+zabbix::userparameters { 'mysql':
   source => 'puppet:///modules/zabbix/mysqld.conf',
 }
 ```
@@ -145,7 +145,7 @@ zabbix::userparameters { 'mysql.conf':
 Or for example when you have just one entry:
 
 ```ruby
-zabbix::userparameters { 'mysql.conf':
+zabbix::userparameters { 'mysql':
   content => 'UserParameter=mysql.ping,mysqladmin -uroot ping | grep -c alive',
 }
 ```


### PR DESCRIPTION
Hi Werner,

Both $source  and  $content file resources in [userparameters.pp](https://github.com/karolisc/puppet-zabbix/blob/master/manifests/userparameters.pp)
has this  -  **file { "${include_dir}/${name}.conf":**

Leaving mysql.conf will add extra "conf" to the file name.

Karolis
