### PR TITLE
Remove execute bit from .conf files

### DIFF
--- a/manifests/userparameters.pp
+++ b/manifests/userparameters.pp
@@ -54,7 +54,7 @@ define zabbix::userparameters (
       ensure  => present,
       owner   => 'zabbix',
       group   => 'zabbix',
-      mode    => '0755',
+      mode    => '0644',
       source  => $source,
     }
   }
@@ -64,7 +64,7 @@ define zabbix::userparameters (
       ensure  => present,
       owner   => 'zabbix',
       group   => 'zabbix',
-      mode    => '0755',
+      mode    => '0644',
       content => $content,
     }
   }


### PR DESCRIPTION
Hi Werner,

Why does .conf files in zabbix_agentd.d directory need to be executable?

Karolis
