### PR TITLE
fix typo in zabbix_host provider

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
 
     # Get the template ids.
     template_array = []
-    if templates.is_af?(Array)
+    if templates.is_a?(Array)
       templates.each do |template|
         template_id = self.class.get_template_id(zbx, template)
         template_array.push template_id


### PR DESCRIPTION
I am assuming here that `is_af?` should be `is_a?`.