### PR TITLE
Fix user parameter template + improved template import

### DIFF
--- a/lib/puppet/provider/zabbix_userparameters/ruby.rb
+++ b/lib/puppet/provider/zabbix_userparameters/ruby.rb
@@ -2,6 +2,8 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'zabbix'))
 Puppet::Type.type(:zabbix_userparameters).provide(:ruby, parent: Puppet::Provider::Zabbix) do
   def create
+    zabbix_url = @resource[:zabbix_url]
+
     self.class.require_zabbix if zabbix_url != ''
 
     host = @resource[:hostname]

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -287,9 +287,15 @@ class zabbix::agent (
       $use_proxy = ''
     }
 
+    if $listen_ip == '*' {
+      $agent_listen_ip = $::ipaddress
+    } else {
+      $agent_listen_ip = $listen_ip
+    }
+
     class { '::zabbix::resources::agent':
       hostname     => $::fqdn,
-      ipaddress    => $listen_ip,
+      ipaddress    => $agent_listen_ip,
       use_ip       => $agent_use_ip,
       port         => $listenport,
       group        => $zbx_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -200,6 +200,8 @@ class zabbix (
     database_port                            => $database_port,
     zabbix_server                            => $zabbix_server,
     zabbix_listenport                        => $listenport,
+    apache_user                              => $apache_user,
+    apache_group                             => $apache_group,
     apache_php_max_execution_time            => $apache_php_max_execution_time,
     apache_php_memory_limit                  => $apache_php_memory_limit,
     apache_php_post_max_size                 => $apache_php_post_max_size,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,8 @@ class zabbix (
   $apache_ssl_key                           = $zabbix::params::apache_ssl_key,
   $apache_ssl_cipher                        = $zabbix::params::apache_ssl_cipher,
   $apache_ssl_chain                         = $zabbix::params::apache_ssl_chain,
+  $apache_user                              = $zabbix::params::apache_user,
+  $apache_group                             = $zabbix::params::apache_group,
   $apache_listen_ip                         = $zabbix::params::apache_listen_ip,
   $apache_listenport                        = $zabbix::params::apache_listenport,
   $apache_listenport_ssl                    = $zabbix::params::apache_listenport_ssl,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,6 +70,8 @@ class zabbix::params {
   $apache_php_upload_max_filesize           = '2M'
 
   # Zabbix-web
+  $apache_user                              = getvar('::apache::user')
+  $apache_group                             = getvar('::apache::group')
   $apache_listen_ip                         = undef
   $apache_listenport                        = '80'
   $apache_listenport_ssl                    = '443'

--- a/manifests/resources/template.pp
+++ b/manifests/resources/template.pp
@@ -19,7 +19,7 @@ define zabbix::resources::template (
   $template_source = '',
 ) {
 
-  @@file { "${template_dir}/${template_name}.xml":
+  file { "${template_dir}/${template_name}.xml":
     ensure => present,
     owner  => 'zabbix',
     group  => 'zabbix',

--- a/manifests/resources/template.pp
+++ b/manifests/resources/template.pp
@@ -23,8 +23,7 @@ define zabbix::resources::template (
     ensure => present,
     owner  => 'zabbix',
     group  => 'zabbix',
-    source => $template_source,
-    tag    => ['zabbix_template']
+    source => $template_source
   }
 
   @@zabbix_template { $template_name:

--- a/manifests/resources/template.pp
+++ b/manifests/resources/template.pp
@@ -19,11 +19,12 @@ define zabbix::resources::template (
   $template_source = '',
 ) {
 
-  file { "${template_dir}/${template_name}.xml":
+  @@file { "${template_dir}/${template_name}.xml":
     ensure => present,
     owner  => 'zabbix',
     group  => 'zabbix',
     source => $template_source,
+    tag    => ['zabbix_template']
   }
 
   @@zabbix_template { $template_name:

--- a/manifests/resources/web.pp
+++ b/manifests/resources/web.pp
@@ -29,6 +29,7 @@ class zabbix::resources::web (
       Package['zabbixapi'],
     ],
   } ->
+  File <<| tag == 'zabbix_template' |>> ->
   Zabbix_template <<| |>> {
     zabbix_url     => $zabbix_url,
     zabbix_user    => $zabbix_user,

--- a/manifests/resources/web.pp
+++ b/manifests/resources/web.pp
@@ -29,7 +29,6 @@ class zabbix::resources::web (
       Package['zabbixapi'],
     ],
   } ->
-  File <<| tag == 'zabbix_template' |>> ->
   Zabbix_template <<| |>> {
     zabbix_url     => $zabbix_url,
     zabbix_user    => $zabbix_user,

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -201,6 +201,8 @@ class zabbix::web (
   $database_port                            = $zabbix::params::server_database_port,
   $zabbix_server                            = $zabbix::params::zabbix_server,
   $zabbix_listenport                        = $zabbix::params::server_listenport,
+  $apache_user                              = $zabbix::params::apache_user,
+  $apache_group                             = $zabbix::params::apache_group,
   $apache_php_max_execution_time            = $zabbix::params::apache_php_max_execution_time,
   $apache_php_memory_limit                  = $zabbix::params::apache_php_memory_limit,
   $apache_php_post_max_size                 = $zabbix::params::apache_php_post_max_size,
@@ -213,9 +215,6 @@ class zabbix::web (
   $ldap_clientkey                           = $zabbix::params::ldap_clientkey,
   $puppetgem                                = $zabbix::params::puppetgem,
 ) inherits zabbix::params {
-  $apache_user = getvar('::apache::user')
-  $apache_group = getvar('::apache::group')
-
   # Only include the repo class if it has not yet been included
   unless defined(Class['Zabbix::Repo']) {
     class { '::zabbix::repo':


### PR DESCRIPTION
Writing puppet modules with templates being imported in each profile with exported resoruces is much cleaner than listing them all in the server.

Also, fixed a bug with user parameters missing variable