### PR TITLE
Accepts "lo" as loopback interface

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -264,7 +264,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|bond|lxc|eno|tap|tun).*/) {
+    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun).*/) {
       $int_name  = getvar("::ipaddress_${listenip}")
     } elsif is_ip_address($listenip) or $listenip == '*' {
       $listen_ip = $listenip


### PR DESCRIPTION
`$::ipaddress_lo` will return 127.0.0.1. This makes `listenip => 'lo'` function as expected.