### PR TITLE
Allows setting ListenIP as "lo" loopback interface.

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -265,8 +265,7 @@ class zabbix::agent (
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
     if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun).*/) {
-      $int_name  = getvar("::ipaddress_${listenip}")
-      $listen_ip = $int_name
+      $listen_ip = getvar("::ipaddress_${listenip}")
     } elsif is_ip_address($listenip) or $listenip == '*' {
       $listen_ip = $listenip
     } else {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -264,8 +264,9 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|bond|lxc|eno|tap|tun).*/) {
+    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun).*/) {
       $int_name  = getvar("::ipaddress_${listenip}")
+      $listen_ip = $int_name
     } elsif is_ip_address($listenip) or $listenip == '*' {
       $listen_ip = $listenip
     } else {

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -420,8 +420,8 @@ class zabbix::proxy (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|bond|lxc|eno|tap|tun).*/) {
-      $int_name  = getvar("::ipaddress_${listenip}")
+    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun).*/) {
+      $listen_ip = getvar("::ipaddress_${listenip}")
     } elsif is_ip_address($listenip) {
       $listen_ip = $listenip
     } else {


### PR DESCRIPTION
* listenip => 'eth0' was being ignored in zabbix-agentd.conf because $listen_ip was not being set when regex matched. now $listen_ip will be set to the IPaddress returned from $::ipaddress_eth0
* added option to use interface "lo" (127.0.0.1)