### PR TITLE
[do not merge]load facts from seperate yaml file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ group :test do
   gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec-puppet-utils',                                         :require => false
-  gem 'puppet-lint',                                                :require => false, :git => 'https://github.com/rodjek/puppet-lint.git'
   gem 'puppet-lint-absolute_classname-check',                       :require => false
   gem 'puppet-lint-leading_zero-check',                             :require => false
   gem 'puppet-lint-trailing_comma-check',                           :require => false

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,0 +1,6 @@
+---
+concat_basedir: "/tmp"
+ipaddress: "172.16.254.254"
+is_pe: false
+macaddress: "AA:AA:AA:AA:AA:AA"
+selinux_config_mode: "disabled"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,15 +3,13 @@ require 'rspec-puppet-facts'
 include RspecPuppetFacts
 
 RSpec.configure do |c|
-  c.default_facts = {
-    concat_basedir: '/tmp',
-    is_pe: false,
-    selinux_config_mode: 'disabled',
+  default_facts = {
     puppetversion: Puppet.version,
-    facterversion: Facter.version,
-    ipaddress: '172.16.254.254',
-    macaddress: 'AA:AA:AA:AA:AA:AA'
+    facterversion: Facter.version
   }
+  default_facts += YAML.read_file('default_facts.yml') if File.exist?('default_facts.yml')
+  default_facts += YAML.read_file('default_facts.yml') if File.exist?('default_module_facts.yml')
+  c.default_facts = default_facts
 end
 require 'spec_helper_methods'
 # vim: syntax=ruby


### PR DESCRIPTION
We had a discussion on IRC about moving the facts from spec_helper.rb (which are generated by modulesync from a yaml file) to a dedicated yaml file, and the spec helper only reads the file. I also added support to read module-specific facts.