### PR TITLE
Fix for issue #240

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,5 +9,6 @@ fixtures:
     mysql: "git://github.com/puppetlabs/puppetlabs-mysql.git"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
     pe_gem: "git://github.com/puppetlabs/puppetlabs-pe_gem.git"
+    systemd: "git://github.com/camptocamp/puppet-systemd.git"
   symlinks:
     zabbix: "#{source_dir}"

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -316,7 +316,7 @@ class zabbix::agent (
   # Ensure that the correct config file is used.
   
   if $::osfamily == 'debian' {
-    if $::operatingsystemmajrelease < 8 {
+    if versioncmp($::operatingsystemmajrelease, 8) == -1 {
       file { '/etc/init.d/zabbix-agent':
         ensure  => file,
         mode    => '0755',
@@ -338,7 +338,7 @@ class zabbix::agent (
       }
     }
   } elsif $::osfamily == 'redhat' {
-    if $::operatingsystemmajrelease < 7 {
+    if versioncmp($::operatingsystemmajrelease, 7) == -1 {
       file { '/etc/init.d/zabbix-agent':
         ensure  => file,
         mode    => '0755',

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -316,7 +316,7 @@ class zabbix::agent (
   # Ensure that the correct config file is used.
   
   if $::osfamily == 'debian' {
-    if versioncmp($::operatingsystemmajrelease, 8) == -1 {
+    if versioncmp($::operatingsystemmajrelease, '8') == -1 {
       file { '/etc/init.d/zabbix-agent':
         ensure  => file,
         mode    => '0755',
@@ -338,7 +338,7 @@ class zabbix::agent (
       }
     }
   } elsif $::osfamily == 'redhat' {
-    if versioncmp($::operatingsystemmajrelease, 7) == -1 {
+    if versioncmp($::operatingsystemmajrelease, '7') == -1 {
       file { '/etc/init.d/zabbix-agent':
         ensure  => file,
         mode    => '0755',

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -360,11 +360,11 @@ class zabbix::agent (
       }
     }
   }
-	
+
   if $agent_configfile_path != '/etc/zabbix/zabbix_agentd.conf' {
     file { '/etc/zabbix/zabbix_agentd.conf':
-      require => Package[$zabbix_package_agent],
       ensure  => absent,
+      require => Package[$zabbix_package_agent],
     }
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -474,8 +474,8 @@ class zabbix::server (
 
   if $server_configfile_path != '/etc/zabbix/zabbix_server.conf' {
     file { '/etc/zabbix/zabbix_server.conf':
-      require => Package["zabbix-server-${db}"],
       ensure  => absent,
+      require => Package["zabbix-server-${db}"],
     }
   }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -427,7 +427,7 @@ class zabbix::server (
   # Ensure that the correct config file is used.
   
   if $::osfamily == 'debian' {
-    if $::operatingsystemmajrelease < 8 {
+    if versioncmp($::operatingsystemmajrelease, 8) == -1 {
       file { '/etc/init.d/zabbix-server':
         ensure  => file,
         mode    => '0755',
@@ -449,7 +449,7 @@ class zabbix::server (
       }
     }
   } elsif $::osfamily == 'redhat' {
-    if $::operatingsystemrelease < 7 {
+    if versioncmp($::operatingsystemmajrelease, 7) == -1 {
       file { '/etc/init.d/zabbix-server':
         ensure  => file,
         mode    => '0755',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -427,7 +427,7 @@ class zabbix::server (
   # Ensure that the correct config file is used.
   
   if $::osfamily == 'debian' {
-    if versioncmp($::operatingsystemmajrelease, 8) == -1 {
+    if versioncmp($::operatingsystemmajrelease, '8') == -1 {
       file { '/etc/init.d/zabbix-server':
         ensure  => file,
         mode    => '0755',
@@ -449,7 +449,7 @@ class zabbix::server (
       }
     }
   } elsif $::osfamily == 'redhat' {
-    if versioncmp($::operatingsystemmajrelease, 7) == -1 {
+    if versioncmp($::operatingsystemmajrelease, '7') == -1 {
       file { '/etc/init.d/zabbix-server':
         ensure  => file,
         mode    => '0755',

--- a/metadata.json
+++ b/metadata.json
@@ -39,6 +39,10 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 1.2.5"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 0.3.0"
     }
   ],
   "source": "https://github.com/voxpupuli/puppet-zabbix.git",

--- a/templates/zabbix-agent-debian.init.erb
+++ b/templates/zabbix-agent-debian.init.erb
@@ -1,0 +1,68 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          zabbix-agent
+# Required-Start:    $remote_fs $network 
+# Required-Stop:     $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start zabbix-agent daemon
+### END INIT INFO
+
+set -e
+
+NAME=zabbix_agentd
+DAEMON=/usr/sbin/$NAME
+DAEMON_OPTS="-c <%= @agent_configfile_path %>"
+DESC="Zabbix agent"
+
+test -x $DAEMON || exit 0
+
+DIR=/var/run/zabbix
+PID=$DIR/$NAME.pid
+RETRY=15
+
+if test ! -d "$DIR"; then
+  mkdir -p "$DIR"
+  chown -R zabbix:zabbix "$DIR"
+fi
+
+export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
+
+# define LSB log_* functions.
+. /lib/lsb/init-functions
+
+if [ -r "/etc/default/zabbix-agent" ]; then
+    . /etc/default/zabbix-agent
+fi
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC" "$NAME"
+    start-stop-daemon --oknodo --start --pidfile $PID --exec $DAEMON -- $DAEMON_OPTS >/dev/null 2>&1
+    case "$?" in
+        0) log_end_msg 0 ;;
+        *) log_end_msg 1; exit 1 ;;
+    esac
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    start-stop-daemon --oknodo --stop --pidfile $PID --retry $RETRY
+    case "$?" in
+        0) log_end_msg 0 ;;
+        *) log_end_msg 1; exit 1 ;;
+    esac
+    ;;
+  status)
+    status_of_proc -p "$PID" "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
+  restart|force-reload)
+    $0 stop
+    $0 start
+    ;;
+  *)
+    echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/templates/zabbix-agent-redhat.init.erb
+++ b/templates/zabbix-agent-redhat.init.erb
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+#       /etc/rc.d/init.d/zabbix_agentd
+#
+# Starts the zabbix_agentd daemon
+#
+# chkconfig: - 95 5
+# description: Zabbix Monitoring Agent
+# processname: zabbix_agentd
+# pidfile: /tmp/zabbix_agentd.pid
+
+# Modified for Zabbix 2.0.0
+# May 2012, Zabbix SIA
+
+# Source function library.
+
+. /etc/init.d/functions
+
+RETVAL=0
+prog="Zabbix Agent"
+ZABBIX_BIN="/usr/local/sbin/zabbix_agentd"
+OPTS="-c <%= @agent_configfile_path %>"
+
+if [ ! -x ${ZABBIX_BIN} ] ; then
+        echo -n "${ZABBIX_BIN} not installed! "
+        # Tell the user this has skipped
+        exit 5
+fi
+
+start() {
+        echo -n $"Starting $prog: "
+        daemon "$ZABBIX_BIN -c $OPTS"
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && touch /var/lock/subsys/zabbix_agentd
+        echo
+}
+
+stop() {
+        echo -n $"Stopping $prog: "
+        killproc $ZABBIX_BIN
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/zabbix_agentd
+        echo
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  reload|restart)
+        stop
+        sleep 10
+        start
+        RETVAL=$?
+        ;;
+  condrestart)
+        if [ -f /var/lock/subsys/zabbix_agentd ]; then
+            stop
+            start
+        fi
+        ;;
+  status)
+        status $ZABBIX_BIN
+        RETVAL=$?
+        ;;
+  *)
+        echo $"Usage: $0 {condrestart|start|stop|restart|reload|status}"
+        exit 1
+esac
+
+exit $RETVAL

--- a/templates/zabbix-agent-systemd.init.erb
+++ b/templates/zabbix-agent-systemd.init.erb
@@ -1,0 +1,16 @@
+[Unit]
+Description=Zabbix Agent
+After=syslog.target network.target
+Documentation=man:zabbix_agentd
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/zabbix_agentd -c <%= @agent_configfile_path %>
+Restart=on-abnormal
+PIDFile=<%= @pidfile %>
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/zabbix-server-debian.init.erb
+++ b/templates/zabbix-server-debian.init.erb
@@ -1,0 +1,71 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:          zabbix-server
+# Required-Start:    $remote_fs $network
+# Required-Stop:     $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:	     0 1 6
+# Should-Start:      mysql
+# Should-Stop:       mysql
+# Short-Description: Start zabbix-server daemon
+### END INIT INFO
+
+set -e
+
+NAME=zabbix_server
+DAEMON=/usr/sbin/$NAME
+DAEMON_OPTS="-c <%= @server_configfile_path %>"
+DESC="Zabbix server"
+
+test -x $DAEMON || exit 0
+
+DIR=/var/run/zabbix
+PID=$DIR/$NAME.pid
+RETRY=15
+
+if test ! -d "$DIR"; then
+  mkdir -p "$DIR"
+  chown -R zabbix:zabbix "$DIR"
+fi
+
+export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
+
+# define LSB log_* functions.
+. /lib/lsb/init-functions
+
+if [ -r "/etc/default/zabbix-server" ]; then
+    . /etc/default/zabbix-server
+fi
+
+case "$1" in
+  start)
+    log_daemon_msg "Starting $DESC" "$NAME"
+    start-stop-daemon --oknodo --start --pidfile $PID \
+      --exec $DAEMON -- $DAEMON_OPTS >/dev/null 2>&1
+    case "$?" in
+        0) log_end_msg 0 ;;
+        *) log_end_msg 1; exit 1 ;;
+    esac
+    ;;
+  stop)
+    log_daemon_msg "Stopping $DESC" "$NAME"
+    start-stop-daemon --oknodo --stop --pidfile $PID --retry $RETRY
+    case "$?" in
+        0) log_end_msg 0 ;;
+        *) log_end_msg 1; exit 1 ;;
+    esac
+    ;;
+  status)
+    status_of_proc -p "$PID" "$DAEMON" "$NAME" && exit 0 || exit $?
+    ;;
+  restart|force-reload)
+    $0 stop
+    $0 start
+    ;;
+  *)
+    echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/templates/zabbix-server-redhat.init.erb
+++ b/templates/zabbix-server-redhat.init.erb
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+#       /etc/rc.d/init.d/zabbix_server
+#
+# Starts the zabbix_server daemon
+#
+# chkconfig: - 95 5
+# description: Zabbix Monitoring Server
+# processname: zabbix_server
+# pidfile: /tmp/zabbix_server.pid
+
+# Modified for Zabbix 2.0.0
+# May 2012, Zabbix SIA
+
+# Source function library.
+
+. /etc/init.d/functions
+
+RETVAL=0
+prog="Zabbix Server"
+ZABBIX_BIN="/usr/local/sbin/zabbix_server"
+OPTS="-c <%= @server_configfile_path %>"
+
+if [ ! -x ${ZABBIX_BIN} ] ; then
+        echo -n "${ZABBIX_BIN} not installed! "
+        # Tell the user this has skipped
+        exit 5
+fi
+
+start() {
+        echo -n $"Starting $prog: "
+        daemon "$ZABBIX_BIN -c $OPTS"
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && touch /var/lock/subsys/zabbix_server
+        echo
+}
+
+stop() {
+        echo -n $"Stopping $prog: "
+        killproc $ZABBIX_BIN
+        RETVAL=$?
+        [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/zabbix_server
+        echo
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  reload|restart)
+        stop
+        sleep 10
+        start
+        RETVAL=$?
+        ;;
+  condrestart)
+        if [ -f /var/lock/subsys/zabbix_server ]; then
+            stop
+            start
+        fi
+        ;;
+  status)
+        status $ZABBIX_BIN
+        RETVAL=$?
+        ;;
+  *)
+        echo $"Usage: $0 {condrestart|start|stop|restart|reload|status}"
+        exit 1
+esac
+
+exit $RETVAL

--- a/templates/zabbix-server-systemd.init.erb
+++ b/templates/zabbix-server-systemd.init.erb
@@ -1,0 +1,22 @@
+[Unit]
+Description=Zabbix Server
+Documentation=man:zabbix_server
+<% if @database_type == "mysql" %>
+After=syslog.target network.target mysqld.service
+<% else %>
+After=syslog.target network.target postgresql.service
+<% end -%>
+
+[Service]
+Type=forking
+ExecStart=/usr/sbin/zabbix_server -c <%= @server_configfile_path %>
+ExecReload=/usr/sbin/zabbix_server -R config_cache_reload
+PIDFile=<%= @pidfile %>
+Restart=on-abnormal
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Here I'm adding a method to check the zabbix agent/server config file defined by the user.

This fix allaws the user to specify a different config file than the standard /etc/zabbix/zabbix_[agentd|server].conf without breaking the installation.