### PR TITLE
Fix: manage database parameter not pass to zabbix::server

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -214,6 +214,7 @@ class zabbix (
     zabbix_version          => $zabbix_version,
     manage_firewall         => $manage_firewall,
     manage_repo             => $manage_repo,
+    manage_database         => $manage_database,
     nodeid                  => $nodeid,
     listenport              => $listenport,
     sourceip                => $sourceip,


### PR DESCRIPTION
https://github.com/voxpupuli/puppet-zabbix/issues/170

In issues #170 the parameter was added but it didn't get pass down from zabbix to zabbix::server if using Class['zabbix']