### PR TITLE
Respect user provided Zabbix agent package name in userparameters

### DIFF
--- a/manifests/userparameters.pp
+++ b/manifests/userparameters.pp
@@ -61,7 +61,7 @@ define zabbix::userparameters (
   $script_dir = '/usr/bin',
 ) {
   $include_dir          = getvar('::zabbix::agent::include_dir')
-  $zabbix_agent_package = getvar('::zabbix::params::zabbix_package_agent')
+  $zabbix_agent_package = getvar('::zabbix::agent::zabbix_package_agent')
 
   if $source != '' {
     file { "${include_dir}/${name}.conf":


### PR DESCRIPTION
This patch makes zabbix::userparameters respect the zabbix_package_agent parameter of zabbix::agent

