### PR TITLE
add systemd provider

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -328,9 +328,15 @@ class zabbix::agent (
   }
 
   # Controlling the 'zabbix-agent' service
+  if str2bool($::systemd) {
+    $service_provider = 'systemd'
+  } else {
+    $service_provider = undef
+  }
   service { 'zabbix-agent':
     ensure     => running,
     enable     => true,
+    provider   => $service_provider,
     hasstatus  => true,
     hasrestart => true,
     require    => Package[$zabbix_package_agent],


### PR DESCRIPTION
Hi,

I've come to an issue on debian Jessie (8) where service provider 'systemd' was not selected, so it couldn't find scripts in /etc/init.d/*. I just added a `provider` variable to the service, based on the `$::systemd` fact.

Thanx

