### PR TITLE
Fix for php db package name on Ubuntu 16.04

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -299,11 +299,23 @@ class zabbix::web (
       }
 
       # Check OS release for proper prefix
-      if versioncmp($::operatingsystemmajrelease, '16.04') >= 0 {
-        $php_db_package = "php-${db}"
-      }
-      else {
-        $php_db_package = "php5-${db}"
+      case $::operatingsystem {
+        'Ubuntu' : {
+          if versioncmp($::operatingsystemmajrelease, '16.04') >= 0 {
+            $php_db_package = "php-${db}"
+          }
+          else {
+            $php_db_package = "php5-${db}"
+          }
+        }
+        'Debian' : {
+          if versioncmp($::operatingsystemmajrelease, '9') >= 0 {
+            $php_db_package = "php-${db}"
+          }
+          else {
+            $php_db_package = "php5-${db}"
+          }
+        }
       }
 
       package { $php_db_package:

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -316,9 +316,9 @@ class zabbix::web (
             $php_db_package = "php5-${db}"
           }
         }
-      }
-      default : {
-        $php_db_package = "php5-${db}"
+        default : {
+          $php_db_package = "php5-${db}"
+        }
       }
 
       package { $php_db_package:

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -317,6 +317,9 @@ class zabbix::web (
           }
         }
       }
+      default : {
+        $php_db_package = "php5-${db}"
+      }
 
       package { $php_db_package:
         ensure => $zabbix_package_state,

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -299,7 +299,7 @@ class zabbix::web (
       }
 
       # Check OS release for proper prefix
-      if $::operatingsystemmajrelease >= '16.04' {
+      if versioncmp($::operatingsystemmajrelease, '16.04') >= 0 {
         $php_db_package = "php-${db}"
       }
       else {

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -297,7 +297,16 @@ class zabbix::web (
           $zabbix_web_package = 'zabbix-frontend-php'
         }
       }
-      package { "php5-${db}":
+
+      # Check OS release for proper prefix
+      if $::operatingsystemmajrelease >= '16.04' {
+        $php_db_package = "php-${db}"
+      }
+      else {
+        $php_db_package = "php5-${db}"
+      }
+
+      package { "${php_db_package}":
         ensure => $zabbix_package_state,
         before => [
           Package[$zabbix_web_package],

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -306,7 +306,7 @@ class zabbix::web (
         $php_db_package = "php5-${db}"
       }
 
-      package { "${php_db_package}":
+      package { $php_db_package:
         ensure => $zabbix_package_state,
         before => [
           Package[$zabbix_web_package],

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -56,7 +56,20 @@ describe 'zabbix::web' do
           let :params do
             super().merge(database_type: 'postgresql')
           end
-          packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-pgsql', 'zabbix-web'] : ['zabbix-frontend-php', 'php5-pgsql']
+
+          pgsqlpackage = ""
+          case facts[:osfamily]
+          when 'Debian'
+            if facts[:operatingsystemmajrelease] >= '16.04'
+              pgsqlpackage = "php-pgsql"
+            else
+              pgsqlpackage = "php5-pgsql"
+            end
+          else
+            pgsqlpackage = "php5-pgsql"
+          end
+
+          packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-pgsql', 'zabbix-web'] : ['zabbix-frontend-php', pgsqlpackage]
           packages.each do |package|
             it { should contain_package(package) }
           end
@@ -67,7 +80,20 @@ describe 'zabbix::web' do
           let :params do
             super().merge(database_type: 'mysql')
           end
-          packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-mysql', 'zabbix-web'] : ['zabbix-frontend-php', 'php5-mysql']
+
+          mysqlpackage = ""
+          case facts[:osfamily]
+          when 'Debian'
+            if facts[:operatingsystemmajrelease] >= '16.04'
+              mysqlpackage = "php-mysql"
+            else
+              mysqlpackage = "php5-mysql"
+            end
+          else
+            mysqlpackage = "php5-mysql"
+          end
+
+          packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-mysql', 'zabbix-web'] : ['zabbix-frontend-php', mysqlpackage]
           packages.each do |package|
             it { should contain_package(package) }
           end

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -95,9 +95,9 @@ describe 'zabbix::web' do
                            end
                          when 'Debian'
                            if facts[:operatingsystemmajrelease] >= '8'
-                             'php-pgsql'
+                             'php-mysql'
                            else
-                             'php5-pgsql'
+                             'php5-mysql'
                            end
                          else
                            'php5-mysql'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -57,17 +57,16 @@ describe 'zabbix::web' do
             super().merge(database_type: 'postgresql')
           end
 
-          pgsqlpackage = ""
-          case facts[:osfamily]
-          when 'Debian'
-            if facts[:operatingsystemmajrelease] >= '16.04'
-              pgsqlpackage = "php-pgsql"
-            else
-              pgsqlpackage = "php5-pgsql"
-            end
-          else
-            pgsqlpackage = "php5-pgsql"
-          end
+          pgsqlpackage = case facts[:osfamily]
+                         when 'Debian'
+                           if facts[:operatingsystemmajrelease] >= '16.04'
+                             "php-pgsql"
+                           else
+                             "php5-pgsql"
+                           end
+                         else
+                           "php5-pgsql"
+                         end
 
           packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-pgsql', 'zabbix-web'] : ['zabbix-frontend-php', pgsqlpackage]
           packages.each do |package|
@@ -81,17 +80,16 @@ describe 'zabbix::web' do
             super().merge(database_type: 'mysql')
           end
 
-          mysqlpackage = ""
-          case facts[:osfamily]
-          when 'Debian'
-            if facts[:operatingsystemmajrelease] >= '16.04'
-              mysqlpackage = "php-mysql"
-            else
-              mysqlpackage = "php5-mysql"
-            end
-          else
-            mysqlpackage = "php5-mysql"
-          end
+          mysqlpackage = case facts[:osfamily]
+                         when 'Debian'
+                           if facts[:operatingsystemmajrelease] >= '16.04'
+                             "php-mysql"
+                           else
+                             "php5-mysql"
+                           end
+                         else
+                           "php5-mysql"
+                         end
 
           packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-mysql', 'zabbix-web'] : ['zabbix-frontend-php', mysqlpackage]
           packages.each do |package|

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -60,12 +60,12 @@ describe 'zabbix::web' do
           pgsqlpackage = case facts[:osfamily]
                          when 'Debian'
                            if facts[:operatingsystemmajrelease] >= '16.04'
-                             "php-pgsql"
+                             'php-pgsql'
                            else
-                             "php5-pgsql"
+                             'php5-pgsql'
                            end
                          else
-                           "php5-pgsql"
+                           'php5-pgsql'
                          end
 
           packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-pgsql', 'zabbix-web'] : ['zabbix-frontend-php', pgsqlpackage]
@@ -83,12 +83,12 @@ describe 'zabbix::web' do
           mysqlpackage = case facts[:osfamily]
                          when 'Debian'
                            if facts[:operatingsystemmajrelease] >= '16.04'
-                             "php-mysql"
+                             'php-mysql'
                            else
-                             "php5-mysql"
+                             'php5-mysql'
                            end
                          else
-                           "php5-mysql"
+                           'php5-mysql'
                          end
 
           packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-mysql', 'zabbix-web'] : ['zabbix-frontend-php', mysqlpackage]

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -57,9 +57,15 @@ describe 'zabbix::web' do
             super().merge(database_type: 'postgresql')
           end
 
-          pgsqlpackage = case facts[:osfamily]
-                         when 'Debian'
+          pgsqlpackage = case facts[:operatingsystem]
+                         when 'Ubuntu'
                            if facts[:operatingsystemmajrelease] >= '16.04'
+                             'php-pgsql'
+                           else
+                             'php5-pgsql'
+                           end
+                         when 'Debian'
+                           if facts[:operatingsystemmajrelease] >= '8'
                              'php-pgsql'
                            else
                              'php5-pgsql'
@@ -80,12 +86,18 @@ describe 'zabbix::web' do
             super().merge(database_type: 'mysql')
           end
 
-          mysqlpackage = case facts[:osfamily]
-                         when 'Debian'
+          mysqlpackage = case facts[:operatingsystem]
+                         when 'Ubuntu'
                            if facts[:operatingsystemmajrelease] >= '16.04'
                              'php-mysql'
                            else
                              'php5-mysql'
+                           end
+                         when 'Debian'
+                           if facts[:operatingsystemmajrelease] >= '8'
+                             'php-pgsql'
+                           else
+                             'php5-pgsql'
                            end
                          else
                            'php5-mysql'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -65,7 +65,7 @@ describe 'zabbix::web' do
                              'php5-pgsql'
                            end
                          when 'Debian'
-                           if facts[:operatingsystemmajrelease] >= '8'
+                           if facts[:operatingsystemmajrelease] >= '9'
                              'php-pgsql'
                            else
                              'php5-pgsql'
@@ -94,7 +94,7 @@ describe 'zabbix::web' do
                              'php5-mysql'
                            end
                          when 'Debian'
-                           if facts[:operatingsystemmajrelease] >= '8'
+                           if facts[:operatingsystemmajrelease] >= '9'
                              'php-mysql'
                            else
                              'php5-mysql'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->
As explained in [https://github.com/voxpupuli/puppet-zabbix/issues/282](https://github.com/voxpupuli/puppet-zabbix/issues/282) the code for installing the php5 database package does not currently work on Ubuntu 16.04.  This is because the name has changed from "php5-${db}" to "php-${db}" in the official repos.  This pull will update it only in those instances and still use the legacy facts for determining version for backward compatibility.