### PR TITLE
Adapt to zabbix-3.2 and higher.

### DIFF
--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -27,7 +27,7 @@ class zabbix::database::mysql (
   #
   # Adjustments for version 3.0 - structure of package with sqls differs from previous versions
   case $zabbix_version {
-    '3.0': {
+    /^3.\d+$/: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         $schema_path   = '/usr/share/doc/zabbix-*-mysql*'
       }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -28,7 +28,7 @@ class zabbix::database::postgresql (
   #
   # Adjustments for version 3.0 - structure of package with sqls differs from previous versions
   case $zabbix_version {
-    '3.0': {
+    /^3.\d+$/: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         case $::operatingsystem {
           'CentOS', 'RedHat', 'OracleLinux': {

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -316,6 +316,22 @@ describe 'zabbix::server' do
         it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSCertFile=/etc/zabbix/keys/zabbix-server.crt$} }
         it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSKeyFile=/etc/zabbix/keys/zabbix-server.key$} }
       end
+      context 'with zabbix_server.conf and version 3.2' do
+        let :params do
+          {
+            tlscafile: '/etc/zabbix/keys/zabbix-server.ca',
+            tlscrlfile: '/etc/zabbix/keys/zabbix-server.crl',
+            tlscertfile: '/etc/zabbix/keys/zabbix-server.crt',
+            tlskeyfile: '/etc/zabbix/keys/zabbix-server.key',
+            zabbix_version: '3.2'
+          }
+        end
+
+        it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSCAFile=/etc/zabbix/keys/zabbix-server.ca$} }
+        it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSCRLFile=/etc/zabbix/keys/zabbix-server.crl$} }
+        it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSCertFile=/etc/zabbix/keys/zabbix-server.crt$} }
+        it { should contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSKeyFile=/etc/zabbix/keys/zabbix-server.key$} }
+      end
     end
   end
 end

--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -241,7 +241,7 @@ LoadModulePath=<%= @loadmodulepath %>
 #
 <% if @loadmodule %>LoadModule=<%= @loadmodule %><% end %>
 
-<% if @zabbix_version == '3.0' %>
+<% if @zabbix_version.to_f >= 3.0 %>
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSConnect

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -449,7 +449,7 @@ LoadModulePath=<%= @loadmodulepath %>
 <% if @loadmodule %>LoadModule=<%= @loadmodule %><% end %>
 
 
-<% if @zabbix_version == '3.0' %>
+<% if @zabbix_version.to_f >= 3.0 %>
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSConnect

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -466,7 +466,7 @@ LoadModulePath=<%= @loadmodulepath %>
 #
 <% if @loadmodule %>LoadModule = <%= @loadmodule %><% end %>
 
-<% if @zabbix_version == '3.0' %>
+<% if @zabbix_version.to_f >= 3.0 %>
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSCAFile


### PR DESCRIPTION
A few changes to adapt module to zabbix-3.2 and higher versions.

Some of ```3.0``` strings replaced with regular expressions, some ```@zabbix_version == '3.0'``` replaced with ```@zabbix_version >= '3.0'```.