### PR TITLE
allow web interface title configuration

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,7 @@ class zabbix::params {
   $zabbix_proxy                             = 'localhost'
   $zabbix_proxy_ip                          = '127.0.0.1'
   $zabbix_server                            = 'localhost'
+  $zabbix_server_name                       = 'localhost'
   $zabbix_server_ip                         = '127.0.0.1'
   $zabbix_template_dir                      = '/etc/zabbix/imported_templates'
   $zabbix_timezone                          = 'Europe/Amsterdam'

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -104,7 +104,11 @@
 #   Database port when not using local socket. Ignored for sqlite.
 #
 # [*zabbix_server*]
-#   The fqdn name of the host running the zabbix-server. When single node:
+#   The ip of the host running the zabbix-server. When single node:
+#   localhost
+#
+# [*zabbix_server_name*]
+#   The fqdn name of the host running the zabbix-server. Shows up in the Webinterface and titleWhen single node:
 #   localhost
 #
 # [*zabbix_listenport*]
@@ -200,6 +204,7 @@ class zabbix::web (
   $database_socket                          = $zabbix::params::server_database_socket,
   $database_port                            = $zabbix::params::server_database_port,
   $zabbix_server                            = $zabbix::params::zabbix_server,
+  $zabbix_server_name                       = $zabbix::params::zabbix_server_name,
   $zabbix_listenport                        = $zabbix::params::server_listenport,
   $apache_php_max_execution_time            = $zabbix::params::apache_php_max_execution_time,
   $apache_php_memory_limit                  = $zabbix::params::apache_php_memory_limit,

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -104,11 +104,11 @@
 #   Database port when not using local socket. Ignored for sqlite.
 #
 # [*zabbix_server*]
-#   The ip of the host running the zabbix-server. When single node:
+#   The fqdn name of the host running the zabbix-server. When single node:
 #   localhost
 #
 # [*zabbix_server_name*]
-#   The fqdn name of the host running the zabbix-server. Shows up in the Webinterface and titleWhen single node:
+#   The fqdn name of the host running the zabbix-server. Shows up in the Webinterface and title. When single node:
 #   localhost
 #
 # [*zabbix_listenport*]

--- a/templates/web/zabbix.conf.php.erb
+++ b/templates/web/zabbix.conf.php.erb
@@ -20,7 +20,7 @@ $DB['SCHEMA'] = '';
 
 $ZBX_SERVER      = '<%= @zabbix_server %>';
 $ZBX_SERVER_PORT = '<%= @zabbix_listenport %>';
-$ZBX_SERVER_NAME = '<%= @zabbix_server %>';
+$ZBX_SERVER_NAME = '<%= @zabbix_server_name %>';
 
 $IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;
 


### PR DESCRIPTION
Currently the web interface has to have the same IP of the configured server. This makes the window or tab title the IP and not the fqdn. I currently did not add any test to this PR, but will do so if required.
This PR allows one to configure the web with its own name.
