### PR TITLE
Added the new ZABIIX-A14FE591 GPG Key.

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -57,7 +57,7 @@ class zabbix::repo (
           descr    => "Zabbix_${reponame}_${::architecture}",
           baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/\$basearch/",
           gpgcheck => '1',
-          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+          gpgkey   => ['http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX, http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591'],
           priority => '1',
         }
 
@@ -66,7 +66,7 @@ class zabbix::repo (
           descr    => "Zabbix_nonsupported_${reponame}_${::architecture}",
           baseurl  => "http://repo.zabbix.com/non-supported/rhel/${majorrelease}/\$basearch/",
           gpgcheck => '1',
-          gpgkey   => 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX',
+          gpgkey   => ['http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX, http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591'],
           priority => '1',
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

Zabbix started signing RPMs with a new GPG keypair a few months back. Here is a pull request that keeps the original GPG key but adds the new as well. Without it, Zabbix 3.2 cannot be installed.