### PR TITLE
use getvar to get systemd fact

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -328,7 +328,7 @@ class zabbix::agent (
   }
 
   # Controlling the 'zabbix-agent' service
-  if str2bool($::systemd) {
+  if str2bool(getvar('::systemd')) {
     $service_provider = 'systemd'
   } else {
     $service_provider = undef

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -35,7 +35,7 @@ define zabbix::startup (
       fail('we currently only spport a title that contains agent or server')
     }
   }
-  if str2bool($::systemd) {
+  if str2bool(getvar('::systemd')) {
     unless $pidfile {
       fail('you have to provide a pidfile param')
     }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
-->

The fact is confined to Linux. we need to use getvar() to ensure it
works on other Operating systems as well.

This is a preparation for any insane person that wants to add FreeBSD
support.
