### PR TITLE
Option to define owner of web interface configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,8 @@ This is the class for installing everything on a single host and thus all parame
 * `zabbix_api_user`: Username of user in Zabbix which is able to create hosts and edit hosts via the zabbix-api. Default: Admin
 * `zabbix_api_pass`: Password for the user in Zabbix for zabbix-api usage. Default: zabbix
 * `zabbix_template_dir`: The directory where all templates are stored before uploading via API
+* `web_config_owner`: Which user should own the web interface configuration file.
+* `web_config_group`: Which group should own the web interface configuration file.
 * `ldap_cacert`: The location of the CA Cert to be used for Zabbix LDAP authentication. The module will not install this file so it must be present on the system.
 * `ldap_clientcrt`: The location of the Client Cert to be used for Zabbix LDAP authentication. The module will not install this file so it must be present on the system.
 * `ldap_clientkey`: The location of the Client Key to be used for Zabbix LDAP authentication. The module will not install this file so it must be present on the system.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -324,4 +324,30 @@ class zabbix::params {
       $puppetgem = 'gem'
     }
   }
+
+  if $::apache::user {
+    $web_config_owner = getvar('::apache::user')
+  } else {
+    case $::operatingsystem {
+      'ubuntu', 'debian': {
+        $web_config_owner = 'www-data'
+      }
+      default: {
+        $web_config_owner = 'apache'
+      }
+    }
+  }
+
+  if $::apache::group {
+    $web_config_group = getvar('::apache::group')
+  } else {
+    case $::operatingsystem {
+      'ubuntu', 'debian': {
+        $web_config_owner = 'www-data'
+      }
+      default: {
+        $web_config_group = 'apache'
+      }
+    }
+  }
 }

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -37,6 +37,12 @@
 #   The state of the package that needs to be installed: present or latest.
 #   Default: present
 #
+# [*web_config_owner*]
+#   Which user should own the web interface configuration file.
+#
+# [*web_config_group*]
+#   Which group should own the web interface configuration file.
+#
 # [*manage_vhost*]
 #   When true, it will create an vhost for apache. The parameter zabbix_url
 #   has to be set.
@@ -179,6 +185,8 @@ class zabbix::web (
   $zabbix_timezone                          = $zabbix::params::zabbix_timezone,
   $zabbix_package_state                     = $zabbix::params::zabbix_package_state,
   $zabbix_template_dir                      = $zabbix::params::zabbix_template_dir,
+  $web_config_owner                         = $zabbix::params::web_config_owner,
+  $web_config_group                         = $zabbix::params::web_config_group,
   $manage_vhost                             = $zabbix::params::manage_vhost,
   $default_vhost                            = $zabbix::params::default_vhost,
   $manage_resources                         = $zabbix::params::manage_resources,
@@ -218,9 +226,6 @@ class zabbix::web (
   if $::osfamily == 'Archlinux' {
     fail('Archlinux is currently not supported for zabbix::web ')
   }
-
-  $apache_user = getvar('::apache::user')
-  $apache_group = getvar('::apache::group')
 
   # Only include the repo class if it has not yet been included
   unless defined(Class['Zabbix::Repo']) {
@@ -359,8 +364,8 @@ class zabbix::web (
   # Webinterface config file
   file { '/etc/zabbix/web/zabbix.conf.php':
     ensure  => present,
-    owner   => $apache_user,
-    group   => $apache_group,
+    owner   => $web_config_owner,
+    group   => $web_config_group,
     mode    => '0640',
     replace => true,
     content => template('zabbix/web/zabbix.conf.php.erb'),


### PR DESCRIPTION
Puppet will fail with errors in case we are not using apache:
Error: Could not find user class ::apache has not been evaluated
Error: Could not find group class ::apache has not been evaluated

for these variables:
$apache_user = getvar('::apache::user')
$apache_group = getvar('::apache::group')

In my commit you can find a possible solution for this problem.