### PR TITLE
Default web_config_owner/group correctly

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -325,31 +325,34 @@ class zabbix::params {
     }
   }
 
+  $default_web_config_owner = $::operatingsystem ? {
+    /(Ubuntu|Debian)/ => 'www-data',
+    default           => 'apache',
+  }
+
   $_web_config_owner = getvar('::apache::user')
-  if $_web_config_owner != '' {
-    $web_config_owner = $_web_config_owner
-  } else {
-    case $::operatingsystem {
-      'ubuntu', 'debian': {
-        $web_config_owner = 'www-data'
-      }
-      default: {
-        $web_config_owner = 'apache'
-      }
+  if $_web_config_owner {
+    if $_web_config_owner =~ /^\S+$/ {
+      # One or more non-whitespace chars
+      $web_config_owner = $_web_config_owner
+    } else {
+      # Empty string or contains whitespace (stdlib < 4.13.0 bug)
+      $web_config_owner = $default_web_config_owner
     }
+  } else {
+    # getvar returned undef
+    $web_config_owner = $default_web_config_owner
   }
 
   $_web_config_group = getvar('::apache::group')
-  if $_web_config_group != '' {
-    $web_config_group = getvar('::apache::group')
-  } else {
-    case $::operatingsystem {
-      'ubuntu', 'debian': {
-        $web_config_group = 'www-data'
-      }
-      default: {
-        $web_config_group = 'apache'
-      }
+  if $_web_config_group {
+    if $_web_config_group =~ /^\S+$/ {
+      $web_config_group = $_web_config_group
+    } else {
+      $web_config_group = $default_web_config_owner
     }
+  } else {
+    # getvar returned undef
+    $web_config_group = $default_web_config_owner
   }
 }


### PR DESCRIPTION
When apache hasn't been evaluated `getvar('::apache::user')` should
return `undef`.

This commit attempts to address 2 issues.

1) In puppet 4 `''` (empty string) != `undef`
2) In stdlib < 4.13.0 instead of `undef`, `getvar('::apache::user')`
returns a literal string `'class ::apache has not been evaluated'`. This
is a bug that was fixed, but it's not too hard to work around.