### PR TITLE
Add virtual bridge (virbr) to the list of network interfaces that are checked when setting listenip

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -264,7 +264,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun).*/) {
+    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun|virbr).*/) {
       $listen_ip = getvar("::ipaddress_${listenip}")
     } elsif is_ip_address($listenip) or $listenip == '*' {
       $listen_ip = $listenip


### PR DESCRIPTION
See Issue #323 (Feature Request)

Added virbr interface to list of matched interfaces.  This change allows the IP address to be set from the IP address assigned to a virtual bridge network interface.  

I did not add enp.* since that would require a more substantial modification of the code in order to do correctly since the current matching only matches at the end while predictable network interface names such as enp.* actually match in two locations:  enp[0-9]+s[0-9]+

