### PR TITLE
Fix failing test due to missing selinux fact

### DIFF
--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -26,7 +26,8 @@ describe 'zabbix::database::postgresql' do
         lsbdistcodename: '',
         id: 'root',
         kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin'
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin',
+        selinux: true
       }
     end
 

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -26,7 +26,8 @@ describe 'zabbix::database' do
         lsbdistcodename: '',
         id: 'root',
         kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin'
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin',
+        selinux: true
       }
     end
 

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -30,6 +30,7 @@ describe 'zabbix::proxy' do
         id: 'root',
         kernel: 'Linux',
         path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin',
+        selinux: true,
         selinux_config_mode: ''
       }
     end


### PR DESCRIPTION
puppet-postgresql now uses $::selinux for conditional logic
