### PR TITLE
add the ability to manage ZBX_SERVER_NAME in zabbix web

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -113,6 +113,11 @@
 #   The fqdn name of the host running the zabbix-server. When single node:
 #   localhost
 #
+# [*zabbix_server_name*]
+#   The fqdn name of the host running the zabbix-server. When single node:
+#   localhost
+#   This can also be used to upave a different name such as "Zabbix DEV"
+#
 # [*zabbix_listenport*]
 #   The port on which the zabbix-server is listening. Default: 10051
 #
@@ -208,6 +213,7 @@ class zabbix::web (
   $database_socket                          = $zabbix::params::server_database_socket,
   $database_port                            = $zabbix::params::server_database_port,
   $zabbix_server                            = $zabbix::params::zabbix_server,
+  $zabbix_server_name                       = $zabbix::params::zabbix_server,
   $zabbix_listenport                        = $zabbix::params::server_listenport,
   $apache_php_max_execution_time            = $zabbix::params::apache_php_max_execution_time,
   $apache_php_memory_limit                  = $zabbix::params::apache_php_memory_limit,

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -169,7 +169,9 @@ describe 'zabbix::web' do
               database_name: 'zabbix-server',
               database_user: 'zabbix-server',
               database_password: 'zabbix-server',
-              zabbix_server: 'localhost'
+              zabbix_server: 'localhost',
+              zabbix_listenport: '3306',
+              zabbix_server_name: 'localhost'
             )
           end
 
@@ -178,6 +180,8 @@ describe 'zabbix::web' do
           it { is_expected.to contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(%r{^\$DB\['USER'\]     = 'zabbix-server'}) }
           it { is_expected.to contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(%r{^\$DB\['PASSWORD'\] = 'zabbix-server'}) }
           it { is_expected.to contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(%r{^\$ZBX_SERVER      = 'localhost'}) }
+          it { is_expected.to contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(%r{^\$ZBX_SERVER_PORT = '3306'}) }
+          it { is_expected.to contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(%r{^\$ZBX_SERVER_NAME = 'localhost'}) }
         end
       end
     end

--- a/templates/web/zabbix.conf.php.erb
+++ b/templates/web/zabbix.conf.php.erb
@@ -20,7 +20,7 @@ $DB['SCHEMA'] = '';
 
 $ZBX_SERVER      = '<%= @zabbix_server %>';
 $ZBX_SERVER_PORT = '<%= @zabbix_listenport %>';
-$ZBX_SERVER_NAME = '<%= @zabbix_server %>';
+$ZBX_SERVER_NAME = '<%= @zabbix_server_name %>';
 
 $IMAGE_FORMAT_DEFAULT = IMAGE_FORMAT_PNG;
 


### PR DESCRIPTION
added zabbix_server_name for zabbix web, but left the default calling the same params as zabbix_server

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
