### PR TITLE
remove the include ::apt

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,6 @@ class zabbix::params {
       $server_fping6location = '/usr/bin/fping6'
       $proxy_fpinglocation   = '/usr/bin/fping'
       $proxy_fping6location  = '/usr/bin/fping6'
-      $manage_apt            = true
       $manage_repo           = true
       $zabbix_package_agent  = 'zabbix-agent'
       $agent_configfile_path = '/etc/zabbix/zabbix_agentd.conf'
@@ -69,6 +68,7 @@ class zabbix::params {
   $manage_service                           = true
   $default_vhost                            = false
   $manage_firewall                          = false
+  $manage_apt                               = true
   $repo_location                            = ''
   $manage_resources                         = false
   $manage_vhost                             = true

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class zabbix::params {
       $server_fping6location = '/usr/bin/fping6'
       $proxy_fpinglocation   = '/usr/bin/fping'
       $proxy_fping6location  = '/usr/bin/fping6'
+      $manage_apt            = true
       $manage_repo           = true
       $zabbix_package_agent  = 'zabbix-agent'
       $agent_configfile_path = '/etc/zabbix/zabbix_agentd.conf'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -80,7 +80,6 @@ class zabbix::repo (
 
       }
       'Debian' : {
-        include ::apt
         if ($::architecture == 'armv6l') {
           apt::source { 'zabbix':
             location => 'http://naizvoru.com/raspbian/zabbix',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -27,6 +27,7 @@
 #
 class zabbix::repo (
   $manage_repo    = $zabbix::params::manage_repo,
+  $manage_apt     = $zabbix::params::manage_apt,
   $repo_location  = $zabbix::params::repo_location,
   $zabbix_version = $zabbix::params::zabbix_version,
 ) inherits zabbix::params {
@@ -80,6 +81,10 @@ class zabbix::repo (
 
       }
       'Debian' : {
+        if ($manage_apt) {
+          include ::apt
+        }
+
         if ($::architecture == 'armv6l') {
           apt::source { 'zabbix':
             location => 'http://naizvoru.com/raspbian/zabbix',


### PR DESCRIPTION
Having the `include ::apt` in this module then prevents someone from defining their own instance of the apt class with custom parameters in another manifest, forcing the use of hiera to configure the apt class (unless of course this is the intention...).