### PR TITLE
Add basic SLES 12 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,3 +571,7 @@ Could not evaluate: Connection refused - connect(2)
 ```
 
 When running puppet again (for 3rd time) everything goes fine.
+
+### SuSE (SLES)
+
+Initial support for SLES has been added and makes use of the puppet-zypprepo forge module to add a repo containing Zabbix 2.2.  Because support ends for Zabbix 2.2 soon, it is recommended that only agents are installed on SuSE - the Zabbix server should be a newer version and installed on a Zabbix LLC-supported platform (RedHat/CentOS/Oracle, Debian, or Ubuntu).

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -122,12 +122,12 @@ class zabbix::repo (
       'Suse': {
         $minorrelease = $facts['os']['release']['minor']
         zypprepo { 'monitoring':
-          baseurl      => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/",
-          enabled      => 1,
-          autorefresh  => 1,
-          gpgcheck     => 1,
-          gpgkey       => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/repodata/repomd.xml.key",
-          type         => 'rpm-md',
+          baseurl     => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/",
+          enabled     => 1,
+          autorefresh => 1,
+          gpgcheck    => 1,
+          gpgkey      => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/repodata/repomd.xml.key",
+          type        => 'rpm-md',
         }
       }
       default  : {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -119,6 +119,14 @@ class zabbix::repo (
         Apt::Source['zabbix'] -> Package<|tag == 'zabbix'|>
         Class['Apt::Update']  -> Package<|tag == 'zabbix'|>
       }
+      'Suse': {
+        $minorrelease = $facts[os][release][minor]
+        exec { 'zypper addrepo':
+          path    => ['/usr/bin'],
+          command => "zypper ar -f http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/ monitoring",
+          creates => '/etc/zypp/repos.d/monitoring.repo',
+        }
+      }
       default  : {
         fail("Managing a repo on ${::osfamily} is currently not implemented")
       }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -125,7 +125,7 @@ class zabbix::repo (
           baseurl     => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/",
           enabled     => 1,
           autorefresh => 1,
-          gpgcheck    => 1,
+          gpgcheck    => 0,
           gpgkey      => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/repodata/repomd.xml.key",
           type        => 'rpm-md',
         }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -128,6 +128,7 @@ class zabbix::repo (
           gpgcheck     => 1,
           gpgkey       => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/repodata/repomd.xml.key",
           type         => 'rpm-md',
+        }
       }
       default  : {
         fail("Managing a repo on ${::osfamily} is currently not implemented")

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -120,12 +120,14 @@ class zabbix::repo (
         Class['Apt::Update']  -> Package<|tag == 'zabbix'|>
       }
       'Suse': {
-        $minorrelease = $facts[os][release][minor]
-        exec { 'zypper addrepo':
-          path    => ['/usr/bin'],
-          command => "zypper ar -f http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/ monitoring",
-          creates => '/etc/zypp/repos.d/monitoring.repo',
-        }
+        $minorrelease = $facts['os']['release']['minor']
+        zypprepo { 'monitoring':
+          baseurl      => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/",
+          enabled      => 1,
+          autorefresh  => 1,
+          gpgcheck     => 1,
+          gpgkey       => "http://download.opensuse.org/repositories/server:/monitoring/SLE_${majorrelease}_SP${minorrelease}/repodata/repomd.xml.key",
+          type         => 'rpm-md',
       }
       default  : {
         fail("Managing a repo on ${::osfamily} is currently not implemented")

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -40,7 +40,7 @@ define zabbix::startup (
       fail('you have to provide a pidfile param')
     }
     contain ::systemd
-    case $::osfamily {
+    case $facts['osfamily'] {
       'Suse': {
         $zabbix_agentd = '/usr/sbin/zabbix-agentd'
       }

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -40,6 +40,14 @@ define zabbix::startup (
       fail('you have to provide a pidfile param')
     }
     contain ::systemd
+    case $::osfamily {
+      'Suse': {
+        $zabbix_agentd = '/usr/sbin/zabbix-agentd'
+      }
+      default: {
+        $zabbix_agentd = '/usr/sbin/zabbix_agentd'
+      }
+    }
     file { "/etc/systemd/system/${name}.service":
       ensure  => file,
       mode    => '0664',

--- a/templates/zabbix-agent-systemd.init.erb
+++ b/templates/zabbix-agent-systemd.init.erb
@@ -8,7 +8,7 @@ Type=forking
 Restart=on-failure
 PIDFile=<%= @pidfile %>
 KillMode=control-group
-ExecStart=/usr/sbin/zabbix_agentd -c <%= @agent_configfile_path %>
+ExecStart=<%= @zabbix_agentd %> -c <%= @agent_configfile_path %>
 ExecStop=/bin/kill -SIGTERM $MAINPID
 RestartSec=10s
 


### PR DESCRIPTION
My use case was to install the zabbix-agent on SLES 12.2.  I found a non-zabbix (opensuse) repo that provided zabbix version 2.2.

SuSE packaging also renamed the zabbix_agentd to zabbix-agentd which I needed to make it start.
