### PR TITLE
Execute zabbix-server as zabbix user

### DIFF
--- a/templates/zabbix-server-systemd.init.erb
+++ b/templates/zabbix-server-systemd.init.erb
@@ -16,6 +16,8 @@ PrivateDevices=yes
 PrivateTmp=yes
 ProtectSystem=full
 ProtectHome=yes
+User=zabbix
+Group=zabbix
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
A good practice is to run a daemon under a non-root user account.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
