### PR TITLE
make logtype avaiable to all proxy/server (for 2.6.2)

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -53,6 +53,9 @@
 # [*pidfile*]
 #   Name of pid file.
 #
+# [*logtype*]
+#   Where log messages are written to, only available on Zabbix>=3.0
+#
 # [*logfile*]
 #   Name of log file.
 #
@@ -82,8 +85,8 @@
 #   You can also specify which network interface it should listen on.
 #
 #   Example:
-#   listenip => 'eth0',  or
-#   listenip => 'bond0.73',
+#   listenip            => 'eth0',  or
+#   listenip            => 'bond0.73',
 #
 #   It will find out which ip is configured for this ipaddress. Can be handy
 #   if more than 1 interface is on the server.
@@ -181,8 +184,8 @@
 #
 #  Basic installation:
 #  class { 'zabbix::agent':
-#    zabbix_version => '2.2',
-#    server         => '192.168.1.1',
+#    zabbix_version     => '2.2',
+#    server             => '192.168.1.1',
 #  }
 #
 #  Exported resources:
@@ -214,7 +217,7 @@ class zabbix::agent (
   $zbx_templates         = $zabbix::params::agent_zbx_templates,
   $agent_configfile_path = $zabbix::params::agent_configfile_path,
   $pidfile               = $zabbix::params::agent_pidfile,
-  $logtype               = $zabbix::params::agent_logtype,
+  $logtype               = $zabbix::params::logtype,
   $logfile               = $zabbix::params::agent_logfile,
   $logfilesize           = $zabbix::params::agent_logfilesize,
   $debuglevel            = $zabbix::params::agent_debuglevel,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,6 +64,7 @@ class zabbix::params {
   $zabbix_version                           = '3.0'
   $zabbix_web                               = 'localhost'
   $zabbix_web_ip                            = '127.0.0.1'
+  $logtype                                  = 'file'
   $manage_database                          = true
   $manage_service                           = true
   $default_vhost                            = false
@@ -193,7 +194,6 @@ class zabbix::params {
   $agent_listenport                         = '10050'
   $agent_loadmodule                         = undef
   $agent_loadmodulepath                     = '/usr/lib/modules'
-  $agent_logtype                            = 'file'
   $agent_logfile                            = '/var/log/zabbix/zabbix_agentd.log'
   $agent_logfilesize                        = '100'
   $agent_logremotecommands                  = '0'

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -69,6 +69,9 @@
 # [*sourceip*]
 #   Source ip address for outgoing connections.
 #
+# [*logtype*]
+#   Where log messages are written to, only available on Zabbix>=3.0
+#
 # [*logfile*]
 #   Name of log file.
 #
@@ -346,6 +349,7 @@ class zabbix::proxy (
   $hostname                = $zabbix::params::proxy_hostname,
   $listenport              = $zabbix::params::proxy_listenport,
   $sourceip                = $zabbix::params::proxy_sourceip,
+  $logtype                 = $zabbix::params::logtype,
   $logfile                 = $zabbix::params::proxy_logfile,
   $logfilesize             = $zabbix::params::proxy_logfilesize,
   $debuglevel              = $zabbix::params::proxy_debuglevel,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,6 +50,9 @@
 # [*sourceip*]
 #   Source ip address for outgoing connections.
 #
+# [*logtype*]
+#   Where log messages are written to, only available on Zabbix>=3.0
+#
 # [*logfile*]
 #   Name of log file.
 #
@@ -304,6 +307,7 @@ class zabbix::server (
   $nodeid                  = $zabbix::params::server_nodeid,
   $listenport              = $zabbix::params::server_listenport,
   $sourceip                = $zabbix::params::server_sourceip,
+  $logtype                 = $zabbix::params::logtype,
   $logfile                 = $zabbix::params::server_logfile,
   $logfilesize             = $zabbix::params::server_logfilesize,
   $debuglevel              = $zabbix::params::server_debuglevel,


### PR DESCRIPTION
logtype was only present as a parameter in agent but not server/proxy

this change combine agent/server/proxy logtype to one parameter in params.pp, and
added parameter to proxy.pp and server.pp