### PR TITLE
Fix rpm key handling + chaning default values depending on zabbix version

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,64 @@ zabbix::template { 'Template App MySQL':
 }
 ```
 
+## Zabbix Upgrades
+
+It is possible to do upgrades via this module. An example for the zabbix agent:
+
+```puppet
+class{'zabbix::agent':
+  zabbix_version => '2.4',
+  manage_repo    => true,
+}
+```
+
+This will install the latest zabbix 2.4 agent for you. The module won't to any upgrades nor install patch releases. If you want to get patch releases automatically:
+
+```puppet
+class{'zabbix::agent':
+  zabbix_version       => '2.4',
+  manage_repo          => true,
+  zabbix_package_state => 'latest',
+}
+```
+
+Let's asume zabbix just released version 3.4. Than you can do upgrades as follow:
+```puppet
+class{'zabbix::agent':
+  zabbix_version       => '3.4',
+  manage_repo          => true,
+  zabbix_package_state => 'latest',
+}
+```
+
+You can also tell the module to only create the new repository, but not to update the existing agent:
+
+```puppet
+class{'zabbix::agent':
+  zabbix_version       => '3.4',
+  manage_repo          => true,
+  zabbix_package_state => 'installed',
+}
+```
+
+Last but not least you can disable the repo management completely, which will than install zabbix from the present system repos:
+
+```puppet
+class{'zabbix::agent':
+  manage_repo          => false,
+  zabbix_package_state => 'present',
+}
+```
+
+Even in this scenario you can do automatic upgrades via the module (it is the job of the user to somehow bring updates into the repo, for example by managing the repo on their own):
+
+```puppet
+class{'zabbix::agent':
+  manage_repo          => false,
+  zabbix_package_state => 'latest',
+}
+```
+
 ## Reference
 There are some overall parameters which exists on all of the classes:
 * `zabbix_version`: You can specify which zabbix release needs to be installed. Default is '3.0'.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,7 +68,7 @@ class zabbix::params {
   }
 
   # Zabbix overall params. Is used by all components.
-  $zabbix_package_state                     = 'latest'
+  $zabbix_package_state                     = 'present'
   $zabbix_proxy                             = 'localhost'
   $zabbix_proxy_ip                          = '127.0.0.1'
   $zabbix_server                            = 'localhost'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -68,7 +68,7 @@ class zabbix::params {
   }
 
   # Zabbix overall params. Is used by all components.
-  $zabbix_package_state                     = 'present'
+  $zabbix_package_state                     = 'latest'
   $zabbix_proxy                             = 'localhost'
   $zabbix_proxy_ip                          = '127.0.0.1'
   $zabbix_server                            = 'localhost'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -332,14 +332,16 @@ class zabbix::params {
   $javagateway_timeout                      = '3'
   $manage_selinux                           = $facts['selinux']
 
-  # services should run foreground
+  # services should run foreground and as simple type
   # but this only works in 3.0 and newer
-  $additional_service_params = versioncmp($zabbix_version, '3.0') ? {
-    1  => '--foreground',
-    0  => '--foreground',
-    -1 => '',
+  # https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=
+  if versioncmp($zabbix_version, '3.0') < 0 {
+    $additional_service_params = ''
+    $service_type              = 'forking'
+  } else {
+    $additional_service_params = '--foreground'
+    $service_type              = 'simple'
   }
-
   # Gem provider may vary based on version/type of puppet install.
   # This can be a little complicated and may need revisited over time.
   if str2bool($::is_pe) {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -55,10 +55,12 @@ class zabbix::repo (
       'RedHat' : {
         # Zabbix-3.2 and newer RPMs are signed with the GPG key
         if versioncmp($zabbix_version, '3.2') < 0 {
-          $gpgkey = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX'
+          $gpgkey_zabbix = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX'
+          $gpgkey_nonsupported = $gpgkey_zabbix
         }
         else {
-          $gpgkey = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591'
+          $gpgkey_zabbix = 'http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591'
+          $gpgkey_nonsupported = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-79EA5ED4'
         }
 
         yumrepo { 'zabbix':
@@ -66,7 +68,7 @@ class zabbix::repo (
           descr    => "Zabbix_${reponame}_${::architecture}",
           baseurl  => "http://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/\$basearch/",
           gpgcheck => '1',
-          gpgkey   => $gpgkey,
+          gpgkey   => $gpgkey_zabbix,
           priority => '1',
         }
 
@@ -75,7 +77,7 @@ class zabbix::repo (
           descr    => "Zabbix_nonsupported_${reponame}_${::architecture}",
           baseurl  => "http://repo.zabbix.com/non-supported/rhel/${majorrelease}/\$basearch/",
           gpgcheck => '1',
-          gpgkey   => $gpgkey,
+          gpgkey   => $gpgkey_nonsupported,
           priority => '1',
         }
 

--- a/manifests/sender.pp
+++ b/manifests/sender.pp
@@ -21,7 +21,8 @@
 class zabbix::sender(
   $zabbix_version        = $zabbix::params::zabbix_version,
   $zabbix_package_state  = $zabbix::params::zabbix_package_state,
-  $manage_repo           = $zabbix::params::manage_repo,) inherits zabbix::params {
+  $manage_repo           = $zabbix::params::manage_repo,
+) inherits zabbix::params {
 
   # Only include the repo class if it has not yet been included
   unless defined(Class['Zabbix::Repo']) {

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -18,6 +18,7 @@ define zabbix::startup (
   Optional[String] $database_type                        = undef,
   Optional[String] $zabbix_user                          = undef,
   String $additional_service_params                      = '',
+  String $service_type                                   = 'simple',
   ) {
 
   case $title {

--- a/spec/acceptance/agent_spec.rb
+++ b/spec/acceptance/agent_spec.rb
@@ -1,28 +1,35 @@
 require 'spec_helper_acceptance'
 
-describe 'zabbix::agent class' do
-  context 'default parameters' do
-    # Using puppet_apply as a helper
-    it 'works idempotently with no errors' do
-      pp = <<-EOS
-      class { 'zabbix::agent':
-        server => '192.168.20.11'
-      }
-      EOS
+['2.4', '3.2'].each do |version|
+  if version == '2.4' && default[:platform] =~ %r{(ubuntu-16.04-amd64|debian-8-amd64)}
+    next
+  end
+  describe 'zabbix::agent class' do
+    context "default parameters and zabbix version #{version}" do
+      # Using puppet_apply as a helper
+      it 'works idempotently with no errors' do
+        pp = <<-EOS
+        class { 'zabbix::agent':
+          server               => '192.168.20.11',
+          zabbix_package_state => 'latest',
+          zabbix_version       => '#{version}'
+        }
+        EOS
 
-      # Run it twice and test for idempotency
-      apply_manifest(pp, catch_failures: true)
-      apply_manifest(pp, catch_changes: true)
-    end
+        # Run it twice and test for idempotency
+        apply_manifest(pp, catch_failures: true)
+        apply_manifest(pp, catch_changes: true)
+      end
 
-    # do some basic checks
-    describe package('zabbix-agent') do
-      it { is_expected.to be_installed }
-    end
+      # do some basic checks
+      describe package('zabbix-agent') do
+        it { is_expected.to be_installed }
+      end
 
-    describe service('zabbix-agent') do
-      it { is_expected.to be_running }
-      it { is_expected.to be_enabled }
+      describe service('zabbix-agent') do
+        it { is_expected.to be_running }
+        it { is_expected.to be_enabled }
+      end
     end
   end
 end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -221,7 +221,7 @@ describe 'zabbix::repo' do
             it { is_expected.to contain_yumrepo('zabbix').with_baseurl('http://repo.zabbix.com/zabbix/3.2/rhel/6/$basearch/') }
             it { is_expected.to contain_yumrepo('zabbix').with_gpgkey('http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591') }
             it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_baseurl('http://repo.zabbix.com/non-supported/rhel/6/$basearch/') }
-            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_gpgkey('http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591') }
+            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_gpgkey('https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-79EA5ED4') }
           end
         when '7'
 
@@ -250,7 +250,7 @@ describe 'zabbix::repo' do
             it { is_expected.to contain_yumrepo('zabbix').with_baseurl('http://repo.zabbix.com/zabbix/3.2/rhel/7/$basearch/') }
             it { is_expected.to contain_yumrepo('zabbix').with_gpgkey('http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591') }
             it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_baseurl('http://repo.zabbix.com/non-supported/rhel/7/$basearch/') }
-            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_gpgkey('http://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591') }
+            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_gpgkey('https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-79EA5ED4') }
           end
         end
       end

--- a/templates/zabbix-agent-systemd.init.erb
+++ b/templates/zabbix-agent-systemd.init.erb
@@ -3,7 +3,7 @@ Description=Zabbix Agent
 After=network.target
 
 [Service]
-Type=simple
+<% if @service_type %>Type=<%= @service_type %><% end %>
 Restart=on-failure
 <% if @pidfile %>PIDFile=<%= @pidfile %><% end %>
 KillMode=control-group


### PR DESCRIPTION
These are multiple bugs that I found while doing acceptance testing. The implementation is described in the individual commit messages. This fixes https://github.com/voxpupuli/puppet-zabbix/issues/398 and https://github.com/voxpupuli/puppet-zabbix/issues/397 and is based on the work from https://github.com/voxpupuli/puppet-zabbix/pull/396 and https://github.com/voxpupuli/puppet-zabbix/pull/382