### PR TITLE
define owner and group via parameters

### DIFF
--- a/manifests/userparameters.pp
+++ b/manifests/userparameters.pp
@@ -1,6 +1,6 @@
 # == Define: zabbix::userparameters
 #
-#  This will install an userparameters file with keys for item that can be check
+#  This will install an userparameters file with keys for items that can be checked
 #  with zabbix.
 #
 # === Requirements
@@ -61,41 +61,43 @@ define zabbix::userparameters (
   $script_dir = '/usr/bin',
 ) {
   $include_dir          = getvar('::zabbix::agent::include_dir')
-  $zabbix_agent_package = getvar('::zabbix::agent::zabbix_package_agent')
+  $zabbix_package_agent = getvar('::zabbix::agent::zabbix_package_agent')
+  $agent_config_owner   = getvar('::zabbix::agent::agent_config_owner')
+  $agent_config_group   = getvar('::zabbix::agent::agent_config_group')
 
   if $source != '' {
     file { "${include_dir}/${name}.conf":
       ensure  => present,
-      owner   => 'zabbix',
-      group   => 'zabbix',
+      owner   => $agent_config_owner,
+      group   => $agent_config_group,
       mode    => '0644',
       source  => $source,
       notify  => Service['zabbix-agent'],
-      require => Package[$zabbix_agent_package],
+      require => Package[$zabbix_package_agent],
     }
   }
 
   if $content != '' {
     file { "${include_dir}/${name}.conf":
       ensure  => present,
-      owner   => 'zabbix',
-      group   => 'zabbix',
+      owner   => $agent_config_owner,
+      group   => $agent_config_group,
       mode    => '0644',
       content => $content,
       notify  => Service['zabbix-agent'],
-      require => Package[$zabbix_agent_package],
+      require => Package[$zabbix_package_agent],
     }
   }
 
   if $script != '' {
     file { "${script_dir}/${name}${script_ext}":
       ensure  => present,
-      owner   => 'zabbix',
-      group   => 'zabbix',
+      owner   => $agent_config_owner,
+      group   => $agent_config_group,
       mode    => '0755',
       source  => $script,
       notify  => Service['zabbix-agent'],
-      require => Package[$zabbix_agent_package],
+      require => Package[$zabbix_package_agent],
     }
   }
 


### PR DESCRIPTION
userparameters.pp used 'zabbix' hardcoded as owner and group. Some
distributions like Arch Linux use 'zabbix-agent'.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
