### PR TITLE
Add pg_hba rule to allow zabbix server #411

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -158,7 +158,7 @@ class zabbix::database(
         }
 
         # When every component has its own server, we have to allow those servers to
-        # access the database from the network. Postgresl allows this via the
+        # access the database from the network. Postgresql allows this via the
         # pg_hba.conf file. As this file only accepts ip addresses, the ip address
         # of server and web has to be supplied as an parameter.
         if $zabbix_web_ip != $zabbix_server_ip {

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -146,7 +146,7 @@ class zabbix::database(
         }
 
         # When database not in some server with zabbix server include pg_hba_rule to server
-        if $database_host_ip != $zabbix_server_ip {
+        if ($database_host_ip != $zabbix_server_ip) ||  $zabbix_web_ip != $zabbix_server_ip{
           postgresql::server::pg_hba_rule { 'Allow zabbix-server to access database':
             description => 'Open up postgresql for access from zabbix-server',
             type        => 'host',

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -153,7 +153,7 @@ class zabbix::database(
           address     => "${zabbix_server_ip}/32",
           auth_method => 'md5',
         }
-     
+
         # When every component has its own server, we have to allow those servers to
         # access the database from the network. Postgresl allows this via the
         # pg_hba.conf file. As this file only accepts ip addresses, the ip address

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -146,7 +146,7 @@ class zabbix::database(
         }
 
         # When database not in some server with zabbix server include pg_hba_rule to server
-        if ($database_host_ip != $zabbix_server_ip) ||  $zabbix_web_ip != $zabbix_server_ip{
+        if ($database_host_ip != $zabbix_server_ip) or ($zabbix_web_ip != $zabbix_server_ip){
           postgresql::server::pg_hba_rule { 'Allow zabbix-server to access database':
             description => 'Open up postgresql for access from zabbix-server',
             type        => 'host',

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -126,6 +126,7 @@ class zabbix::database(
   $database_user                   = $zabbix::params::server_database_user,
   $database_password               = $zabbix::params::server_database_password,
   $database_host                   = $zabbix::params::server_database_host,
+  $database_host_ip                = $zabbix::params::zabbix_server_ip,
   $database_charset                = $zabbix::params::server_database_charset,
   $database_collate                = $zabbix::params::server_database_collate,
 ) inherits zabbix::params {

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -143,21 +143,22 @@ class zabbix::database(
           password => postgresql_password($database_user, $database_password),
           require  => Class['postgresql::server'],
         }
-
+        # This rule alway insert a pg_hba_rule to allow Zabbix Server to connect the
+        # the database even when Zabbix Server and Database are in same server
+        postgresql::server::pg_hba_rule { 'Allow zabbix-server to access database':
+          description => 'Open up postgresql for access from zabbix-server',
+          type        => 'host',
+          database    => $database_name,
+          user        => $database_user,
+          address     => "${zabbix_server_ip}/32",
+          auth_method => 'md5',
+        }
+     
         # When every component has its own server, we have to allow those servers to
         # access the database from the network. Postgresl allows this via the
         # pg_hba.conf file. As this file only accepts ip addresses, the ip address
         # of server and web has to be supplied as an parameter.
         if $zabbix_web_ip != $zabbix_server_ip {
-          postgresql::server::pg_hba_rule { 'Allow zabbix-server to access database':
-            description => 'Open up postgresql for access from zabbix-server',
-            type        => 'host',
-            database    => $database_name,
-            user        => $database_user,
-            address     => "${zabbix_server_ip}/32",
-            auth_method => 'md5',
-          }
-
           postgresql::server::pg_hba_rule { 'Allow zabbix-web to access database':
             description => 'Open up postgresql for access from zabbix-web',
             type        => 'host',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -130,6 +130,7 @@ class zabbix::params {
   $server_database_charset                  = 'utf8'
   $server_database_collate                  = 'utf8_general_ci'
   $server_database_host                     = 'localhost'
+  $server_database_host_ip                  = '127.0.0.1'
   $server_database_name                     = 'zabbix_server'
   $server_database_password                 = 'zabbix_server'
   $server_database_port                     = undef
@@ -258,7 +259,6 @@ class zabbix::params {
   $proxy_configfile_path                    = '/etc/zabbix/zabbix_proxy.conf'
   $proxy_configfrequency                    = '3600'
   $proxy_database_host                      = 'localhost'
-  $proxy_database_host_ip                   = '127.0.0.1'
   $proxy_database_name                      = 'zabbix_proxy'
   $proxy_database_password                  = 'zabbix-proxy'
   $proxy_database_port                      = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -258,6 +258,7 @@ class zabbix::params {
   $proxy_configfile_path                    = '/etc/zabbix/zabbix_proxy.conf'
   $proxy_configfrequency                    = '3600'
   $proxy_database_host                      = 'localhost'
+  $proxy_database_host_ip                   = '127.0.0.1'
   $proxy_database_name                      = 'zabbix_proxy'
   $proxy_database_password                  = 'zabbix-proxy'
   $proxy_database_port                      = undef

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -65,6 +65,32 @@ describe 'zabbix::database' do
         it { is_expected.to contain_class('zabbix::params') }
       end
 
+      describe 'database_type is postgresql, zabbix_type is server and zabbbix_server anda zabbix_web in the some server but zabbix_database is on other server' do
+        let :params do
+          {
+            database_type: 'postgresql',
+            database_name: 'zabbix-server',
+            database_user: 'zabbix-server',
+            zabbix_type: 'server',
+            zabbix_web_ip: '127.0.0.1',
+            zabbix_server_ip: '127.0.0.1',
+            database_host_ip: '127.0.0.2'
+          }
+        end
+
+        it { is_expected.to contain_postgresql__server__db('zabbix-server').with_name('zabbix-server') }
+        it { is_expected.to contain_postgresql__server__db('zabbix-server').with_user('zabbix-server') }
+
+        it { is_expected.to contain_postgresql__server__pg_hba_rule('Allow zabbix-server to access database').with_database('zabbix-server') }
+        it { is_expected.to contain_postgresql__server__pg_hba_rule('Allow zabbix-server to access database').with_user('zabbix-server') }
+        it { is_expected.to contain_postgresql__server__pg_hba_rule('Allow zabbix-server to access database').with_address('127.0.0.1/32') }
+
+        it { is_expected.not_to contain_postgresql__server__pg_hba_rule('Allow zabbix-web to access database').with_database('zabbix-server') }
+        it { is_expected.not_to contain_postgresql__server__pg_hba_rule('Allow zabbix-web to access database').with_user('zabbix-server') }
+        it { is_expected.not_to contain_postgresql__server__pg_hba_rule('Allow zabbix-web to access database').with_address('127.0.0.2/32') }
+        it { is_expected.to contain_class('zabbix::params') }
+      end
+
       describe 'database_type is postgresql, zabbix_type is proxy' do
         let :params do
           {

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -23,7 +23,8 @@ describe 'zabbix::database' do
             database_user: 'zabbix-server',
             zabbix_type: 'server',
             zabbix_web_ip: '127.0.0.2',
-            zabbix_server_ip: '127.0.0.1'
+            zabbix_server_ip: '127.0.0.1',
+            database_host_ip: '127.0.0.3'
           }
         end
 

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -66,7 +66,7 @@ describe 'zabbix::database' do
         it { is_expected.to contain_class('zabbix::params') }
       end
 
-      describe 'database_type is postgresql, zabbix_type is server and zabbbix_server anda zabbix_web in the some server but zabbix_database is on other server' do
+      describe 'database_type is postgresql, zabbix_type is server and zabbbix_server and a zabbix_web in the some server but zabbix_database is on other server' do
         let :params do
           {
             database_type: 'postgresql',


### PR DESCRIPTION
Add a pg_hba rule to aways add this rule for allow zabbix server connect to database. #411

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
