### PR TITLE
Fix proxy service not being enabled

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -542,14 +542,16 @@ class zabbix::proxy (
 
   # Workaround for: The redhat provider can not handle attribute enable
   # This is only happening when using an redhat family version 5.x.
-  if $::osfamily == 'redhat' and $::operatingsystemrelease !~ /^5.*/ {
-    Service[$proxy_service_name] {
-      enable => true }
+  if $::osfamily == 'redhat' and $::operatingsystemrelease =~ /^5.*/ {
+    $enable = undef
+  }  else {
+    $enable = true
   }
 
   # Controlling the 'zabbix-proxy' service
   service { $proxy_service_name:
     ensure     => running,
+    enable     => $enable,
     hasstatus  => true,
     hasrestart => true,
     require    => [


### PR DESCRIPTION
service enable is not available for RedHat-5.x.
Prior to this commit, the manifest only enabled the service for
\>Redhat-5.x, but not for other operating systems.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
