### PR TITLE
Collect and realize 'zabbix_template_host' resources

### DIFF
--- a/manifests/resources/web.pp
+++ b/manifests/resources/web.pp
@@ -46,7 +46,7 @@ class zabbix::resources::web (
     zabbix_user    => $zabbix_user,
     zabbix_pass    => $zabbix_pass,
     apache_use_ssl => $apache_use_ssl,
- }
+  }
   -> Zabbix_userparameters <<| |>> {
     zabbix_url     => $zabbix_url,
     zabbix_user    => $zabbix_user,

--- a/manifests/resources/web.pp
+++ b/manifests/resources/web.pp
@@ -41,6 +41,12 @@ class zabbix::resources::web (
     zabbix_pass    => $zabbix_pass,
     apache_use_ssl => $apache_use_ssl,
   }
+  -> Zabbix_template_host <<| |>> {
+    zabbix_url     => $zabbix_url,
+    zabbix_user    => $zabbix_user,
+    zabbix_pass    => $zabbix_pass,
+    apache_use_ssl => $apache_use_ssl,
+ }
   -> Zabbix_userparameters <<| |>> {
     zabbix_url     => $zabbix_url,
     zabbix_user    => $zabbix_user,


### PR DESCRIPTION
'zabbix_template_host' resources are not collected not realized. The same for 'zabbix_application' and 'zabbix_hostgroup' resources.

Maybe this behavior is wanted, but it is not consistent with the way other exported resources are automatically realized.
