### PR TITLE
Add "ens*" to interface name matching

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -293,7 +293,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun|virbr).*/) {
+    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun|virbr|ens).*/) {
       $listen_ip = getvar("::ipaddress_${listenip}")
     } elsif is_ip_address($listenip) or $listenip == '*' {
       $listen_ip = $listenip

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -293,7 +293,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   if ($listenip != undef) {
-    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun|virbr|ens).*/) {
+    if ($listenip =~ /^(eth|lo|bond|lxc|en|wl|ww|em|p|tap|tun|virbr).*/) {
       $listen_ip = getvar("::ipaddress_${listenip}")
     } elsif is_ip_address($listenip) or $listenip == '*' {
       $listen_ip = $listenip


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
Fix an issue with Ubuntu 16.04 TLS having "ens*" names for interfaces