### PR TITLE
Fix for Zabbix 3.4

### DIFF
--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -251,10 +251,12 @@ HousekeepingFrequency=<%= @housekeepingfrequency %>
 #
 MaxHousekeeperDelete=<%= @maxhousekeeperdelete %>
 
+<% if @zabbix_version.to_f < 3.4 %>
 ### Option: SenderFrequency
 #   How often Zabbix will try to send unsent alerts (in seconds).
 #
 SenderFrequency=<%= @senderfrequency %>
+<% end %>
 
 ### Option: CacheSize
 #   Size of configuration cache, in bytes.


### PR DESCRIPTION
The SenderFrequency variable does not exist anymore in zabbix 3.4.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
