### PR TITLE
Add missing proxy_mode variable to zabbix_proxy provider

### DIFF
--- a/lib/puppet/provider/zabbix_proxy/ruby.rb
+++ b/lib/puppet/provider/zabbix_proxy/ruby.rb
@@ -10,6 +10,10 @@ Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix
     # Set some vars
     host = @resource[:hostname]
     ipaddress = @resource[:ipaddress]
+
+    # Normally 0 is active and 1 is passive, in the API, its 5 and 6
+    proxy_mode = @resource[:mode] + 5
+
     use_ip = @resource[:use_ip]
     port = @resource[:port]
     templates = @resource[:templates]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
This is a fix for #334

I found a couple issues with the zabbix_proxy ruby code used for managing the proxy resources on the zabbix server. I think this is fixed in a proper way. I am not a Ruby developer, but it has fixed the issues I was experiencing with my manifests.
