### PR TITLE
Remove updateExisting from applications in zabbix template provider.

### DIFF
--- a/lib/puppet/provider/zabbix_template/ruby.rb
+++ b/lib/puppet/provider/zabbix_template/ruby.rb
@@ -14,8 +14,7 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
       format: 'xml',
       rules: {
         applications: {
-          createMissing: true,
-          updateExisting: true
+          createMissing: true
         },
         discoveryRules: {
           createMissing: true,


### PR DESCRIPTION
This parameter does not exist on the applications parameter. I have double checked that all the parameters are valid in this class according to the [Zabbix docs for configuration.import](https://www.zabbix.com/documentation/3.4/manual/api/reference/configuration/import) so hopefully this is the last pull request from me for now.

This fixes #449 (which I should have caught the first time around)

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
