### PR TITLE
wait for network connectivity before Zabbix Server startup

### DIFF
--- a/templates/zabbix-server-systemd.init.erb
+++ b/templates/zabbix-server-systemd.init.erb
@@ -6,6 +6,10 @@ After=mysqld.service
 <% elsif @database_type == "postgresql" and @manage_database %>
 After=postgresql.service
 <% end -%>
+# Wait for network-online and not just network:
+# - Required in case of a remote database.
+# - Avoids missing data at boot on all network-based checks.
+After=network-online.target
 
 [Service]
 ExecStart=/usr/sbin/zabbix_server <%= @additional_service_params %> -c <%= @server_configfile_path %>


### PR DESCRIPTION
Zabbix Server starts too early in the boot process :
- It can't reach its database (if remote).
- It may have missing data for all the items that require network access.

This change makes it wait until routed networking is available.
