### PR TITLE
upgrade default zabbixapi to 3.2.1

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -267,7 +267,7 @@ class zabbix::web (
         $zabbixapi_version = '2.4.4'
       }
       default : {
-        $zabbixapi_version = '2.4.7'
+        $zabbixapi_version = '3.2.1'
       }
     }
 


### PR DESCRIPTION
I've recently came across an issue with the old version of the zabbixapi gem:

```
Error: Could not run: Unable to activate zabbixapi-2.4.7, because json-2.0.2 conflicts with json (>= 1.6.0, ~> 1.6)
```

The most recent version, zabbixapi 3.2.1, relaxed the json dependency and works as expected (Zabbix 3.2.x, CentOS 7.4, Puppet 5.x). I'd suggest to upgrade the default version accordingly.