### PR TITLE
Fix dependency cycle with Package[dirmngr]

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -339,7 +339,7 @@ class zabbix::agent (
   package { $zabbix_package_agent:
     ensure  => $zabbix_package_state,
     require => Class['zabbix::repo'],
-    tag     => 'zabbix',
+    tag     => 'zabbix_package',
   }
 
   # Ensure that the correct config file is used.

--- a/manifests/javagateway.pp
+++ b/manifests/javagateway.pp
@@ -74,7 +74,7 @@ class zabbix::javagateway(
   package { 'zabbix-java-gateway':
     ensure  => $zabbix_package_state,
     require => Class['zabbix::repo'],
-    tag     => 'zabbix',
+    tag     => 'zabbix_package',
   }
 
   # Configuring the zabbix-javagateway configuration file

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -519,21 +519,21 @@ class zabbix::proxy (
         package { 'zabbix-proxy':
           ensure  => $zabbix_package_state,
           require => Package["zabbix-proxy-${db}"],
-          tag     => 'zabbix',
+          tag     => 'zabbix_package',
         }
       }
 
       # Installing the packages
       package { "zabbix-proxy-${db}":
         ensure => $zabbix_package_state,
-        tag    => 'zabbix',
+        tag    => 'zabbix_package',
       }
     } # END 'redhat','centos','oraclelinux'
     default : {
       # Installing the packages
       package { "zabbix-proxy-${db}":
         ensure => $zabbix_package_state,
-        tag    => 'zabbix',
+        tag    => 'zabbix_package',
       }
     } # END default
   } # END case $::operatingsystem

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -122,8 +122,8 @@ class zabbix::repo (
             ,
           }
         }
-        Apt::Source['zabbix'] -> Package<|tag == 'zabbix'|>
-        Class['Apt::Update']  -> Package<|tag == 'zabbix'|>
+        Apt::Source['zabbix'] -> Package<|tag == 'zabbix_package'|>
+        Exec['apt_update']  -> Package<|tag == 'zabbix_package'|>
       }
       default  : {
         fail("Managing a repo on ${::osfamily} is currently not implemented")

--- a/manifests/sender.pp
+++ b/manifests/sender.pp
@@ -36,6 +36,6 @@ class zabbix::sender(
   package { 'zabbix-sender':
     ensure  => $zabbix_package_state,
     require => Class['zabbix::repo'],
-    tag     => 'zabbix',
+    tag     => 'zabbix_package',
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -450,7 +450,7 @@ class zabbix::server (
   package { "zabbix-server-${db}":
     ensure  => $zabbix_package_state,
     require => Class['zabbix::repo'],
-    tag     => 'zabbix',
+    tag     => 'zabbix_package',
   }
 
   # Ensure that the correct config file is used.

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -342,7 +342,7 @@ class zabbix::web (
         ensure  => $zabbix_package_state,
         before  => Package[$zabbix_web_package],
         require => Class['zabbix::repo'],
-        tag     => 'zabbix',
+        tag     => 'zabbix_package',
       }
     }
   } # END case $::operatingsystem
@@ -359,7 +359,7 @@ class zabbix::web (
     ensure  => $zabbix_package_state,
     before  => File['/etc/zabbix/web/zabbix.conf.php'],
     require => Class['zabbix::repo'],
-    tag     => 'zabbix',
+    tag     => 'zabbix_package',
   }
 
   # Webinterface config file

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -37,7 +37,7 @@ describe 'zabbix::agent' do
           is_expected.to contain_package(package).with(
             ensure:   'present',
             require:  'Class[Zabbix::Repo]',
-            tag:      'zabbix'
+            tag:      'zabbix_package'
           )
         end
 


### PR DESCRIPTION
When ::apt is included by ::zabbix::repo it gets automaticaly tagged with zabbix.
So we need to use a custom tag to set the correct order for packages manage by the zabbix module.
Else we get a dependency cycle with the package dirmngr installed by ::apt in recent Debian 9 or Ubuntu

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
