### PR TITLE
Support SSL parameters for web monitoring in all versions >= 2.4

### DIFF
--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -293,6 +293,8 @@ describe 'zabbix::server' do
         it { is_expected.not_to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeID=0$} }
         it { is_expected.not_to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoEvents=0} }
         it { is_expected.not_to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^NodeNoHistory=0} }
+        it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SSLCertLocation=/usr/lib/zabbix/ssl/certs} }
+        it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SSLKeyLocation=/usr/lib/zabbix/ssl/keys} }
       end
 
       context 'with zabbix_server.conf and version 3.0' do
@@ -310,6 +312,8 @@ describe 'zabbix::server' do
         it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSCRLFile=/etc/zabbix/keys/zabbix-server.crl$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSCertFile=/etc/zabbix/keys/zabbix-server.crt$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^TLSKeyFile=/etc/zabbix/keys/zabbix-server.key$} }
+        it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SSLCertLocation=/usr/lib/zabbix/ssl/certs} }
+        it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SSLKeyLocation=/usr/lib/zabbix/ssl/keys} }
       end
       context 'with zabbix_server.conf and version 3.2' do
         let :params do

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -431,7 +431,7 @@ AllowRoot=<%= @allowroot %>
 #
 Include=<%= @include_dir %>
 
-<% if @zabbix_version == '2.4' %>
+<% if @zabbix_version.to_f >= 2.4 %>
 ### Option: SSLCertLocation
 #   Location of SSL client certificates.
 #   This parameter is used only in web monitoring.


### PR DESCRIPTION
This PR is for the following issue: https://github.com/voxpupuli/puppet-zabbix/issues/468

I am sorry if the tests aren't correct and will gladly improve if pointed in the right direction.