### PR TITLE
#476 Pass credentials for HTTP auth

### DIFF
--- a/lib/puppet/provider/zabbix.rb
+++ b/lib/puppet/provider/zabbix.rb
@@ -11,7 +11,9 @@ class Puppet::Provider::Zabbix < Puppet::Provider
     zbx = ZabbixApi.connect(
       url: "#{protocol}://#{zabbix_url}/api_jsonrpc.php",
       user: zabbix_user,
-      password: zabbix_pass
+      password: zabbix_pass,
+      http_user: zabbix_user,
+      http_password: zabbix_pass
     )
     zbx
   end


### PR DESCRIPTION
Along the usual Zabbix user and password, the credentials are now passed on to the Zabbix api client for HTTP basic auth support.
