### PR TITLE
Fixed versioncmp compare and fixed typo in file zabbix-server-ips.te

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -568,10 +568,10 @@ class zabbix::server (
     }
     # zabbix-server 3.4 introduced IPC via a socket in /tmp
     # https://support.zabbix.com/browse/ZBX-12567
-    if versioncmp($zabbix_version, '3.3') > 1  {
+    if versioncmp($zabbix_version, '3.3') > 0  {
       selinux::module{'zabbix-server-ipc':
         ensure    => 'present',
-        source_te => 'puppet:///modules/zabbix/zabbix-server-ips.te',
+        source_te => 'puppet:///modules/zabbix/zabbix-server-ipc.te',
         before    => $dependency,
       }
     }


### PR DESCRIPTION
The versioncmp in server.pp to check if it is 3.3 or greater, doesn't work. versioncmp can't return a value greater then 1. It should be greater then 0 (see: [versioncmp docs](https://puppet.com/docs/puppet/5.3/function.html#versioncmp))

And if the versioncmp did work, it couldn't have loaded the correct .te file. It has a typo in it. The file is named zabbix-server-ipc.te and not zabbix-server-ips.te.

So this code looks like it never runned on anyone's server.