### PR TITLE
Do not guess ListenIP, fixes #473, bump stdlib to 4.19.0

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -294,16 +294,10 @@ class zabbix::agent (
   # to network name. If more than 1 interfaces are available, we
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
-  if ($listenip != undef) {
-    if ($listenip =~ /^(eth|lo|bond|lxc|eno|tap|tun|virbr).*/) {
-      $listen_ip = getvar("::ipaddress_${listenip}")
-    } elsif is_ip_address($listenip) or $listenip == '*' {
-      $listen_ip = $listenip
-    } else {
-      $listen_ip = $::ipaddress
-    }
-  } else {
-    $listen_ip = undef
+  $listen_ip = $listenip ? {
+    /^(eth|lo|bond|lxc|eno|tap|tun|virbr).*/ => fact("networking.interfaces.${listen_ip}.ip"), # the stdlib fact function still returns undef if the fact can't be found.  This keeps the behaviour similar to how getvar would have worked, but now we use the modern networking fact instead of the legacy ipaddress_INTERFACE one
+    '*' => undef,
+    default => $listenip, # I think this is then right for all other possibilities (an ip address, or undef)
   }
 
   # So if manage_resources is set to true, we can send some data

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -303,7 +303,7 @@ class zabbix::agent (
       $listen_ip = $::ipaddress
     }
   } else {
-    $listen_ip = $::ipaddress
+    $listen_ip = undef
   }
 
   # So if manage_resources is set to true, we can send some data

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -295,9 +295,9 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   $listen_ip = $listenip ? {
-    /^(eth|lo|bond|lxc|eno|tap|tun|virbr).*/ => fact("networking.interfaces.${listen_ip}.ip"), # the stdlib fact function still returns undef if the fact can't be found.  This keeps the behaviour similar to how getvar would have worked, but now we use the modern networking fact instead of the legacy ipaddress_INTERFACE one
+    /^(eth|lo|bond|lxc|eno|tap|tun|virbr).*/ => fact("networking.interfaces.${listen_ip}.ip"),
     '*' => undef,
-    default => $listenip, # I think this is then right for all other possibilities (an ip address, or undef)
+    default => $listenip,
   }
 
   # So if manage_resources is set to true, we can send some data

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.19.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/mysql",

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -235,27 +235,13 @@ describe 'zabbix::agent' do
       end
 
       context 'without ListenIP' do
-        package = 'zabbix-agent'
-        # Make sure package will be installed, service running and ensure of directory.
-        it do
-          is_expected.to contain_package(package).with(
-            ensure:   'present',
-            require:  'Class[Zabbix::Repo]',
-            tag:      'zabbix'
-          )
+        let :params do
+          {
+            listenip: '*'
+          }
         end
 
-        it do
-          is_expected.to contain_service('zabbix-agent').with(
-            ensure:     'running',
-            enable:     true,
-            hasstatus:  true,
-            hasrestart: true,
-            require:    "Package[#{package}]"
-          )
-        end
-
-        it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').without_content %r{^ListenIP=127.0.0.1$} }
+        it { is_expected.to contain_file(config_path).without_content %r{^ListenIP=} }
       end
     end
   end

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -177,6 +177,7 @@ describe 'zabbix::agent' do
             hostname: '10050',
             include_dir: '/etc/zabbix/zabbix_agentd.d',
             listenport: '10050',
+            listenip: '127.0.0.1',
             loadmodulepath: '${libdir}/modules',
             logfilesize: '4',
             logfile: '/var/log/zabbix/zabbix_agentd.log',
@@ -209,6 +210,7 @@ describe 'zabbix::agent' do
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Hostname=10050$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^Include=/etc/zabbix/zabbix_agentd.d$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^ListenPort=10050$} }
+        it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^ListenIP=127.0.0.1$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LoadModulePath=\$\{libdir\}/modules$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogFileSize=4$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^LogFile=/var/log/zabbix/zabbix_agentd.log$} }
@@ -230,6 +232,30 @@ describe 'zabbix::agent' do
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^TLSKeyFile=/etc/zabbix/keys/tls.key$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^TLSPSKIdentity=/etc/zabbix/keys/tlspskidentity.id$} }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').with_content %r{^TLSPSKFile=/etc/zabbix/keys/tlspskfile.key$} }
+      end
+
+      context 'without ListenIP' do
+        package = 'zabbix-agent'
+        # Make sure package will be installed, service running and ensure of directory.
+        it do
+          is_expected.to contain_package(package).with(
+            ensure:   'present',
+            require:  'Class[Zabbix::Repo]',
+            tag:      'zabbix'
+          )
+        end
+
+        it do
+          is_expected.to contain_service('zabbix-agent').with(
+            ensure:     'running',
+            enable:     true,
+            hasstatus:  true,
+            hasrestart: true,
+            require:    "Package[#{package}]"
+          )
+        end
+
+        it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf').without_content %r{^ListenIP=127.0.0.1$} }
       end
     end
   end


### PR DESCRIPTION
This commit changes the behaviour if the $listen_ip argument is not
given. In that case ListenIP is omitted from the agent configuration.
Having no ListenIP in the configuration ensures the agent listens on
both IPv4 and IPv6.
Also added a spec test for the case were ListenIP is left empty.
Acceptance testing gave no errors.

Signed-off-by: Olivier van der Toorn <oliviervdtoorn@gmail.com>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
