### PR TITLE
bump mysql version to >= 5.4.0 < 6.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 3.5.0 < 6.0.0"
+      "version_requirement": ">= 5.4.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/apache",


### PR DESCRIPTION
This is based on
https://github.com/puppetlabs/puppetlabs-mysql/pull/1057 and depends on https://tickets.puppetlabs.com/browse/MODULES-6932

----

We should not merge this before the MODULES-6932 issue is solved