### PR TITLE
Fix listen_ip bug and relax interface regex

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -295,7 +295,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   $listen_ip = $listenip ? {
-    /^(eth|lo|bond|lxc|eno|tap|tun|virbr).*/ => fact("networking.interfaces.${listen_ip}.ip"),
+    /^(e|lo|bond|lxc|tap|tun|virbr).*/ => fact("networking.interfaces.${listen_ip}.ip"),
     '*' => undef,
     default => $listenip,
   }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -295,7 +295,7 @@ class zabbix::agent (
   # can find the ipaddress of this specific interface if listenip
   # is set to for example "eth1" or "bond0.73".
   $listen_ip = $listenip ? {
-    /^(e|lo|bond|lxc|tap|tun|virbr).*/ => fact("networking.interfaces.${listen_ip}.ip"),
+    /^(e|lo|bond|lxc|tap|tun|virbr).*/ => fact("networking.interfaces.${listenip}.ip"),
     '*' => undef,
     default => $listenip,
   }

--- a/spec/acceptance/agent_spec.rb
+++ b/spec/acceptance/agent_spec.rb
@@ -30,6 +30,47 @@ require 'spec_helper_acceptance'
         it { is_expected.to be_running }
         it { is_expected.to be_enabled }
       end
+
+      describe file('/etc/zabbix/zabbix_agentd.conf') do
+        its(:content) { is_expected.not_to match %r{ListenIP=} }
+      end
+    end
+  end
+end
+
+describe 'zabbix::agent class' do
+  context 'With ListenIP set to an IP-Address' do
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class { 'zabbix::agent':
+        server               => '192.168.20.11',
+        zabbix_package_state => 'latest',
+        listenip             => '127.0.0.1',
+        zabbix_version       => '3.4'
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+    describe file('/etc/zabbix/zabbix_agentd.conf') do
+      its(:content) { is_expected.to match %r{ListenIP=127.0.0.1} }
+    end
+  end
+  context 'With ListenIP set to lo' do
+    it 'works idempotently with no errors' do
+      pp = <<-EOS
+      class { 'zabbix::agent':
+        server               => '192.168.20.11',
+        zabbix_package_state => 'latest',
+        listenip             => 'lo',
+        zabbix_version       => '3.4'
+      }
+      EOS
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+    describe file('/etc/zabbix/zabbix_agentd.conf') do
+      its(:content) { is_expected.to match %r{ListenIP=127.0.0.1} }
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
    Replace this comment with a description of your pull request.
-->
The old regex didn't match for enp0s5 for example. Other values are
possible as well. We should match for ^e*

#### This Pull Request (PR) fixes the following issues
<!--
    Replace this comment with the list of issues or n/a.
    Use format:
    Fixes #123
    Fixes #124
-->

Fixes https://github.com/voxpupuli/puppet-zabbix/issues/493