### PR TITLE
Fix missing enable for zabbix::proxy

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -555,6 +555,7 @@ class zabbix::proxy (
       ensure     => running,
       hasstatus  => true,
       hasrestart => true,
+      enable     => $enable,
       subscribe  => [
         File[$proxy_configfile_path],
         Class['::zabbix::database']

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -191,6 +191,7 @@ describe 'zabbix::proxy' do
           end
 
           it { is_expected.to contain_service('zabbix-proxy').with_ensure('running') }
+          it { is_expected.to contain_service('zabbix-proxy').with_enable('true') }
           it { is_expected.to contain_service('zabbix-proxy').with_require(['Package[zabbix-proxy-pgsql]', 'File[/etc/zabbix/zabbix_proxy.conf.d]', 'File[/etc/zabbix/zabbix_proxy.conf]', 'Class[Zabbix::Database]']) }
         end
 


### PR DESCRIPTION
37e7173a477ca866ff6643c8dea4797db0281fc5 removed the enable option.
This commit adds it again.


#### Pull Request (PR) description
https://github.com/voxpupuli/puppet-zabbix/commit/37e7173a477ca866ff6643c8dea4797db0281fc5 removed the enable option for the proxy service.

#### This Pull Request (PR) fixes the following issues

I've added it again.