### PR TITLE
Fix missing $ in repo definition for Debian sid

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -104,7 +104,7 @@ class zabbix::repo (
         } else {
           $operatingsystem = downcase($facts['os']['name'])
           case $facts['os']['release']['full'] {
-            /\/sid$/ : { $releasename = regsubst(facts['os']['release']['full'], '/sid$', '') }
+            /\/sid$/ : { $releasename = regsubst($facts['os']['release']['full'], '/sid$', '') }
             default  : { $releasename = $facts['lsbdistcodename'] }
           }
           apt::key { 'zabbix-FBABD5F':


### PR DESCRIPTION
#### Pull Request (PR) description
Fix typo (missing $ before variable $facts).