### PR TITLE
Add Gentoo support

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -215,6 +215,7 @@ class zabbix::agent (
   $zbx_templates                          = $zabbix::params::agent_zbx_templates,
   $agent_configfile_path                  = $zabbix::params::agent_configfile_path,
   $pidfile                                = $zabbix::params::agent_pidfile,
+  $servicename                            = $zabbix::params::agent_servicename,
   String $logtype                         = $zabbix::params::agent_logtype,
   Optional[Stdlib::Absolutepath] $logfile = $zabbix::params::agent_logfile,
   $logfilesize                            = $zabbix::params::agent_logfilesize,
@@ -339,7 +340,7 @@ class zabbix::agent (
   }
 
   # Ensure that the correct config file is used.
-  zabbix::startup {'zabbix-agent':
+  zabbix::startup {$servicename:
     pidfile                   => $pidfile,
     agent_configfile_path     => $agent_configfile_path,
     zabbix_user               => $zabbix_user,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class zabbix::params {
       $agent_zabbix_user     = 'zabbix'
       $agent_config_group    = 'zabbix'
       $agent_pidfile         = '/var/run/zabbix/zabbix_agentd.pid'
+      $agent_servicename     = 'zabbix-agent'
       $server_zabbix_user    = 'zabbix'
     }
     'Archlinux': {
@@ -39,6 +40,7 @@ class zabbix::params {
       $agent_zabbix_user     = 'zabbix-agent'
       $agent_config_group    = 'zabbix-agent'
       $agent_pidfile         = undef
+      $agent_servicename     = 'zabbix-agent'
       $server_zabbix_user    = 'zabbix-server'
     }
     'Fedora': {
@@ -53,6 +55,22 @@ class zabbix::params {
       $agent_zabbix_user     = 'zabbix'
       $agent_config_group    = 'zabbix'
       $agent_pidfile         = '/var/run/zabbix/zabbix_agentd.pid'
+      $agent_servicename     = 'zabbix-agent'
+      $server_zabbix_user    = 'zabbix'
+    }
+    'Gentoo': {
+      $server_fpinglocation  = '/usr/sbin/fping'
+      $server_fping6location = '/usr/sbin/fping6'
+      $proxy_fpinglocation   = '/usr/sbin/fping'
+      $proxy_fping6location  = '/usr/sbin/fping6'
+      $manage_repo           = false
+      $zabbix_package_agent  = 'zabbix'
+      $agent_configfile_path = '/etc/zabbix/zabbix_agentd.conf'
+      $agent_config_owner    = 'zabbix'
+      $agent_zabbix_user     = 'zabbix'
+      $agent_config_group    = 'zabbix'
+      $agent_pidfile         = '/var/run/zabbix/zabbix_agentd.pid'
+      $agent_servicename     = 'zabbix-agentd'
       $server_zabbix_user    = 'zabbix'
     }
     default  : {
@@ -67,6 +85,7 @@ class zabbix::params {
       $agent_zabbix_user     = 'zabbix'
       $agent_config_group    = 'zabbix'
       $agent_pidfile         = '/var/run/zabbix/zabbix_agentd.pid'
+      $agent_servicename     = 'zabbix-agent'
       $server_zabbix_user    = 'zabbix'
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -143,6 +143,9 @@
     },
     {
       "operatingsystem": "Archlinux"
+    },
+    {
+      "operatingsystem": "Gentoo"
     }
   ]
 }


### PR DESCRIPTION
The agent service name is now defined in the params.pp as well since it is different on Gentoo.

#### Pull Request (PR) description
It introduces variables for Gentoo. Additionally it replaces the hardcoded agent service name with one from params.pp (which is also OS dependend).
This PR does not fix the repo not bein supported on Gentoo warning. However, the agent can be used without managing the repo as well.

#### This Pull Request (PR) fixes the following issues
Fixes #531
