### PR TITLE
Gentoo service fix

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -346,6 +346,7 @@ class zabbix::agent (
     zabbix_user               => $zabbix_user,
     additional_service_params => $real_additional_service_params,
     service_type              => $real_service_type,
+    service_name              => 'zabbix-agent',
     require                   => Package[$zabbix_package_agent],
   }
 
@@ -362,7 +363,7 @@ class zabbix::agent (
   } else {
     $service_provider = undef
   }
-  service { 'zabbix-agent':
+  service { $servicename:
     ensure     => running,
     enable     => true,
     provider   => $service_provider,
@@ -377,7 +378,7 @@ class zabbix::agent (
     owner   => $agent_config_owner,
     group   => $agent_config_group,
     mode    => '0644',
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$servicename],
     require => Package[$zabbix_package_agent],
     replace => true,
     content => template('zabbix/zabbix_agentd.conf.erb'),
@@ -390,7 +391,7 @@ class zabbix::agent (
     group   => $agent_config_group,
     recurse => true,
     purge   => $include_dir_purge,
-    notify  => Service['zabbix-agent'],
+    notify  => Service[$servicename],
     require => File[$agent_configfile_path],
   }
 
@@ -413,7 +414,7 @@ class zabbix::agent (
     selinux::module{'zabbix-agent':
       ensure     => 'present',
       content_te => template('zabbix/selinux/zabbix-agent.te.erb'),
-      before     => Service['zabbix-agent'],
+      before     => Service[$servicename],
     }
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -465,6 +465,7 @@ class zabbix::server (
     zabbix_user               => $zabbix_user,
     additional_service_params => $real_additional_service_params,
     manage_database           => $manage_database,
+    service_name              => 'zabbix-server',
     require                   => Package["zabbix-server-${db}"],
   }
 

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -20,6 +20,7 @@ define zabbix::startup (
   String $additional_service_params                      = '',
   String $service_type                                   = 'simple',
   Optional[Boolean] $manage_database                     = undef,
+  Optional[String] $service_name                         = $name,
   ) {
 
   case $title {
@@ -41,7 +42,7 @@ define zabbix::startup (
     file { "/etc/systemd/system/${name}.service":
       ensure  => file,
       mode    => '0664',
-      content => template("zabbix/${name}-systemd.init.erb"),
+      content => template("zabbix/${service_name}-systemd.init.erb"),
     }
     ~> Exec['systemctl-daemon-reload']
     file { "/etc/init.d/${name}":
@@ -50,7 +51,7 @@ define zabbix::startup (
   } elsif $facts['os']['family'] in ['Debian', 'RedHat'] {
     # Currently other osfamily without systemd is not supported
     $osfamily_downcase = downcase($facts['os']['family'])
-    file { "/etc/init.d/${name}":
+    file { "/etc/init.d/${service_name}":
       ensure  => file,
       mode    => '0755',
       content => template("zabbix/${name}-${osfamily_downcase}.init.erb"),

--- a/manifests/userparameters.pp
+++ b/manifests/userparameters.pp
@@ -69,6 +69,7 @@ define zabbix::userparameters (
   $zabbix_package_agent = getvar('::zabbix::agent::zabbix_package_agent')
   $agent_config_owner   = getvar('::zabbix::agent::agent_config_owner')
   $agent_config_group   = getvar('::zabbix::agent::agent_config_group')
+  $agent_servicename    = getvar('::zabbix::agent::agent_servicename')
 
   if $source != '' {
     file { "${include_dir}/${name}.conf":
@@ -77,7 +78,7 @@ define zabbix::userparameters (
       group   => $agent_config_group,
       mode    => $config_mode,
       source  => $source,
-      notify  => Service['zabbix-agent'],
+      notify  => Service[$agent_servicename],
       require => Package[$zabbix_package_agent],
     }
   }
@@ -89,7 +90,7 @@ define zabbix::userparameters (
       group   => $agent_config_group,
       mode    => $config_mode,
       content => $content,
-      notify  => Service['zabbix-agent'],
+      notify  => Service[$agent_servicename],
       require => Package[$zabbix_package_agent],
     }
   }
@@ -101,7 +102,7 @@ define zabbix::userparameters (
       group   => $agent_config_group,
       mode    => '0755',
       source  => $script,
-      notify  => Service['zabbix-agent'],
+      notify  => Service[$agent_servicename],
       require => Package[$zabbix_package_agent],
     }
   }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR continues the Gentoo support of the puppet-zabbix module.
It fixes a few forgotten changes from `zabbix-agent` to `$servicename`. Which is sourced from `params.pp`.

In the second commit a copy is made of `zabbix-agent-systemd.init.erb` and named as `zabbix-agentd-systemd.init.erb`. I'm not sure if this is the wanted procedure, hence I left it as a separate commit. If this is not the correct procedure feel free to reject it ;)

The last commit adds `$servicename` like support to userparameters.pp.