### PR TITLE
Zabbix agent: ordering to avoid initial service start failure

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -378,7 +378,7 @@ class zabbix::agent (
     group   => $agent_config_group,
     mode    => '0644',
     notify  => Service['zabbix-agent'],
-    require => Package[$zabbix_package_agent],
+    require => Zabbix::Startup['zabbix-agent'],
     replace => true,
     content => template('zabbix/zabbix_agentd.conf.erb'),
   }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Initial start of Zabbix agent service after installation fails as a service definition file is created only after the service is started for the first time. Issue is easily resolved by changed ordering.

#### This Pull Request (PR) fixes the following issues
Fixes #496 