### PR TITLE
Fix proxy documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,11 @@ The following is an example for using the PostgreSQL as database:
 ```ruby
 node 'proxy.example.com' {
   class { 'postgresql::server': }
-
+  
+  class { 'zabbix::database':
+    database_type => 'postgresql',
+  }
+  
   class { 'zabbix::proxy':
     zabbix_server_host => '192.168.20.11',
     database_type      => 'postgresql',
@@ -210,6 +214,10 @@ When you want to make use of an MySQL database as backend:
 ```ruby
 node 'proxy.example.com' {
   class { 'mysql::server': }
+
+  class { 'zabbix::database': 
+    database_type => 'mysql',
+  }
 
   class { 'zabbix::proxy':
     zabbix_server_host => '192.168.20.11',


### PR DESCRIPTION
I updated the zabbix-proxy section to account for the database type error message `Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Class[Zabbix::Database]: parameter 'database_type' expects a match for Zabbix::Databases = Enum['mysql', 'postgresql', 'sqlite']` when using the example documentation that was provided.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
   This is an update to the README.md to fix an issue i encountered when using the base example on a test machine. With the current documentation there is an error that mentions there is a missing reference to the database_type from the zabbix::database class. The fix was to simply define the database_type for that class and reference it in the node definition. This might be also required for the sqlite installation as well but I was unable to test that at this time. 
-->

#### This Pull Request (PR) fixes the following issues
<!--
N/A
-->
