### PR TITLE
Add manage_init_script parameter

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -177,6 +177,9 @@
 # [*loadmodule*]
 #   Module to load at agent startup.
 #
+# [*manage_startup_script*]
+#  If the init script should be managed by this module. Attention: This might cause problems with some config options of this module (e.g agent_configfile_path)
+#
 # === Example
 #
 #  Basic installation:
@@ -263,6 +266,7 @@ class zabbix::agent (
   Hash[String, Array] $selinux_rules      = $zabbix::params::selinux_rules,
   String $additional_service_params       = $zabbix::params::additional_service_params,
   String $service_type                    = $zabbix::params::service_type,
+  Boolean $manage_startup_script          = $zabbix::params::manage_startup_script,
 ) inherits zabbix::params {
 
   # the following two codeblocks are a bit blargh. The correct default value for
@@ -340,14 +344,16 @@ class zabbix::agent (
   }
 
   # Ensure that the correct config file is used.
-  zabbix::startup {$servicename:
-    pidfile                   => $pidfile,
-    agent_configfile_path     => $agent_configfile_path,
-    zabbix_user               => $zabbix_user,
-    additional_service_params => $real_additional_service_params,
-    service_type              => $real_service_type,
-    service_name              => 'zabbix-agent',
-    require                   => Package[$zabbix_package_agent],
+  if $manage_startup_script {
+    zabbix::startup {$servicename:
+      pidfile                   => $pidfile,
+      agent_configfile_path     => $agent_configfile_path,
+      zabbix_user               => $zabbix_user,
+      additional_service_params => $real_additional_service_params,
+      service_type              => $real_service_type,
+      service_name              => 'zabbix-agent',
+      require                   => Package[$zabbix_package_agent],
+    }
   }
 
   if $agent_configfile_path != '/etc/zabbix/zabbix_agentd.conf' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,6 +104,7 @@ class zabbix::params {
   $zabbix_web_ip                            = '127.0.0.1'
   $manage_database                          = true
   $manage_service                           = true
+  $manage_startup_script                    = true
   $default_vhost                            = false
   $manage_firewall                          = false
   $manage_apt                               = true

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -258,6 +258,9 @@
 # [*sslkeylocation_dir*]
 #   Location of SSL private key files for client authentication.
 #
+# [*manage_startup_script*]
+#  If the init script should be managed by this module. Attention: This might cause problems with some config options of this module (e.g server_configfile_path)
+#
 # === Example
 #
 #   When running everything on a single node, please check
@@ -378,6 +381,7 @@ class zabbix::server (
   Boolean $manage_selinux           = $zabbix::params::manage_selinux,
   String $additional_service_params = $zabbix::params::additional_service_params,
   Optional[String[1]] $zabbix_user  = $zabbix::params::server_zabbix_user,
+  Boolean $manage_startup_script    = $zabbix::params::manage_startup_script,
 ) inherits zabbix::params {
 
   # the following codeblock is a bit blargh. The correct default value for
@@ -458,15 +462,17 @@ class zabbix::server (
   }
 
   # Ensure that the correct config file is used.
-  zabbix::startup {'zabbix-server':
-    pidfile                   => $pidfile,
-    database_type             => $database_type,
-    server_configfile_path    => $server_configfile_path,
-    zabbix_user               => $zabbix_user,
-    additional_service_params => $real_additional_service_params,
-    manage_database           => $manage_database,
-    service_name              => 'zabbix-server',
-    require                   => Package["zabbix-server-${db}"],
+  if $manage_startup_script {
+    zabbix::startup {'zabbix-server':
+      pidfile                   => $pidfile,
+      database_type             => $database_type,
+      server_configfile_path    => $server_configfile_path,
+      zabbix_user               => $zabbix_user,
+      additional_service_params => $real_additional_service_params,
+      manage_database           => $manage_database,
+      service_name              => 'zabbix-server',
+      require                   => Package["zabbix-server-${db}"],
+    }
   }
 
   if $server_configfile_path != '/etc/zabbix/zabbix_server.conf' {

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -144,6 +144,16 @@ describe 'zabbix::agent' do
         end
       end
 
+      context 'when declaring manage_startup_script is false' do
+        let :params do
+          {
+            manage_startup_script: false
+          }
+        end
+
+        it { is_expected.not_to contain_zabbix__startup('zabbix-agent') }
+      end
+
       context 'when declaring zabbix_alias' do
         let :params do
           {

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -126,6 +126,27 @@ describe 'zabbix::server' do
         it { is_expected.not_to contain_firewall('151 zabbix-server') }
       end
 
+      context 'it creates a startup script' do
+        case facts[:osfamily]
+        when 'Archlinux', 'Fedora'
+          it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('absent') }
+          it { is_expected.to contain_file('/etc/systemd/system/zabbix-server.service').with_ensure('file') }
+        else
+          it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('file') }
+          it { is_expected.not_to contain_file('/etc/systemd/system/zabbix-server.service') }
+        end
+      end
+
+      context 'when declaring manage_startup_script is false' do
+        let :params do
+          {
+            manage_startup_script: false
+          }
+        end
+
+        it { is_expected.not_to contain_zabbix__startup('zabbix-server') }
+      end
+
       # If manage_service is true (default), it should create a service
       # and ensure that it is running.
       context 'when declaring manage_service is true' do


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds a parameter `manage_init_script` which makes it possible to disable the Init File management.

#### This Pull Request (PR) fixes the following issues
Fixes #541.
