### PR TITLE
Fix tests by adding missing `operatingsystem` fact

### DIFF
--- a/spec/defines/startup_spec.rb
+++ b/spec/defines/startup_spec.rb
@@ -53,6 +53,7 @@ describe 'zabbix::startup', type: :define do # rubocop:disable RSpec/MultipleDes
           {
             path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/sbin',
             osfamily: osfamily,
+            operatingsystem: osfamily,
             systemd: systemd_fact_state,
             os: { family: osfamily }
           }


### PR DESCRIPTION
Fixes
```
Could not autoload puppet/provider/service/init: undefined method `downcase' for nil:NilClass
```

camptocamp::systemd recently got journald support.  Since it now manages
the service, not having an `operatingsystem` fact was causing
https://github.com/puppetlabs/puppet/blob/55d2f844203b391bc6d3bc07bd92ca9b7cdb9aa2/lib/puppet/provider/service/init.rb#L24
to explode.

