### PR TITLE
Add ability to stop the agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -237,7 +237,7 @@ class zabbix::agent (
   $listenip                               = $zabbix::params::agent_listenip,
   $startagents                            = $zabbix::params::agent_startagents,
   $serveractive                           = $zabbix::params::agent_serveractive,
-  Enum['running','stopped'] $service_state  = $zabbix::params::agent_service_state,
+  Stdlib::Ensure::Service $service_state  = $zabbix::params::agent_service_state,
   Boolean $service_enable                 = $zabbix::params::agent_service_enable,
   $hostname                               = $zabbix::params::agent_hostname,
   $hostnameitem                           = $zabbix::params::agent_hostnameitem,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -94,6 +94,15 @@
 # [*serveractive*]
 #   List of comma delimited ip:port (or hostname:port) pairs of zabbix servers for active checks.
 #
+# [*service_state*]
+#   Start / stop the agent service. E.g. to preconfigure a hosts agent and turn on the service
+#   at a later time (when the server reaches production SLA)
+#   Default: 'running'
+#
+# [*service_enable*]
+#   Automatically start the agent on system boot
+#   Default: true
+#
 # [*hostname*]
 #   Unique, case sensitive hostname.
 #
@@ -228,6 +237,8 @@ class zabbix::agent (
   $listenip                               = $zabbix::params::agent_listenip,
   $startagents                            = $zabbix::params::agent_startagents,
   $serveractive                           = $zabbix::params::agent_serveractive,
+  Enum['running','stopped'] $service_state  = $zabbix::params::agent_service_state,
+  Boolean $service_enable                 = $zabbix::params::agent_service_enable,
   $hostname                               = $zabbix::params::agent_hostname,
   $hostnameitem                           = $zabbix::params::agent_hostnameitem,
   $hostmetadata                           = $zabbix::params::agent_hostmetadata,
@@ -364,8 +375,8 @@ class zabbix::agent (
     $service_provider = undef
   }
   service { $servicename:
-    ensure     => running,
-    enable     => true,
+    ensure     => $service_state,
+    enable     => $service_enable,
     provider   => $service_provider,
     hasstatus  => true,
     hasrestart => true,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -94,7 +94,7 @@
 # [*serveractive*]
 #   List of comma delimited ip:port (or hostname:port) pairs of zabbix servers for active checks.
 #
-# [*service_state*]
+# [*service_ensure*]
 #   Start / stop the agent service. E.g. to preconfigure a hosts agent and turn on the service
 #   at a later time (when the server reaches production SLA)
 #   Default: 'running'
@@ -237,7 +237,7 @@ class zabbix::agent (
   $listenip                               = $zabbix::params::agent_listenip,
   $startagents                            = $zabbix::params::agent_startagents,
   $serveractive                           = $zabbix::params::agent_serveractive,
-  Stdlib::Ensure::Service $service_state  = $zabbix::params::agent_service_state,
+  Stdlib::Ensure::Service $service_ensure = $zabbix::params::agent_service_ensure,
   Boolean $service_enable                 = $zabbix::params::agent_service_enable,
   $hostname                               = $zabbix::params::agent_hostname,
   $hostnameitem                           = $zabbix::params::agent_hostnameitem,
@@ -375,7 +375,7 @@ class zabbix::agent (
     $service_provider = undef
   }
   service { $servicename:
-    ensure     => $service_state,
+    ensure     => $service_ensure,
     enable     => $service_enable,
     provider   => $service_provider,
     hasstatus  => true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -239,6 +239,8 @@ class zabbix::params {
   $agent_refreshactivechecks                = '120'
   $agent_server                             = '127.0.0.1'
   $agent_serveractive                       = undef
+  $agent_service_state                      = 'running'
+  $agent_service_enable                     = true
   $agent_sourceip                           = undef
   $agent_startagents                        = '3'
   $agent_timeout                            = '3'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -239,7 +239,7 @@ class zabbix::params {
   $agent_refreshactivechecks                = '120'
   $agent_server                             = '127.0.0.1'
   $agent_serveractive                       = undef
-  $agent_service_state                      = 'running'
+  $agent_service_ensure                     = 'running'
   $agent_service_enable                     = true
   $agent_sourceip                           = undef
   $agent_startagents                        = '3'

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -243,6 +243,25 @@ describe 'zabbix::agent' do
 
         it { is_expected.to contain_file(config_path).without_content %r{^ListenIP=} }
       end
+
+      context 'when declaring service_ensure is stopped and service_enable false' do
+        package = 'zabbix-agent'
+
+        let :params do
+          {
+            service_ensure: 'stopped',
+            service_enable: false
+          }
+        end
+
+        it do
+          is_expected.to contain_service('zabbix-agent').with(
+            ensure:     'stopped',
+            enable:     false,
+            require:    "Package[#{package}]"
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
For our "IoT use case" we want to completely configure a mini server during the staging process. When a technician installs the device to its final position (in a vehicle), we want to activate the monitoring agent.

This PR adds the ability to start/stop the agent and to enable/disable the agents automatic startup during boot.

--> Could someone help me writing my first rspec tests for this feature?