### PR TITLE
Make hostname withint exported resources configurable

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -315,9 +315,10 @@ class zabbix::agent (
     } else {
       $use_proxy = ''
     }
+    $_hostname = pick($hostname, $facts['fqdn'])
 
     class { 'zabbix::resources::agent':
-      hostname     => $facts['fqdn'],
+      hostname     => $_hostname,
       ipaddress    => $listen_ip,
       use_ip       => $agent_use_ip,
       port         => $listenport,


### PR DESCRIPTION
#### Pull Request (PR) description
If zabbix::agent::hostname is configured it should also be used for
exported resources.

#### This Pull Request (PR) fixes the following issues
Fixes #563.
