### PR TITLE
Add zabbix_package_state to the zabbix class to allow upgrade of se…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,7 @@
 class zabbix (
   $zabbix_url                               = '',
   $zabbix_version                           = $zabbix::params::zabbix_version,
+  $zabbix_package_state                     = $zabbix::params::zabbix_package_state,
   $zabbix_timezone                          = $zabbix::params::zabbix_timezone,
   $zabbix_web                               = $zabbix::params::zabbix_web,
   $zabbix_server                            = $zabbix::params::zabbix_server,
@@ -184,6 +185,7 @@ class zabbix (
     database_type                            => $database_type,
     manage_repo                              => $manage_repo,
     zabbix_version                           => $zabbix_version,
+    zabbix_package_state                     => $zabbix_package_state,
     zabbix_timezone                          => $zabbix_timezone,
     zabbix_template_dir                      => $zabbix_template_dir,
     manage_vhost                             => $manage_vhost,
@@ -222,6 +224,7 @@ class zabbix (
     database_type             => $database_type,
     database_path             => $database_path,
     zabbix_version            => $zabbix_version,
+    zabbix_package_state      => $zabbix_package_state,
     manage_firewall           => $manage_firewall,
     manage_repo               => $manage_repo,
     manage_database           => $manage_database,


### PR DESCRIPTION

#### Pull Request (PR) description

    Added zabbix_package_state to the zabbix class to allow server and zabbix web upgrades.


#### This Pull Request (PR) fixes the following issues

   The zabbix_package_state variable was missing from the zabbix class.  This impacted upgrades of the zabbix server. 

