### PR TITLE
Feature/acceptance test custom types

### DIFF
--- a/lib/puppet/provider/zabbix_hostgroup/ruby.rb
+++ b/lib/puppet/provider/zabbix_hostgroup/ruby.rb
@@ -1,5 +1,7 @@
 require_relative '../zabbix'
 Puppet::Type.type(:zabbix_hostgroup).provide(:ruby, parent: Puppet::Provider::Zabbix) do
+  confine feature: :zabbixapi
+
   def connect
     @zbx ||= self.class.create_connection(@resource[:zabbix_url], @resource[:zabbix_user], @resource[:zabbix_pass], @resource[:apache_use_ssl])
     @zbx

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -267,13 +267,19 @@ class zabbix::web (
   # "Warning: You cannot collect without storeconfigs being set"
   if $manage_resources {
     include ruby::dev
+    $compile_packages = $facts['os']['family'] ? {
+      'RedHat' => [ 'make', 'gcc-c++', ],
+      'Debian' => [ 'make', 'g++', ],
+      default  => [],
+    }
+    ensure_packages($compile_packages, { before => Package['zabbixapi'], })
 
     # Determine correct zabbixapi version.
     case $zabbix_version {
-      '2.2' : {
+      '2.2': {
         $zabbixapi_version = '2.2.2'
       }
-      '2.4' : {
+      '2.4': {
         $zabbixapi_version = '2.4.4'
       }
       '3.2' : {
@@ -307,12 +313,12 @@ class zabbix::web (
   }
 
   case $facts['os']['name'] {
-    'ubuntu', 'debian' : {
+    'ubuntu', 'debian': {
       $zabbix_web_package = 'zabbix-frontend-php'
 
       # Check OS release for proper prefix
       case $facts['os']['name'] {
-        'Ubuntu' : {
+        'Ubuntu': {
           if versioncmp($facts['os']['release']['major'], '16.04') >= 0 {
             $php_db_package = "php-${db}"
           }
@@ -320,7 +326,7 @@ class zabbix::web (
             $php_db_package = "php5-${db}"
           }
         }
-        'Debian' : {
+        'Debian': {
           if versioncmp($facts['os']['release']['major'], '9') >= 0 {
             $php_db_package = "php-${db}"
           }
@@ -328,7 +334,7 @@ class zabbix::web (
             $php_db_package = "php5-${db}"
           }
         }
-        default : {
+        default: {
           $php_db_package = "php5-${db}"
         }
       }
@@ -341,7 +347,7 @@ class zabbix::web (
         ],
       }
     }
-    default : {
+    default: {
       $zabbix_web_package = 'zabbix-web'
 
       package { "zabbix-web-${db}":

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper_acceptance'
+require 'serverspec_type_zabbixapi'
+
+describe 'zabbix_application type' do
+  context 'create zabbix_application resources' do
+    it 'runs successfully' do
+      # This will deploy a running Zabbix setup (server, web, db) which we can
+      # use for custom type tests
+      pp = <<-EOS
+        class { 'apache':
+            mpm_module => 'prefork',
+        }
+        include apache::mod::php
+        include postgresql::server
+
+        class { 'zabbix':
+          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_url       => 'localhost',
+          manage_resources => true,
+          require          => [ Class['postgresql::server'], Class['apache'], ],
+        }
+
+        Zabbix_application {
+          zabbix_user    => 'Admin',
+          zabbix_pass    => 'zabbix',
+          zabbix_url     => 'localhost',
+          apache_use_ssl => false,
+          require        => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+
+        zabbix_application { 'TestApplication1':
+          template       => 'Template OS Linux',
+        }
+      EOS
+
+      shell('yum clean metadata') if fact('os.family') == 'RedHat'
+
+      # Cleanup old database
+      shell('/opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped; /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged; rm -f /etc/zabbix/.*done; su - postgres -c "psql -c \'drop database if exists zabbix_server;\'"')
+
+      apply_manifest(pp, expect_failures: true) # Error: Could not find a suitable provider for zabbix_application
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    let(:result_templates) do
+      zabbixapi('localhost', 'Admin', 'zabbix', 'template.get', selectApplications: ['name'],
+                                                                output: ['host']).result
+    end
+
+    context 'TestApplication1' do
+      let(:template1) { result_templates.select { |t| t['host'] == 'Template OS Linux' }.first }
+
+      it 'is attached to Template OS Linux' do
+        expect(template1['applications'].map { |a| a['name'] }).to include('TestApplication1')
+      end
+    end
+  end
+end

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -1,0 +1,126 @@
+require 'spec_helper_acceptance'
+require 'serverspec_type_zabbixapi'
+
+describe 'zabbix_host type' do
+  context 'create zabbix_host resources' do
+    it 'runs successfully' do
+      # This will deploy a running Zabbix setup (server, web, db) which we can
+      # use for custom type tests
+      pp = <<-EOS
+        class { 'apache':
+            mpm_module => 'prefork',
+        }
+        include apache::mod::php
+        include postgresql::server
+
+        class { 'zabbix':
+          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_url       => 'localhost',
+          manage_resources => true,
+          require          => [ Class['postgresql::server'], Class['apache'], ],
+        }
+
+        Zabbix_host {
+          zabbix_user    => 'Admin',
+          zabbix_pass    => 'zabbix',
+          zabbix_url     => 'localhost',
+          apache_use_ssl => false,
+          require        => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+
+        zabbix_host { 'test1.example.com':
+          ipaddress    => '127.0.0.1',
+          use_ip       => true,
+          port         => 10050,
+          group        => 'TestgroupOne',
+          group_create => true,
+          templates    => [ 'Template OS Linux', ],
+        }
+        zabbix_host { 'test2.example.com':
+          ipaddress    => '127.0.0.2',
+          use_ip       => false,
+          port         => 1050,
+          group        => 'Virtual machines',
+          templates    => [ 'Template OS Linux', 'Template ICMP Ping', ],
+        }
+      EOS
+
+      shell('yum clean metadata') if fact('os.family') == 'RedHat'
+
+      # Cleanup old database
+      shell('/opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped; /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged; rm -f /etc/zabbix/.*done; su - postgres -c "psql -c \'drop database if exists zabbix_server;\'"')
+
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    let(:result_hosts) do
+      zabbixapi('localhost', 'Admin', 'zabbix', 'host.get', selectParentTemplates: ['host'],
+                                                            selectInterfaces: %w[dns ip main port type useip],
+                                                            selectGroups: ['name'], output: ['host', '']).result
+    end
+
+    context 'test1.example.com' do
+      let(:test1) { result_hosts.select { |h| h['host'] == 'test1.example.com' }.first }
+
+      it 'is created' do
+        expect(test1['host']).to eq('test1.example.com')
+      end
+      it 'is in group TestgroupOne' do
+        expect(test1['groups'].map { |g| g['name'] }).to eq(['TestgroupOne'])
+      end
+      it 'has a correct interface dns configured' do
+        expect(test1['interfaces'][0]['dns']).to eq('test1.example.com')
+      end
+      it 'has a correct interface ip configured' do
+        expect(test1['interfaces'][0]['ip']).to eq('127.0.0.1')
+      end
+      it 'has a correct interface main configured' do
+        expect(test1['interfaces'][0]['main']).to eq('1')
+      end
+      it 'has a correct interface port configured' do
+        expect(test1['interfaces'][0]['port']).to eq('10050')
+      end
+      it 'has a correct interface type configured' do
+        expect(test1['interfaces'][0]['type']).to eq('1')
+      end
+      it 'has a correct interface useip configured' do
+        expect(test1['interfaces'][0]['useip']).to eq('1')
+      end
+      it 'has templates attached' do
+        expect(test1['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template OS Linux'])
+      end
+    end
+
+    context 'test2.example.com' do
+      let(:test2) { result_hosts.select { |h| h['host'] == 'test2.example.com' }.first }
+
+      it 'is created' do
+        expect(test2['host']).to eq('test2.example.com')
+      end
+      it 'is in group Virtual machines' do
+        expect(test2['groups'].map { |g| g['name'] }).to eq(['Virtual machines'])
+      end
+      it 'has a correct interface dns configured' do
+        expect(test2['interfaces'][0]['dns']).to eq('test2.example.com')
+      end
+      it 'has a correct interface ip configured' do
+        expect(test2['interfaces'][0]['ip']).to eq('127.0.0.2')
+      end
+      it 'has a correct interface main configured' do
+        expect(test2['interfaces'][0]['main']).to eq('1')
+      end
+      it 'has a correct interface port configured' do
+        expect(test2['interfaces'][0]['port']).to eq('1050')
+      end
+      it 'has a correct interface type configured' do
+        expect(test2['interfaces'][0]['type']).to eq('1')
+      end
+      it 'has a correct interface useip configured' do
+        expect(test2['interfaces'][0]['useip']).to eq('0')
+      end
+      it 'has templates attached' do
+        expect(test2['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template ICMP Ping', 'Template OS Linux'])
+      end
+    end
+  end
+end

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper_acceptance'
+require 'serverspec_type_zabbixapi'
+
+describe 'zabbix_hostgroup type' do
+  context 'create zabbix_hostgroup resources' do
+    it 'runs successfully' do
+      # This will deploy a running Zabbix setup (server, web, db) which we can
+      # use for custom type tests
+      pp = <<-EOS
+        class { 'apache':
+            mpm_module => 'prefork',
+        }
+        include apache::mod::php
+        include postgresql::server
+
+        class { 'zabbix':
+          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_url       => 'localhost',
+          manage_resources => true,
+          require          => [ Class['postgresql::server'], Class['apache'], ],
+        }
+
+        Zabbix_hostgroup {
+          zabbix_user    => 'Admin',
+          zabbix_pass    => 'zabbix',
+          zabbix_url     => 'localhost',
+          apache_use_ssl => false,
+          require        => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+
+        zabbix_hostgroup { 'Testgroup2': }
+        zabbix_hostgroup { 'Linux servers':
+          ensure => absent,
+        }
+      EOS
+
+      shell('yum clean metadata') if fact('os.family') == 'RedHat'
+
+      # Cleanup old database
+      shell('/opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped; /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged; rm -f /etc/zabbix/.*done; su - postgres -c "psql -c \'drop database if exists zabbix_server;\'"')
+
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    let(:result_hostgroups) do
+      zabbixapi('localhost', 'Admin', 'zabbix', 'hostgroup.get', output: 'extend').result
+    end
+
+    context 'Testgroup2' do
+      it 'is created' do
+        expect(result_hostgroups.map { |t| t['name'] }).to include('Testgroup2')
+      end
+    end
+
+    context 'Linux servers' do
+      it 'is absent' do
+        expect(result_hostgroups.map { |t| t['name'] }).not_to include('Linux servers')
+      end
+    end
+  end
+end

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper_acceptance'
+require 'serverspec_type_zabbixapi'
+
+describe 'zabbix_proxy type' do
+  context 'create zabbix_proxy resources' do
+    it 'runs successfully' do
+      # This will deploy a running Zabbix setup (server, web, db) which we can
+      # use for custom type tests
+      pp = <<-EOS
+        class { 'apache':
+            mpm_module => 'prefork',
+        }
+        include apache::mod::php
+        include postgresql::server
+
+        class { 'zabbix':
+          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_url       => 'localhost',
+          manage_resources => true,
+          require          => [ Class['postgresql::server'], Class['apache'], ],
+        }
+
+        Zabbix_proxy {
+          zabbix_user    => 'Admin',
+          zabbix_pass    => 'zabbix',
+          zabbix_url     => 'localhost',
+          apache_use_ssl => false,
+          require        => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+
+        zabbix_proxy { 'ZabbixProxy1':
+          ipaddress => '127.0.0.1',
+          use_ip    => true,
+          mode      => 0,
+          port      => 10051,
+        }
+        zabbix_proxy { 'ZabbixProxy2':
+          ipaddress => '127.0.0.3',
+          use_ip    => false,
+          mode      => 1,
+          port      => 10055,
+        }
+      EOS
+
+      shell('yum clean metadata') if fact('os.family') == 'RedHat'
+
+      # Cleanup old database
+      shell('/opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped; /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged; rm -f /etc/zabbix/.*done; su - postgres -c "psql -c \'drop database if exists zabbix_server;\'"')
+
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    let(:result_proxies) do
+      zabbixapi('localhost', 'Admin', 'zabbix', 'proxy.get', selectInterface: %w[dns ip port useip],
+                                                             output: ['host']).result
+    end
+
+    context 'ZabbixProxy1' do
+      let(:proxy1) { result_proxies.select { |h| h['host'] == 'ZabbixProxy1' }.first }
+
+      it 'is created' do
+        expect(proxy1['host']).to eq('ZabbixProxy1')
+      end
+
+      it 'has no interfaces configured' do
+        # Active proxies do not have interface
+        expect(proxy1['interface']).to eq([])
+      end
+    end
+
+    context 'ZabbixProxy2' do
+      let(:proxy2) { result_proxies.select { |h| h['host'] == 'ZabbixProxy2' }.first }
+
+      it 'is created' do
+        expect(proxy2['host']).to eq('ZabbixProxy2')
+      end
+
+      it 'has a interfaces dns configured' do
+        expect(proxy2['interface']['dns']).to eq('ZabbixProxy2')
+      end
+      it 'has a interfaces ip configured' do
+        expect(proxy2['interface']['ip']).to eq('127.0.0.3')
+      end
+      it 'has a interfaces port configured' do
+        expect(proxy2['interface']['port']).to eq('10055')
+      end
+      it 'has a interfaces useip configured' do
+        expect(proxy2['interface']['useip']).to eq('0')
+      end
+    end
+  end
+end

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper_acceptance'
+require 'serverspec_type_zabbixapi'
+
+describe 'zabbix_template_host type' do
+  context 'create zabbix_template_host resources' do
+    it 'runs successfully' do
+      # This will deploy a running Zabbix setup (server, web, db) which we can
+      # use for custom type tests
+      pp = <<-EOS
+        class { 'apache':
+            mpm_module => 'prefork',
+        }
+        include apache::mod::php
+        include postgresql::server
+
+        class { 'zabbix':
+          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_url       => 'localhost',
+          manage_resources => true,
+          require          => [ Class['postgresql::server'], Class['apache'], ],
+        }
+
+        $zabbix_user    = 'Admin'
+        $zabbix_pass    = 'zabbix'
+        $zabbix_url     = 'localhost'
+        $apache_use_ssl = false
+
+        zabbix_host { 'test1.example.com':
+          ipaddress      => '127.0.0.1',
+          use_ip         => true,
+          port           => 10050,
+          group          => 'TestgroupOne',
+          group_create   => true,
+          zabbix_user    => $zabbix_user,
+          zabbix_pass    => $zabbix_pass,
+          zabbix_url     => $zabbix_url,
+          apache_use_ssl => $apache_use_ssl,
+          templates      => [ 'Template OS Linux', ],
+          require        => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+
+        zabbix_template { 'TestTemplate1':
+          template_source => '/root/TestTemplate1.xml',
+          zabbix_user     => $zabbix_user,
+          zabbix_pass     => $zabbix_pass,
+          zabbix_url      => $zabbix_url,
+          apache_use_ssl  => $apache_use_ssl,
+          require         => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+
+        zabbix_template_host{"TestTemplate1@test1.example.com":
+          zabbix_user    => $zabbix_user,
+          zabbix_pass    => $zabbix_pass,
+          zabbix_url     => $zabbix_url,
+          apache_use_ssl => $apache_use_ssl,
+          require        => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+      EOS
+
+      shell('yum clean metadata') if fact('os.family') == 'RedHat'
+      shell("echo '<?xml version=\"1.0\" encoding=\"UTF-8\"?><zabbix_export><version>3.0</version><date>2018-12-13T15:00:46Z</date><groups><group><name>Templates/Applications</name></group></groups><templates><template><template>TestTemplate1</template><name>TestTemplate1</name><description/><groups><group><name>Templates/Applications</name></group></groups><applications/><items/><discovery_rules/><macros/><templates/><screens/></template></templates></zabbix_export>' > /root/TestTemplate1.xml")
+
+      # Cleanup old database
+      shell('/opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped; /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged; rm -f /etc/zabbix/.*done; su - postgres -c "psql -c \'drop database if exists zabbix_server;\'"')
+
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    let(:result_hosts) do
+      zabbixapi('localhost', 'Admin', 'zabbix', 'host.get', selectParentTemplates: ['host'],
+                                                            selectInterfaces: %w[dns ip main port type useip],
+                                                            selectGroups: ['name'], output: ['host', '']).result
+    end
+
+    context 'test1.example.com' do
+      let(:test1) { result_hosts.select { |h| h['host'] == 'test1.example.com' }.first }
+
+      it 'has template TestTemplate1 attached' do
+        expect(test1['parentTemplates'].map { |t| t['host'] }.sort).to include('TestTemplate1')
+      end
+    end
+  end
+end

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper_acceptance'
+require 'serverspec_type_zabbixapi'
+
+describe 'zabbix_template type' do
+  context 'create zabbix_template resources' do
+    it 'runs successfully' do
+      # This will deploy a running Zabbix setup (server, web, db) which we can
+      # use for custom type tests
+      pp = <<-EOS
+        class { 'apache':
+            mpm_module => 'prefork',
+        }
+        include apache::mod::php
+        include postgresql::server
+
+        class { 'zabbix':
+          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_url       => 'localhost',
+          manage_resources => true,
+          require          => [ Class['postgresql::server'], Class['apache'], ],
+        }
+
+        Zabbix_template {
+          zabbix_user    => 'Admin',
+          zabbix_pass    => 'zabbix',
+          zabbix_url     => 'localhost',
+          apache_use_ssl => false,
+          require        => [ Service['zabbix-server'], Package['zabbixapi'], ],
+        }
+
+        zabbix_template { 'TestTemplate1':
+          template_source => '/root/TestTemplate1.xml',
+        }
+      EOS
+
+      shell('yum clean metadata') if fact('os.family') == 'RedHat'
+      shell("echo '<?xml version=\"1.0\" encoding=\"UTF-8\"?><zabbix_export><version>3.0</version><date>2018-12-13T15:00:46Z</date><groups><group><name>Templates/Applications</name></group></groups><templates><template><template>TestTemplate1</template><name>TestTemplate1</name><description/><groups><group><name>Templates/Applications</name></group></groups><applications/><items/><discovery_rules/><macros/><templates/><screens/></template></templates></zabbix_export>' > /root/TestTemplate1.xml")
+
+      # Cleanup old database
+      shell('/opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped; /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged; rm -f /etc/zabbix/.*done; su - postgres -c "psql -c \'drop database if exists zabbix_server;\'"')
+
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    let(:result_templates) do
+      zabbixapi('localhost', 'Admin', 'zabbix', 'template.get', selectApplications: ['name'],
+                                                                output: ['host']).result
+    end
+
+    context 'TestTemplate1' do
+      let(:template1) { result_templates.select { |t| t['host'] == 'TestTemplate1' }.first }
+
+      it 'is created' do
+        expect(template1['host']).to eq('TestTemplate1')
+      end
+    end
+  end
+end

--- a/spec/serverspec_type_zabbixapi.rb
+++ b/spec/serverspec_type_zabbixapi.rb
@@ -1,0 +1,63 @@
+require 'json'
+
+module Serverspec::Type
+  class Zabbixapi < Base
+    def initialize(host, user, pass, method, params)
+      @name   = 'zabbixapi'
+      @host   = host
+      @user   = user
+      @pass   = pass
+      @method = method
+      @params = params
+      @runner = Specinfra::Runner
+      @curl_base = "curl -s http://#{host}/api_jsonrpc.php -H \"Content-Type: application/json-rpc\" -d"
+
+      @response = query(@method, @params)
+    end
+
+    def result
+      @response['result']
+    end
+
+    private
+
+    def token
+      @token ||= retrieve_token
+    end
+
+    def retrieve_token
+      data = {
+        jsonrpc: '2.0',
+        method: 'user.login',
+        params: {
+          user: @user,
+          password: @pass
+        },
+        auth: nil,
+        id: 0
+      }.to_json
+      do_request(data)['result']
+    end
+
+    def query(method, params)
+      data = {
+        jsonrpc: '2.0',
+        method: method,
+        params: params,
+        auth: token,
+        id: 0
+      }.to_json
+      do_request(data)
+    end
+
+    def do_request(data)
+      command = "#{@curl_base} '#{data}'"
+      result = @runner.run_command(command)
+      JSON.parse(result.stdout.chomp)
+    end
+  end
+  def zabbixapi(host, user, pass, method, params)
+    Zabbixapi.new(host, user, pass, method, params)
+  end
+end
+include Serverspec::Type


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds acceptance tests for the zabbix_ custom types.

Beaker is setting up a server with Zabbix database, server and webfrontend and creates the zabbix_* resources. I had to created a custom ServerSpec::Types to interact with the Zabbix API because we can't access it within Beaker by e.g. zabbixapi gem.

This was done to ensure the changes in #570 don't break the custom types.

#### This Pull Request (PR) fixes the following issues
