### PR TITLE
Fix rspec tests for Gentoo

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -234,8 +234,8 @@ class zabbix::web (
 ) inherits zabbix::params {
 
   # check osfamily, Arch is currently not supported for web
-  if $facts['os']['family'] == 'Archlinux' {
-    fail('Archlinux is currently not supported for zabbix::web ')
+  if $facts['os']['family'] in [ 'Archlinux', 'Gentoo', ] {
+    fail("${facts['os']['family']} is currently not supported for zabbix::web")
   }
 
   # Only include the repo class if it has not yet been included

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -5,15 +5,23 @@ describe 'zabbix::database' do
     'rspec.puppet.com'
   end
 
-  let :pre_condition do
-    "include 'postgresql::server'
-    include 'mysql::server'"
-  end
-
   on_supported_os.each do |os, facts|
     context "on #{os} " do
       let :facts do
         facts
+      end
+
+      let :pre_condition do
+        <<-EOS
+          include 'postgresql::server'
+          if $::osfamily == 'Gentoo' {
+            # We don't need the package to be installed as its the same for the server.
+            class { 'mysql::client':
+              package_manage => false,
+            }
+          }
+          include 'mysql::server'
+        EOS
       end
 
       describe 'database_type is postgresql, zabbix_type is server and is multiple host setup' do

--- a/spec/classes/sender_spec.rb
+++ b/spec/classes/sender_spec.rb
@@ -25,9 +25,9 @@ describe 'zabbix::sender' do
           }
         end
 
-        if facts[:osfamily] == 'Archlinux'
+        if %w[Archlinux Gentoo].include?(facts[:osfamily])
           it 'fails' do
-            is_expected.to raise_error(Puppet::Error, %r{Managing a repo on Archlinux is currently not implemented})
+            is_expected.to raise_error(Puppet::Error, %r{Managing a repo on #{facts[:osfamily]} is currently not implemented})
           end
         else
           it { is_expected.to contain_class('zabbix::repo').with_zabbix_version('3.4') }

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -8,8 +8,14 @@ describe 'zabbix::server' do
   on_supported_os.each do |os, facts|
     next if facts[:osfamily] == 'Archlinux' # zabbix server is currently not supported on archlinux
     context "on #{os} " do
+      systemd_fact = case facts[:osfamily]
+                     when 'Archlinux', 'Fedora', 'Gentoo'
+                       { systemd: true }
+                     else
+                       { systemd: false }
+                     end
       let :facts do
-        facts
+        facts.merge(systemd_fact)
       end
 
       describe 'with default settings' do
@@ -128,7 +134,7 @@ describe 'zabbix::server' do
 
       context 'it creates a startup script' do
         case facts[:osfamily]
-        when 'Archlinux', 'Fedora'
+        when 'Archlinux', 'Fedora', 'Gentoo'
           it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/systemd/system/zabbix-server.service').with_ensure('file') }
         else

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -17,7 +17,7 @@ describe 'zabbix::web' do
         facts
       end
 
-      if facts[:osfamily] == 'Archlinux'
+      if facts[:osfamily] == 'Archlinux' || facts[:osfamily] == 'Gentoo'
         context 'with all defaults' do
           it { is_expected.not_to compile }
         end

--- a/spec/defines/userparameters_spec.rb
+++ b/spec/defines/userparameters_spec.rb
@@ -5,7 +5,7 @@ describe 'zabbix::userparameters', type: :define do
     context "on #{os} " do
       let :facts do
         systemd_fact = case facts[:os]['family']
-                       when 'Archlinux', 'Fedora'
+                       when 'Archlinux', 'Fedora', 'Gentoo'
                          { systemd: true }
                        else
                          { systemd: false }
@@ -15,6 +15,9 @@ describe 'zabbix::userparameters', type: :define do
       let(:title) { 'mysqld' }
       let(:pre_condition) { 'class { "zabbix::agent": include_dir => "/etc/zabbix/zabbix_agentd.d" }' }
 
+      package = facts[:osfamily] == 'Gentoo' ? 'zabbix' : 'zabbix-agent'
+      service = facts[:osfamily] == 'Gentoo' ? 'zabbix-agentd' : 'zabbix-agent'
+
       context 'with an content' do
         let(:params) { { content: 'UserParameter=mysql.ping,mysqladmin -uroot ping | grep -c alive' } }
 
@@ -23,12 +26,12 @@ describe 'zabbix::userparameters', type: :define do
         it { is_expected.to contain_class('zabbix::params') }
         it { is_expected.to contain_class('zabbix::repo') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file('/etc/init.d/zabbix-agent') }
+        it { is_expected.to contain_file("/etc/init.d/#{service}") }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf') }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.d') }
-        it { is_expected.to contain_package('zabbix-agent') }
-        it { is_expected.to contain_service('zabbix-agent') }
-        it { is_expected.to contain_zabbix__startup('zabbix-agent') }
+        it { is_expected.to contain_package(package) }
+        it { is_expected.to contain_service(service) }
+        it { is_expected.to contain_zabbix__startup(service) }
       end
     end
   end


### PR DESCRIPTION
Due to the release of facterdb 0.6.0 we're now testing against Gentoo as
well. This leads to a couple of errors which this commit fixes.

~Strict variable checking was disabled until
https://github.com/puppetlabs/puppetlabs-mysql/pull/1147 got merged.~ --> Merged.
