### PR TITLE
Add Zabbix 3.4 and 4.0 support

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -276,8 +276,11 @@ class zabbix::web (
       '2.4' : {
         $zabbixapi_version = '2.4.4'
       }
-      default : {
+      '3.2' : {
         $zabbixapi_version = '3.2.1'
+      }
+      default : {
+        $zabbixapi_version = '4.0.0'
       }
     }
 


### PR DESCRIPTION
by pinning them to zabbixapi gem version
with support for those versions

Fixes #556