### PR TITLE
update travis distro from trusty to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 sudo: false
-dist: trusty
+dist: xenial
 language: ruby
 cache: bundler
 before_install:


### PR DESCRIPTION
This is a preparation for an upcoming modulesync.