### PR TITLE
Implement self.prefetch for zabbix_host

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -2,97 +2,182 @@ require_relative '../zabbix'
 Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix) do
   confine feature: :zabbixapi
 
-  def create
-    # Set some vars
-    host = @resource[:hostname]
-    ipaddress = @resource[:ipaddress]
-    use_ip = @resource[:use_ip]
-    port = @resource[:port]
-    hostgroup = @resource[:group]
-    hostgroup_create = @resource[:group_create]
-    templates = @resource[:templates]
-    proxy = @resource[:proxy]
+  def self.instances
+    proxies = zbx.proxies.all
+    api_hosts = zbx.query(
+      method: 'host.get',
+      params: {
+        selectParentTemplates: ['host'],
+        selectInterfaces: %w[interfaceid type main ip port useip],
+        selectGroups: ['name'],
+        output: %w[host proxy_hostid]
+      }
+    )
 
-    # Get the template ids.
-    template_array = []
-    if templates.is_a?(Array)
-      templates.each do |template|
-        template_id = get_template_id(zbx, template)
-        template_array.push template_id
+    api_hosts.map do |h|
+      interface = h['interfaces'].select { |i| i['type'].to_i == 1 && i['main'].to_i == 1 }.first
+      use_ip = !interface['useip'].to_i.zero?
+      new(
+        ensure: :present,
+        id: h['hostid'].to_i,
+        name: h['host'],
+        interfaceid: interface['interfaceid'].to_i,
+        ipaddress: interface['ip'],
+        use_ip: use_ip,
+        port: interface['port'].to_i,
+        groups: h['groups'].map { |g| g['name'] },
+        group_create: nil,
+        templates: h['parentTemplates'].map { |x| x['host'] },
+        proxy: proxies.select { |_name, id| id == h['proxy_hostid'] }.keys.first
+      )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
       end
-    else
-      template_array.push get_template_id(zbx, templates)
     end
+  end
 
-    # Check if we need to connect via ip or fqdn
-    use_ip = use_ip ? 1 : 0
+  def create
+    template_ids = get_templateids(@resource[:templates])
+    templates = transform_to_array_hash('templateid', template_ids)
 
-    # When using DNS you still have to send a value for ip
-    ipaddress = '' if ipaddress.nil? && use_ip.zero?
+    gids = get_groupids(@resource[:groups], @resource[:group_create])
+    groups = transform_to_array_hash('groupid', gids)
 
-    hostgroup_create = hostgroup_create ? 1 : 0
-
-    # First check if we have an correct hostgroup and if not, we raise an error.
-    search_hostgroup = zbx.hostgroups.get_id(name: hostgroup)
-    if search_hostgroup.nil? && hostgroup_create == 1
-      zbx.hostgroups.create(name: hostgroup)
-      search_hostgroup = zbx.hostgroups.get_id(name: hostgroup)
-    elsif search_hostgroup.nil? && hostgroup_create.zero?
-      raise Puppet::Error, 'The hostgroup (' + hostgroup + ') does not exist in zabbix. Please use the correct one.'
-    end
+    proxy_hostid = @resource[:proxy].nil? || @resource[:proxy].empty? ? nil : zbx.proxies.get_id(host: @resource[:proxy])
 
     # Now we create the host
-    hostid = zbx.hosts.create_or_update(
-      host: host,
+    zbx.hosts.create(
+      host: @resource[:hostname],
+      proxy_hostid: proxy_hostid,
       interfaces: [
         {
           type: 1,
           main: 1,
-          ip: ipaddress,
-          dns: host,
-          port: port,
-          useip: use_ip
+          ip: @resource[:ipaddress],
+          dns: @resource[:hostname],
+          port: @resource[:port],
+          useip: @resource[:use_ip] ? 1 : 0
         }
       ],
-      templates: template_array,
-      groups: [groupid: search_hostgroup]
-    )
-
-    zbx.templates.mass_add(hosts_id: [hostid], templates_id: template_array)
-
-    return if proxy.nil? || proxy.empty?
-    zbx.hosts.update(
-      hostid: zbx.hosts.get_id(host: host),
-      proxy_hostid: zbx.proxies.get_id(host: proxy)
+      templates: templates,
+      groups: groups
     )
   end
 
   def exists?
-    host = @resource[:hostname]
-    templates = @resource[:templates]
-
-    templates = [templates] unless templates.is_a?(Array)
-
-    host = check_host(host)
-    if host.any?
-      template_ids   = host[0]['parentTemplates'].map { |x| x['templateid'] }
-      template_names = host[0]['parentTemplates'].map { |x| x['host'] }
-      res = []
-      templates.each do |template|
-        if a_number?(template)
-          res.push(template_ids.include?(template))
-        else
-          res.push(template_names.include?(template))
-        end
-      end
-      res.all?
-    else
-      false
-    end
+    @property_hash[:ensure] == :present
   end
 
   def destroy
-    host = @resource[:hostname]
-    zbx.hosts.delete(zbx.hosts.get_id(host: host))
+    zbx.hosts.delete(zbx.hosts.get_id(host: @resource[:hostname]))
+  end
+
+  #
+  # Helper methods
+  #
+  def get_groupids(group_array, create)
+    groupids = []
+    group_array.each do |g|
+      id = zbx.hostgroups.get_id(name: g)
+      if id.nil?
+        raise Puppet::Error, 'The hostgroup (' + g + ') does not exist in zabbix. Please use the correct one or set group_create => true.' unless create
+        groupids << zbx.hostgroups.create(name: g)
+      else
+        groupids << id
+      end
+    end
+    groupids
+  end
+
+  def get_templateids(template_array)
+    templateids = []
+    template_array.each do |t|
+      template_id = zbx.templates.get_id(host: t)
+      raise Puppet::Error, "The template #{t} does not exist in Zabbix. Please use a correct one." if template_id.nil?
+      templateids << template_id
+    end
+    templateids
+  end
+
+  #
+  # zabbix_host properties
+  #
+  mk_resource_methods
+
+  def ipaddress=(string)
+    zbx.query(
+      method: 'hostinterface.update',
+      params: {
+        interfaceid: @property_hash[:interfaceid],
+        ip: string
+      }
+    )
+  end
+
+  def use_ip=(boolean)
+    zbx.query(
+      method: 'hostinterface.update',
+      params: {
+        interfaceid: @property_hash[:interfaceid],
+        useip: boolean ? 1 : 0,
+        dns: @resource[:hostname]
+      }
+    )
+  end
+
+  def port=(int)
+    zbx.query(
+      method: 'hostinterface.update',
+      params: {
+        interfaceid: @property_hash[:interfaceid],
+        port: int
+      }
+    )
+  end
+
+  def groups=(hostgroups)
+    gids = get_groupids(hostgroups, @resource[:group_create])
+    groups = transform_to_array_hash('groupid', gids)
+
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      groups: groups
+    )
+  end
+
+  def templates=(array)
+    should_template_ids = get_templateids(array)
+
+    # Get templates we have to clear. Unlinking only isn't really helpful.
+    is_template_ids = zbx.query(
+      method: 'host.get',
+      params: {
+        hostids: @property_hash[:id],
+        selectParentTemplates: ['templateid'],
+        output: ['host']
+      }
+    ).first['parentTemplates'].map { |t| t['templateid'].to_i }
+    templates_clear = is_template_ids - should_template_ids
+
+    zbx.query(
+      method: 'host.update',
+      params: {
+        hostid: @property_hash[:id],
+        templates: transform_to_array_hash('templateid', should_template_ids),
+        templates_clear: transform_to_array_hash('templateid', templates_clear)
+      }
+    )
+  end
+
+  def proxy=(string)
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      proxy_hostid: zbx.proxies.get_id(host: string)
+    )
   end
 end

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -4,37 +4,106 @@ Puppet::Type.newtype(:zabbix_host) do
     defaultto :present
   end
 
+  def initialize(*args)
+    super
+
+    # Migrate group to groups
+    return if self[:group].nil?
+    self[:groups] = self[:group]
+    delete(:group)
+  end
+
+  def munge_boolean(value)
+    case value
+    when true, 'true', :true
+      true
+    when false, 'false', :false
+      false
+    else
+      raise(Puppet::Error, 'munge_boolean only takes booleans')
+    end
+  end
+
   newparam(:hostname, namevar: true) do
     desc 'FQDN of the machine.'
   end
 
-  newparam(:ipaddress) do
+  newproperty(:id) do
+    desc 'Internally used hostid'
+
+    validate do |_value|
+      raise(Puppet::Error, 'id is read-only and is only available via puppet resource.')
+    end
+  end
+
+  newproperty(:interfaceid) do
+    desc 'Internally used identifier for the host interface'
+
+    validate do |_value|
+      raise(Puppet::Error, 'interfaceid is read-only and is only available via puppet resource.')
+    end
+  end
+
+  newproperty(:ipaddress) do
     desc 'The IP address of the machine running zabbix agent.'
   end
 
-  newparam(:use_ip) do
-    desc 'Using ipadress instead of dns to connect. Is used by the zabbix-api command.'
+  newproperty(:use_ip, boolean: true) do
+    desc 'Using ipadress instead of dns to connect.'
+
+    newvalues(true, false)
+
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
   end
 
-  newparam(:port) do
+  newproperty(:port) do
     desc 'The port that the zabbix agent is listening on.'
+    def insync?(is)
+      is.to_i == should.to_i
+    end
   end
 
-  newparam(:group) do
-    desc 'Name of the hostgroup.'
+  newproperty(:group) do
+    desc 'Deprecated! Name of the hostgroup.'
+
+    validate do |_value|
+      Puppet.warning('Passing group to zabbix_host is deprecated and will be removed. Use groups instead.')
+    end
   end
 
-  newparam(:group_create) do
+  newproperty(:groups, array_matching: :all) do
+    desc 'An array of groups the host belongs to.'
+    def insync?(is)
+      is.sort == should.sort
+    end
+  end
+
+  newparam(:group_create, boolean: true) do
     desc 'Create hostgroup if missing.'
+
+    newvalues(true, false)
+
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
   end
 
-  newparam(:templates) do
+  newproperty(:templates, array_matching: :all) do
     desc 'List of templates which should be loaded for this host.'
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
-  newparam(:proxy) do
+  newproperty(:proxy) do
     desc 'Whether it is monitored by an proxy or not.'
   end
 
   autorequire(:file) { '/etc/zabbix/api.conf' }
+
+  validate do
+    raise(_('The properties group and groups are mutually exclusive.')) if self[:group] && self[:groups]
+  end
 end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -42,7 +42,10 @@
 #   connection should me made via ip, not fqdn.
 #
 # [*zbx_group*]
-#   Name of thehostgroup where this host needs to be added.
+#   Deprecated! Name of the hostgroup where this host needs to be added.
+#
+# [*zbx_groups*]
+#   An array of hostgroups where this host needs to be added.
 #
 # [*zbx_templates*]
 #   List of templates which will be added when host is configured.
@@ -214,70 +217,71 @@
 #
 
 class zabbix::agent (
-  $zabbix_version                         = $zabbix::params::zabbix_version,
-  $zabbix_package_state                   = $zabbix::params::zabbix_package_state,
-  $zabbix_package_agent                   = $zabbix::params::zabbix_package_agent,
-  Boolean $manage_firewall                = $zabbix::params::manage_firewall,
-  Boolean $manage_repo                    = $zabbix::params::manage_repo,
-  Boolean $manage_resources               = $zabbix::params::manage_resources,
-  $monitored_by_proxy                     = $zabbix::params::monitored_by_proxy,
-  $agent_use_ip                           = $zabbix::params::agent_use_ip,
-  $zbx_group                              = $zabbix::params::agent_zbx_group,
-  $zbx_group_create                       = $zabbix::params::agent_zbx_group_create,
-  $zbx_templates                          = $zabbix::params::agent_zbx_templates,
-  $agent_configfile_path                  = $zabbix::params::agent_configfile_path,
-  $pidfile                                = $zabbix::params::agent_pidfile,
-  $servicename                            = $zabbix::params::agent_servicename,
-  String $logtype                         = $zabbix::params::agent_logtype,
-  Optional[Stdlib::Absolutepath] $logfile = $zabbix::params::agent_logfile,
-  $logfilesize                            = $zabbix::params::agent_logfilesize,
-  $debuglevel                             = $zabbix::params::agent_debuglevel,
-  $sourceip                               = $zabbix::params::agent_sourceip,
-  $enableremotecommands                   = $zabbix::params::agent_enableremotecommands,
-  $logremotecommands                      = $zabbix::params::agent_logremotecommands,
-  $server                                 = $zabbix::params::agent_server,
-  $listenport                             = $zabbix::params::agent_listenport,
-  $listenip                               = $zabbix::params::agent_listenip,
-  $startagents                            = $zabbix::params::agent_startagents,
-  $serveractive                           = $zabbix::params::agent_serveractive,
-  Stdlib::Ensure::Service $service_ensure = $zabbix::params::agent_service_ensure,
-  Boolean $service_enable                 = $zabbix::params::agent_service_enable,
-  $hostname                               = $zabbix::params::agent_hostname,
-  $hostnameitem                           = $zabbix::params::agent_hostnameitem,
-  $hostmetadata                           = $zabbix::params::agent_hostmetadata,
-  $hostmetadataitem                       = $zabbix::params::agent_hostmetadataitem,
-  $refreshactivechecks                    = $zabbix::params::agent_refreshactivechecks,
-  $buffersend                             = $zabbix::params::agent_buffersend,
-  $buffersize                             = $zabbix::params::agent_buffersize,
-  $maxlinespersecond                      = $zabbix::params::agent_maxlinespersecond,
-  Optional[Array] $zabbix_alias           = $zabbix::params::agent_zabbix_alias,
-  $timeout                                = $zabbix::params::agent_timeout,
-  $allowroot                              = $zabbix::params::agent_allowroot,
-  $zabbix_user                            = $zabbix::params::agent_zabbix_user,
-  $include_dir                            = $zabbix::params::agent_include,
-  $include_dir_purge                      = $zabbix::params::agent_include_purge,
-  $unsafeuserparameters                   = $zabbix::params::agent_unsafeuserparameters,
-  $userparameter                          = $zabbix::params::agent_userparameter,
-  $loadmodulepath                         = $zabbix::params::agent_loadmodulepath,
-  $loadmodule                             = $zabbix::params::agent_loadmodule,
-  $tlsaccept                              = $zabbix::params::agent_tlsaccept,
-  $tlscafile                              = $zabbix::params::agent_tlscafile,
-  $tlscertfile                            = $zabbix::params::agent_tlscertfile,
-  $tlsconnect                             = $zabbix::params::agent_tlsconnect,
-  $tlscrlfile                             = $zabbix::params::agent_tlscrlfile,
-  $tlskeyfile                             = $zabbix::params::agent_tlskeyfile,
-  $tlspskfile                             = $zabbix::params::agent_tlspskfile,
-  $tlspskidentity                         = $zabbix::params::agent_tlspskidentity,
-  $tlsservercertissuer                    = $zabbix::params::agent_tlsservercertissuer,
-  $tlsservercertsubject                   = $zabbix::params::agent_tlsservercertsubject,
-  String $agent_config_owner              = $zabbix::params::agent_config_owner,
-  String $agent_config_group              = $zabbix::params::agent_config_group,
-  Boolean $manage_selinux                 = $zabbix::params::manage_selinux,
-  Array[String] $selinux_require          = $zabbix::params::selinux_require,
-  Hash[String, Array] $selinux_rules      = $zabbix::params::selinux_rules,
-  String $additional_service_params       = $zabbix::params::additional_service_params,
-  String $service_type                    = $zabbix::params::service_type,
-  Boolean $manage_startup_script          = $zabbix::params::manage_startup_script,
+  $zabbix_version                                 = $zabbix::params::zabbix_version,
+  $zabbix_package_state                           = $zabbix::params::zabbix_package_state,
+  $zabbix_package_agent                           = $zabbix::params::zabbix_package_agent,
+  Boolean $manage_firewall                        = $zabbix::params::manage_firewall,
+  Boolean $manage_repo                            = $zabbix::params::manage_repo,
+  Boolean $manage_resources                       = $zabbix::params::manage_resources,
+  $monitored_by_proxy                             = $zabbix::params::monitored_by_proxy,
+  $agent_use_ip                                   = $zabbix::params::agent_use_ip,
+  $zbx_group                                      = $zabbix::params::agent_zbx_group,
+  Variant[String[1],Array[String[1]]] $zbx_groups = $zabbix::params::agent_zbx_groups,
+  $zbx_group_create                               = $zabbix::params::agent_zbx_group_create,
+  $zbx_templates                                  = $zabbix::params::agent_zbx_templates,
+  $agent_configfile_path                          = $zabbix::params::agent_configfile_path,
+  $pidfile                                        = $zabbix::params::agent_pidfile,
+  $servicename                                    = $zabbix::params::agent_servicename,
+  String $logtype                                 = $zabbix::params::agent_logtype,
+  Optional[Stdlib::Absolutepath] $logfile         = $zabbix::params::agent_logfile,
+  $logfilesize                                    = $zabbix::params::agent_logfilesize,
+  $debuglevel                                     = $zabbix::params::agent_debuglevel,
+  $sourceip                                       = $zabbix::params::agent_sourceip,
+  $enableremotecommands                           = $zabbix::params::agent_enableremotecommands,
+  $logremotecommands                              = $zabbix::params::agent_logremotecommands,
+  $server                                         = $zabbix::params::agent_server,
+  $listenport                                     = $zabbix::params::agent_listenport,
+  $listenip                                       = $zabbix::params::agent_listenip,
+  $startagents                                    = $zabbix::params::agent_startagents,
+  $serveractive                                   = $zabbix::params::agent_serveractive,
+  Stdlib::Ensure::Service $service_ensure         = $zabbix::params::agent_service_ensure,
+  Boolean $service_enable                         = $zabbix::params::agent_service_enable,
+  $hostname                                       = $zabbix::params::agent_hostname,
+  $hostnameitem                                   = $zabbix::params::agent_hostnameitem,
+  $hostmetadata                                   = $zabbix::params::agent_hostmetadata,
+  $hostmetadataitem                               = $zabbix::params::agent_hostmetadataitem,
+  $refreshactivechecks                            = $zabbix::params::agent_refreshactivechecks,
+  $buffersend                                     = $zabbix::params::agent_buffersend,
+  $buffersize                                     = $zabbix::params::agent_buffersize,
+  $maxlinespersecond                              = $zabbix::params::agent_maxlinespersecond,
+  Optional[Array] $zabbix_alias                   = $zabbix::params::agent_zabbix_alias,
+  $timeout                                        = $zabbix::params::agent_timeout,
+  $allowroot                                      = $zabbix::params::agent_allowroot,
+  $zabbix_user                                    = $zabbix::params::agent_zabbix_user,
+  $include_dir                                    = $zabbix::params::agent_include,
+  $include_dir_purge                              = $zabbix::params::agent_include_purge,
+  $unsafeuserparameters                           = $zabbix::params::agent_unsafeuserparameters,
+  $userparameter                                  = $zabbix::params::agent_userparameter,
+  $loadmodulepath                                 = $zabbix::params::agent_loadmodulepath,
+  $loadmodule                                     = $zabbix::params::agent_loadmodule,
+  $tlsaccept                                      = $zabbix::params::agent_tlsaccept,
+  $tlscafile                                      = $zabbix::params::agent_tlscafile,
+  $tlscertfile                                    = $zabbix::params::agent_tlscertfile,
+  $tlsconnect                                     = $zabbix::params::agent_tlsconnect,
+  $tlscrlfile                                     = $zabbix::params::agent_tlscrlfile,
+  $tlskeyfile                                     = $zabbix::params::agent_tlskeyfile,
+  $tlspskfile                                     = $zabbix::params::agent_tlspskfile,
+  $tlspskidentity                                 = $zabbix::params::agent_tlspskidentity,
+  $tlsservercertissuer                            = $zabbix::params::agent_tlsservercertissuer,
+  $tlsservercertsubject                           = $zabbix::params::agent_tlsservercertsubject,
+  String $agent_config_owner                      = $zabbix::params::agent_config_owner,
+  String $agent_config_group                      = $zabbix::params::agent_config_group,
+  Boolean $manage_selinux                         = $zabbix::params::manage_selinux,
+  Array[String] $selinux_require                  = $zabbix::params::selinux_require,
+  Hash[String, Array] $selinux_rules              = $zabbix::params::selinux_rules,
+  String $additional_service_params               = $zabbix::params::additional_service_params,
+  String $service_type                            = $zabbix::params::service_type,
+  Boolean $manage_startup_script                  = $zabbix::params::manage_startup_script,
 ) inherits zabbix::params {
 
   # the following two codeblocks are a bit blargh. The correct default value for
@@ -321,6 +325,22 @@ class zabbix::agent (
   # is set to false, you'll get warnings like this:
   # "Warning: You cannot collect without storeconfigs being set"
   if $manage_resources {
+    # Migrate deprecated zbx_group parameter
+    if $zbx_group == $zabbix::params::agent_zbx_group and $zbx_groups == $zabbix::params::agent_zbx_groups {
+      $groups = $zabbix::params::agent_zbx_groups
+    } else {
+      if $zbx_group != $zabbix::params::agent_zbx_group and $zbx_groups != $zabbix::params::agent_zbx_groups {
+        fail("Seems like you have filled zbx_group and zbx_groups with custom values. This isn't support! Please use zbx_groups only.")
+      }
+
+      if $zbx_group != $zabbix::params::agent_zbx_group {
+        warning('Passing zbx_group to zabbix::agent is deprecated and will be removed. Use zbx_groups instead.')
+        $groups = Array($zbx_group)
+      } else {
+        $groups = $zbx_groups
+      }
+    }
+
     if $monitored_by_proxy != '' {
       $use_proxy = $monitored_by_proxy
     } else {
@@ -333,7 +353,7 @@ class zabbix::agent (
       ipaddress    => $listen_ip,
       use_ip       => $agent_use_ip,
       port         => $listenport,
-      group        => $zbx_group,
+      groups       => [$groups].flatten(),
       group_create => $zbx_group_create,
       templates    => $zbx_templates,
       proxy        => $use_proxy,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -260,6 +260,7 @@ class zabbix::params {
   $agent_userparameter                      = undef
   $agent_zabbix_alias                       = undef
   $agent_zbx_group                          = 'Linux servers'
+  $agent_zbx_groups                         = [ 'Linux servers', ]
   $agent_zbx_group_create                   = true
   $agent_zbx_templates                      = [
     'Template OS Linux',

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -14,20 +14,32 @@
 #
 #
 class zabbix::resources::agent (
-  $hostname      = undef,
-  $ipaddress     = undef,
-  $use_ip        = undef,
-  $port          = undef,
-  $group         = undef,
-  $group_create  = undef,
-  $templates     = undef,
-  $proxy         = undef,
+  $hostname                = undef,
+  $ipaddress               = undef,
+  $use_ip                  = undef,
+  $port                    = undef,
+  $group                   = undef,
+  Array[String[1]] $groups = undef,
+  $group_create            = undef,
+  $templates               = undef,
+  $proxy                   = undef,
 ) {
+  if $group and $groups {
+    fail("Got group and groups. This isn't support! Please use groups only.")
+  } else {
+    if $group {
+      warning('Passing group to zabbix::resources::agent is deprecated and will be removed. Use groups instead.')
+      $_groups = Array($group)
+    } else {
+      $_groups = $groups
+    }
+  }
+
   @@zabbix_host { $hostname:
     ipaddress    => $ipaddress,
     use_ip       => $use_ip,
     port         => $port,
-    group        => $group,
+    groups       => $groups,
     group_create => $group_create,
     templates    => $templates,
     proxy        => $proxy,

--- a/spec/types/zabbix_host_spec.rb
+++ b/spec/types/zabbix_host_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'zabbix_host' do
+  let(:title) { 'test1.example.com' }
+
+  context 'with default provider' do
+    it { is_expected.to be_valid_type.with_provider(:ruby) }
+
+    it { is_expected.to be_valid_type.with_properties('ensure') }
+    it { is_expected.to be_valid_type.with_properties('group') }
+    it { is_expected.to be_valid_type.with_properties('groups') }
+    it { is_expected.to be_valid_type.with_properties('id') }
+    it { is_expected.to be_valid_type.with_properties('interfaceid') }
+    it { is_expected.to be_valid_type.with_properties('ipaddress') }
+    it { is_expected.to be_valid_type.with_properties('port') }
+    it { is_expected.to be_valid_type.with_properties('proxy') }
+    it { is_expected.to be_valid_type.with_properties('templates') }
+    it { is_expected.to be_valid_type.with_properties('use_ip') }
+
+    it { is_expected.to be_valid_type.with_parameters('hostname') }
+    it { is_expected.to be_valid_type.with_parameters('group_create') }
+  end
+end

--- a/spec/unit/puppet/provider/zabbix_host/ruby.rb
+++ b/spec/unit/puppet/provider/zabbix_host/ruby.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'fakefs/spec_helpers'
+
+describe Puppet::Type.type(:zabbix_host).provider(:ruby) do
+  let(:resource) do
+    Puppet::Type.type(:zabbix_host).new(
+      hostname: 'test1.example.com'
+    )
+  end
+  let(:provider) { resource.provider }
+
+  it 'be an instance of the correct provider' do
+    expect(provider).to be_an_instance_of Puppet::Type::Zabbix_host::ProviderRuby
+  end
+
+  [:instances, :prefetch].each do |method|
+    it "should respond to the class method #{method}" do
+      expect(described_class).to respond_to(method)
+    end
+  end
+
+  [:create, :exists?, :destroy, :get_groupids, :get_templateids, :ipaddress, :use_ip, :port, :groups, :templates, :proxy].each do |method|
+    it "should respond to the instance method #{method}" do
+      expect(described_class.new).to respond_to(method)
+    end
+  end
+end

--- a/spec/unit/puppet/type/zabbix_host_spec.rb
+++ b/spec/unit/puppet/type/zabbix_host_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+require 'unit/puppet/x/spec_zabbix_types'
+
+describe Puppet::Type.type(:zabbix_host) do
+  describe 'when validating params' do
+    [
+      :group_create,
+      :hostname
+    ].each do |param|
+      it "should have a #{param} parameter" do
+        expect(described_class.attrtype(param)).to eq(:param)
+      end
+    end
+  end
+
+  describe 'when validating properties' do
+    [
+      :group,
+      :groups,
+      :id,
+      :interfaceid,
+      :ipaddress,
+      :port,
+      :proxy,
+      :templates,
+      :use_ip
+    ].each do |param|
+      it "should have a #{param} property" do
+        expect(described_class.attrtype(param)).to eq(:property)
+      end
+    end
+  end
+
+  describe 'munge_boolean' do
+    {
+      true    => true,
+      false   => false,
+      'true'  => true,
+      'false' => false,
+      :true   => true,
+      :false  => false
+    }.each do |key, value|
+      it "munges #{key.inspect} to #{value}" do
+        expect(described_class.new(name: 'nobody').munge_boolean(key)).to eq value
+      end
+    end
+
+    it 'fails on non boolean-ish values' do
+      expect { described_class.new(name: 'nobody').munge_boolean('foo') }.to raise_error(Puppet::Error, 'munge_boolean only takes booleans')
+    end
+  end
+
+  describe 'parameters' do
+    describe 'hostname' do
+      it_behaves_like 'generic namevar', :hostname
+    end
+
+    describe 'group_create' do
+      it_behaves_like 'boolean parameter', :group_create, true
+
+      { 'true' => true, 'false' => false, :true => true, :false => false }.each do |key, value|
+        it "munge input value #{key.inspect} => #{value}" do
+          object = described_class.new(name: 'nobody', group_create: key)
+          expect(object[:group_create]).to eq(value)
+        end
+      end
+    end
+  end
+
+  describe 'properties' do
+    describe 'ensure' do
+      it_behaves_like 'generic ensurable', :present
+    end
+
+    describe 'group' do
+      it_behaves_like 'validated property', :group, nil, ['group1', 'Group One']
+    end
+
+    describe 'groups' do
+      it_behaves_like 'array_matching property', :groups, nil
+
+      let(:object) { described_class.new(name: 'nobody', groups: ['Group1', 'Group One']) }
+
+      it 'ignores order of array' do
+        expect(object.property(:groups).insync?(['Group One', 'Group1'])).to be true
+      end
+    end
+
+    describe 'id' do
+      it_behaves_like 'readonly property', :id
+    end
+
+    describe 'interfaceid' do
+      it_behaves_like 'readonly property', :interfaceid
+    end
+
+    describe 'ipaddress' do
+      it_behaves_like 'validated property', :ipaddress, nil, ['127.0.0.1', '10.0.1.2', 'fe80::21f:5133:f123:c23f/64']
+    end
+
+    describe 'port' do
+      it_behaves_like 'validated property', :port, nil, [10_050, '10050', 12_345]
+
+      let(:object) { described_class.new(name: 'nobody', port: 40) }
+
+      it 'ignores port received as string' do
+        expect(object.property(:port).insync?('40')).to be true
+      end
+    end
+
+    describe 'proxy' do
+      it_behaves_like 'validated property', :proxy, nil, ['proxy1.example.com', 'proxy1']
+    end
+
+    describe 'templates' do
+      it_behaves_like 'validated property', :templates, nil, ['template1', 'Template One', ['template1', 'Template One']]
+      it_behaves_like 'array_matching property', :templates
+
+      let(:object) { described_class.new(name: 'nobody', templates: ['Template1', 'Template One']) }
+
+      it 'ignores order of array' do
+        expect(object.property(:templates).insync?(['Template One', 'Template1'])).to be true
+      end
+    end
+
+    describe 'use_ip' do
+      it_behaves_like 'boolean property', :use_ip, nil
+    end
+  end
+end

--- a/spec/unit/puppet/x/spec_zabbix_types.rb
+++ b/spec/unit/puppet/x/spec_zabbix_types.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+
+shared_examples 'generic namevar' do |name|
+  it { expect(described_class.attrtype(name)).to eq :param }
+
+  it 'is the namevar' do
+    expect(described_class.key_attributes).to eq [name]
+  end
+end
+
+shared_examples 'generic ensurable' do |*allowed|
+  allowed ||= [:present, :absent, 'present', 'absent']
+
+  context 'attrtype' do
+    it { expect(described_class.attrtype(:ensure)).to eq :property }
+  end
+
+  context 'class' do
+    it do
+      expect(described_class.propertybyname(:ensure).ancestors).
+        to include(Puppet::Property::Ensure)
+    end
+  end
+
+  it 'defaults to :present' do
+    expect(described_class.new(name: 'test').should(:ensure)).to eq(:present)
+  end
+
+  allowed.each do |value|
+    it "should support #{value.inspect} as a value to :ensure" do
+      expect { described_class.new(name: 'nobody', ensure: value) }.not_to raise_error
+    end
+  end
+
+  it 'rejects unknown values' do
+    expect { described_class.new(name: 'nobody', ensure: :foo) }.to raise_error(Puppet::Error)
+  end
+end
+
+shared_examples 'boolean parameter' do |param, _default|
+  it 'does not allow non-boolean values' do
+    expect do
+      described_class.new(:name => 'foo', param => 'unknown')
+    end.to raise_error Puppet::ResourceError, %r{Valid values are true, false}
+  end
+end
+
+shared_examples 'validated property' do |param, default, allowed, disallowed|
+  context 'attrtype' do
+    it { expect(described_class.attrtype(param)).to eq :property }
+  end
+
+  context 'allowed' do
+    allowed.each do |value|
+      it "should support #{value} as a value" do
+        expect { described_class.new(:name => 'nobody', param => value) }.
+          not_to raise_error
+      end
+    end
+  end
+
+  context 'disallowed' do
+    unless disallowed.nil?
+      disallowed.each do |value|
+        it "rejects #{value} as a value" do
+          expect { described_class.new(:name => 'nobody', param => :value) }.
+            to raise_error(Puppet::Error)
+        end
+      end
+    end
+  end
+
+  context 'default' do
+    if default.nil?
+      it 'has no default value' do
+        resource = described_class.new(name: 'nobody')
+        expect(resource.should(param)).to be_nil
+      end
+    else
+      it "should default to #{default}" do
+        resource = described_class.new(name: 'nobody')
+        expect(resource.should(param)).to eq default
+      end
+    end
+  end
+end
+
+shared_examples 'array_matching property' do |param, default|
+  context 'attrtype' do
+    it { expect(described_class.attrtype(param)).to eq :property }
+  end
+
+  context 'array_matching' do
+    it { expect(described_class.attrclass(param).array_matching).to eq :all }
+  end
+
+  it 'supports an array of mixed types' do
+    value = [true, 'foo']
+    resource = described_class.new(name: 'test', param => value)
+    expect(resource[param]).to eq value
+  end
+
+  context 'default' do
+    if default.nil?
+      it 'has no default value' do
+        resource = described_class.new(name: 'nobody')
+        expect(resource.should(param)).to be_nil
+      end
+    else
+      it "should default to #{default}" do
+        resource = described_class.new(name: 'nobody')
+        expect(resource.should(param)).to eq default
+      end
+    end
+  end
+end
+
+shared_examples 'boolean property' do |param, default|
+  it 'does not allow non-boolean values' do
+    expect do
+      described_class.new(:name => 'foo', param => 'unknown')
+    end.to raise_error Puppet::ResourceError, %r{Invalid value "unknown". Valid values are true, false.}
+  end
+
+  it_behaves_like 'validated property', param, default, [true, false, 'true', 'false', :true, :false]
+end
+
+shared_examples 'readonly property' do |param|
+  it 'is readonly' do
+    expect do
+      described_class.new(:name => 'foo', param => 'invalid')
+    end.to raise_error(Puppet::Error, %r{#{param} is read-only})
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
This commits adds the following improvements to zabbix_host:
* Implement self.prefetch (This allows the use of `puppet resource
zabbix_host` as well as purging unmanaged zabbix_host resources)
* Implement proper setters for all properties
* Rename the `group` parameter to `groups` to allow multiple groups to
be specified

This is another change for #570.

#### This Pull Request (PR) fixes the following issues
