### PR TITLE
Put selboolean{'zabbix_can_network'} inside ensure_resources

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -567,15 +567,18 @@ class zabbix::server (
   }
   # check if selinux is active and allow zabbix
   if $facts['selinux'] == true and $manage_selinux {
-    selboolean{'zabbix_can_network':
-      persistent => true,
-      value      => 'on',
-      notify     => $dependency,
-    }
-    -> selinux::module{'zabbix-server':
+    ensure_resource ('selboolean',
+      [
+        'zabbix_can_network',
+      ], {
+        persistent => true,
+        value      => 'on',
+      })
+    selinux::module{'zabbix-server':
       ensure    => 'present',
       source_te => 'puppet:///modules/zabbix/zabbix-server.te',
       before    => $dependency,
+      require   => Selboolean['zabbix_can_network']
     }
     # zabbix-server 3.4 introduced IPC via a socket in /tmp
     # https://support.zabbix.com/browse/ZBX-12567

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -578,7 +578,7 @@ class zabbix::server (
       ensure    => 'present',
       source_te => 'puppet:///modules/zabbix/zabbix-server.te',
       before    => $dependency,
-      require   => Selboolean['zabbix_can_network']
+      require   => Selboolean['zabbix_can_network'],
     }
     # zabbix-server 3.4 introduced IPC via a socket in /tmp
     # https://support.zabbix.com/browse/ZBX-12567


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
puppet-zabbix module depends on stdlib, `ensure_resources` is already availble for usage.
My motivation for this change is global declaration that zabbix_can_network and zabbix server belongs to this global declaration.
ensure_resource allows for resource duplication as long as declaration of those resource is identical.
Also, notifying service dependency is useless IMO, as SELinux and ZBX are separate things and ZBX doesn't need to be restarted in order to make SELinux policies to be applied.

#### This Pull Request (PR) fixes the following issues
Fixes #598
