### PR TITLE
Allow puppetlabs/apache 5.x, puppetlabs/concat 6.x, puppetlabs/firewall 2.x, puppetlabs/mysql 9.x, puppetlabs/stdlib 6.x; drop puppetlabs/ruby dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ zabbix::agent::selinux_rules:
 
 At the moment of writing, the puppet run will fail one or more times when `manage_resources` is set to true when you install an fresh Zabbix server. It is an issue and I'm aware of it. Don't know yet how to solve this, but someone suggested to try puppet stages and for know I haven't made it work yet.
 
-*	Please be aware, that when `manage_resources` is enabled, it can increase an puppet run on the zabbix-server a lot when you have a lot of hosts.
+*	Please be aware, that when `manage_resources` is enabled, it can increase an puppet run on the zabbix-server a lot when you have a lot of hosts. You also need to ensure that you've got ruby installed on your machine, and related packages to compile native extensions for gems (usually gcc and make).
 *	First run of puppet on the zabbix-server can result in this error:
 
 ```ruby

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -266,14 +266,6 @@ class zabbix::web (
   # is set to false, you'll get warnings like this:
   # "Warning: You cannot collect without storeconfigs being set"
   if $manage_resources {
-    include ruby::dev
-    $compile_packages = $facts['os']['family'] ? {
-      'RedHat' => [ 'make', 'gcc-c++', ],
-      'Debian' => [ 'make', 'g++', ],
-      default  => [],
-    }
-    ensure_packages($compile_packages, { before => Package['zabbixapi'], })
-
     # Determine correct zabbixapi version.
     case $zabbix_version {
       '2.2': {
@@ -302,7 +294,6 @@ class zabbix::web (
     -> package { 'zabbixapi':
       ensure   => $zabbixapi_version,
       provider => $puppetgem,
-      require  => Class['ruby::dev'],
     }
     -> class { 'zabbix::resources::web':
       zabbix_url     => $zabbix_url,

--- a/metadata.json
+++ b/metadata.json
@@ -25,10 +25,6 @@
       "version_requirement": ">= 1.7.0 < 3.0.0"
     },
     {
-      "name": "puppetlabs/ruby",
-      "version_requirement": ">= 0.6.0 < 2.0.0"
-    },
-    {
       "name": "puppetlabs/pe_gem",
       "version_requirement": ">= 0.2.0 < 2.0.0"
     },

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 3.5.0 < 8.0.0"
+      "version_requirement": ">= 3.5.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/apache",

--- a/metadata.json
+++ b/metadata.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "puppet/selinux",
-      "version_requirement": ">= 1.1.0 < 2.0.0"
+      "version_requirement": ">= 1.1.0 < 3.0.0"
     }
   ],
   "source": "https://github.com/voxpupuli/puppet-zabbix.git",

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 3.5.0 < 9.0.0"
+      "version_requirement": ">= 3.5.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apache",

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 6.0.0"
+      "version_requirement": ">= 4.25.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/mysql",
@@ -38,7 +38,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.1 < 6.0.0"
+      "version_requirement": ">= 4.1.0 < 7.0.0"
     },
     {
       "name": "camptocamp/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.7.0 < 2.0.0"
+      "version_requirement": ">= 1.7.0 < 3.0.0"
     },
     {
       "name": "puppetlabs/ruby",

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 1.6.0 < 5.0.0"
+      "version_requirement": ">= 1.6.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/firewall",

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -3,55 +3,68 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_application type' do
   context 'create zabbix_application resources' do
-    it 'runs successfully' do
-      # This will deploy a running Zabbix setup (server, web, db) which we can
-      # use for custom type tests
-      pp = <<-EOS
-        class { 'apache':
-            mpm_module => 'prefork',
-        }
-        include apache::mod::php
-        include postgresql::server
+    # This will deploy a running Zabbix setup (server, web, db) which we can
+    # use for custom type tests
+    pp1 = <<-EOS
+      $compile_packages = $facts['os']['family'] ? {
+        'RedHat' => [ 'make', 'gcc-c++', ],
+        'Debian' => [ 'make', 'g++', ],
+        default  => [],
+      }
+      ensure_packages($compile_packages, { before => Package['zabbixapi'], })
+      class { 'apache':
+          mpm_module => 'prefork',
+      }
+      include apache::mod::php
+      include postgresql::server
 
-        class { 'zabbix':
-          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
-          zabbix_url       => 'localhost',
-          zabbix_api_user  => 'Admin',
-          zabbix_api_pass  => 'zabbix',
-          apache_use_ssl   => false,
-          manage_resources => true,
-          require          => [ Class['postgresql::server'], Class['apache'], ],
-        }
+      class { 'zabbix':
+        zabbix_version   => '3.0',
+        zabbix_url       => 'localhost',
+        zabbix_api_user  => 'Admin',
+        zabbix_api_pass  => 'zabbix',
+        apache_use_ssl   => false,
+        manage_resources => true,
+        require          => [ Class['postgresql::server'], Class['apache'], ],
+      }
 
-        Zabbix_application {
-          require => [ Service['zabbix-server'], Package['zabbixapi'], ],
-        }
-
-        zabbix_application { 'TestApplication1':
-          template => 'Template OS Linux',
-        }
       EOS
 
-      shell('yum clean metadata') if fact('os.family') == 'RedHat'
-
+    pp2 = <<-EOS
+      zabbix_application { 'TestApplication1':
+        template => 'Template OS Linux',
+      }
+    EOS
+    # setup zabbix. Apache module isn't idempotent and requires a second run
+    it 'works with no error on the first apply' do
       # Cleanup old database
       shell('/opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped; /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged; rm -f /etc/zabbix/.*done; su - postgres -c "psql -c \'drop database if exists zabbix_server;\'"')
 
-      apply_manifest(pp, expect_failures: true) # Error: Could not find a suitable provider for zabbix_application
-      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp1, catch_failures: true)
+    end
+    it 'works with no error on the second apply' do
+      apply_manifest(pp1, catch_failures: true)
     end
 
-    let(:result_templates) do
-      zabbixapi('localhost', 'Admin', 'zabbix', 'template.get', selectApplications: ['name'],
-                                                                output: ['host']).result
+    # configure the applications within zabbix
+    it 'works with no error on the third apply' do
+      apply_manifest(pp2, catch_failures: true)
     end
+    it 'works without changes on the fourth apply' do
+      apply_manifest(pp2, catch_changes: true)
+    end
+  end
 
-    context 'TestApplication1' do
-      let(:template1) { result_templates.select { |t| t['host'] == 'Template OS Linux' }.first }
+  let(:result_templates) do
+    zabbixapi('localhost', 'Admin', 'zabbix', 'template.get', selectApplications: ['name'],
+                                                              output: ['host']).result
+  end
 
-      it 'is attached to Template OS Linux' do
-        expect(template1['applications'].map { |a| a['name'] }).to include('TestApplication1')
-      end
+  context 'TestApplication1' do
+    let(:template1) { result_templates.select { |t| t['host'] == 'Template OS Linux' }.first }
+
+    it 'is attached to Template OS Linux' do
+      expect(template1['applications'].map { |a| a['name'] }).to include('TestApplication1')
     end
   end
 end

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -24,6 +24,10 @@ describe 'zabbix::database' do
         EOS
       end
 
+      # The zabbix server was never supposed to work on Gentoo, just the agent
+      # We need to skip through those tests
+      next if facts[:os]['name'] == 'Gentoo'
+
       describe 'database_type is postgresql, zabbix_type is server and is multiple host setup' do
         let :params do
           {

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -144,8 +144,7 @@ describe 'zabbix::web' do
               with_content(%r{zabbix_pass    = zabbix}).
               with_content(%r{apache_use_ssl = false})
           end
-          it { is_expected.to contain_package('zabbixapi').that_requires('Class[ruby::dev]').with_provider('puppet_gem') }
-          it { is_expected.to contain_class('ruby::dev') }
+          it { is_expected.to contain_package('zabbixapi').with_provider('puppet_gem') }
           it { is_expected.to contain_file('/etc/zabbix/imported_templates').with_ensure('directory') }
         end
 


### PR DESCRIPTION
This depends on #605.