### PR TITLE
Add support for specifying unsupported repo location.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -109,6 +109,7 @@ class zabbix::params {
   $manage_firewall                          = false
   $manage_apt                               = true
   $repo_location                            = ''
+  $unsupported_repo_location                = ''
   $manage_resources                         = false
   $manage_vhost                             = true
   $database_path                            = '/usr/sbin'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -108,8 +108,8 @@ class zabbix::params {
   $default_vhost                            = false
   $manage_firewall                          = false
   $manage_apt                               = true
-  $repo_location                            = ''
-  $unsupported_repo_location                = ''
+  $repo_location                            = undef
+  $unsupported_repo_location                = undef
   $manage_resources                         = false
   $manage_vhost                             = true
   $database_path                            = '/usr/sbin'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -32,11 +32,11 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix::repo (
-  Boolean         $manage_repo                = $zabbix::params::manage_repo,
-  Boolean         $manage_apt                 = $zabbix::params::manage_apt,
-  Stdlib::HTTPUrl $repo_location              = $zabbix::params::repo_location,
-  Stdlib::HTTPUrl $unsupported_repo_location  = $zabbix::params::unsupported_repo_location,
-  String[1]       $zabbix_version             = $zabbix::params::zabbix_version,
+  Boolean                   $manage_repo               = $zabbix::params::manage_repo,
+  Boolean                   $manage_apt                = $zabbix::params::manage_apt,
+  Optional[Stdlib::HTTPUrl] $repo_location             = $zabbix::params::repo_location,
+  Optional[Stdlib::HTTPUrl] $unsupported_repo_location = $zabbix::params::unsupported_repo_location,
+  String[1]                 $zabbix_version            = $zabbix::params::zabbix_version,
 ) inherits zabbix::params {
   if ($manage_repo) {
     case $facts['os']['name'] {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -32,11 +32,11 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix::repo (
-  Boolean                                              $manage_repo                = $zabbix::params::manage_repo,
-  Boolean                                              $manage_apt                 = $zabbix::params::manage_apt,
-  Variant[String[0],Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $repo_location              = $zabbix::params::repo_location,
-  Variant[String[0],Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $unsupported_repo_location  = $zabbix::params::unsupported_repo_location,
-  String[1]                                            $zabbix_version             = $zabbix::params::zabbix_version,
+  Boolean         $manage_repo                = $zabbix::params::manage_repo,
+  Boolean         $manage_apt                 = $zabbix::params::manage_apt,
+  Stdlib::HTTPUrl $repo_location              = $zabbix::params::repo_location,
+  Stdlib::HTTPUrl $unsupported_repo_location  = $zabbix::params::unsupported_repo_location,
+  String[1]       $zabbix_version             = $zabbix::params::zabbix_version,
 ) inherits zabbix::params {
   if ($manage_repo) {
     case $facts['os']['name'] {
@@ -66,7 +66,7 @@ class zabbix::repo (
         }
 
         $_repo_location = $repo_location ? {
-          ''      => "https://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/\$basearch/",
+          undef   => "https://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/\$basearch/",
           default => $repo_location,
         }
 
@@ -80,7 +80,7 @@ class zabbix::repo (
         }
 
         $_unsupported_repo_location = $unsupported_repo_location ? {
-          ''      => "https://repo.zabbix.com/non-supported/rhel/${majorrelease}/\$basearch/",
+          undef   => "https://repo.zabbix.com/non-supported/rhel/${majorrelease}/\$basearch/",
           default => $unsupported_repo_location,
         }
 
@@ -105,7 +105,7 @@ class zabbix::repo (
 
         if ($facts['os']['architecture'] == 'armv6l') {
           $_repo_location = $repo_location ? {
-            ''      => 'http://naizvoru.com/raspbian/zabbix',
+            undef   => 'http://naizvoru.com/raspbian/zabbix',
             default => $repo_location,
           }
 
@@ -130,7 +130,7 @@ class zabbix::repo (
           }
 
           $_repo_location = $repo_location ? {
-            ''      => "http://repo.zabbix.com/zabbix/${zabbix_version}/${operatingsystem}/",
+            undef   => "http://repo.zabbix.com/zabbix/${zabbix_version}/${operatingsystem}/",
             default => $repo_location,
           }
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,6 +17,10 @@
 # [*repo_location*]
 #   A custom repo location (e.g. your own mirror)
 #
+# [*unsupported_repo_location*]
+#   A custom repo location for unsupported content (e.g. your own mirror)
+#   Currently only supported under RedHat based systems.
+#
 # === Authors
 #
 # Author Name:
@@ -28,10 +32,11 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix::repo (
-  Boolean                                              $manage_repo    = $zabbix::params::manage_repo,
-  Boolean                                              $manage_apt     = $zabbix::params::manage_apt,
-  Variant[String[0],Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $repo_location  = $zabbix::params::repo_location,
-  String[1]                                            $zabbix_version = $zabbix::params::zabbix_version,
+  Boolean                                              $manage_repo                = $zabbix::params::manage_repo,
+  Boolean                                              $manage_apt                 = $zabbix::params::manage_apt,
+  Variant[String[0],Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $repo_location              = $zabbix::params::repo_location,
+  Variant[String[0],Stdlib::HTTPUrl, Stdlib::HTTPSUrl] $unsupported_repo_location  = $zabbix::params::unsupported_repo_location,
+  String[1]                                            $zabbix_version             = $zabbix::params::zabbix_version,
 ) inherits zabbix::params {
   if ($manage_repo) {
     case $facts['os']['name'] {
@@ -74,10 +79,15 @@ class zabbix::repo (
           priority => '1',
         }
 
+        $_unsupported_repo_location = $unsupported_repo_location ? {
+          ''      => "https://repo.zabbix.com/non-supported/rhel/${majorrelease}/\$basearch/",
+          default => $unsupported_repo_location,
+        }
+
         yumrepo { 'zabbix-nonsupported':
           name     => "Zabbix_nonsupported_${majorrelease}_${facts['os']['architecture']}",
           descr    => "Zabbix_nonsupported_${majorrelease}_${facts['os']['architecture']}",
-          baseurl  => "https://repo.zabbix.com/non-supported/rhel/${majorrelease}/\$basearch/",
+          baseurl  => $_unsupported_repo_location,
           gpgcheck => '1',
           gpgkey   => $gpgkey_nonsupported,
           priority => '1',

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -158,6 +158,16 @@ describe 'zabbix::repo' do
           it { is_expected.to contain_yumrepo('zabbix').with_baseurl('https://example.com/foo') }
         end
 
+        context 'when unsupported_repo_location is "https://example.com/foo"' do
+          let :params do
+            {
+              unsupported_repo_location: 'https://example.com/foo'
+            }
+          end
+
+          it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_baseurl('https://example.com/foo') }
+        end
+
         case facts[:os]['release']['major']
         when '5'
           context 'on RedHat 5 and Zabbix 2.0' do


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This fairly simply PR adds the ability to specify the "unsupported" repo path similar to how you can override the repo_path.  (zabbix::repo::unsupported_repo_path is the new setting)  I am using this a a temporary measure to get Zabbix running on some RHEL 8 agents before RHEL 8 is even available, but I imagine it could be useful to others who want to mirror the unsupported repo as well.  At some level I figured, you can configure one, why not the other.  =)

#### This Pull Request (PR) fixes the following issues
n/a
