### PR TITLE
Fix minor typo in agent_servicename param

### DIFF
--- a/manifests/userparameters.pp
+++ b/manifests/userparameters.pp
@@ -74,7 +74,7 @@ define zabbix::userparameters (
   $zabbix_package_agent = $zabbix::agent::zabbix_package_agent
   $agent_config_owner   = $zabbix::agent::agent_config_owner
   $agent_config_group   = $zabbix::agent::agent_config_group
-  $agent_servicename    = $zabbix::agent::agent_servicename
+  $agent_servicename    = $zabbix::agent::servicename
 
   if $source {
     file { "${include_dir}/${name}.conf":


### PR DESCRIPTION
#### Pull Request (PR) description

Fix minor typo than prevents the zabbix::userparameters to notify the service when a change is made.


#### This Pull Request (PR) fixes the following issues

Fixes #607

