### PR TITLE
Delete PrivateDevices attribute in systemd service template file

### DIFF
--- a/templates/zabbix-server-systemd.init.erb
+++ b/templates/zabbix-server-systemd.init.erb
@@ -17,7 +17,6 @@ ExecStart=/usr/sbin/zabbix_server <%= @additional_service_params %> -c <%= @serv
 ExecReload=/usr/sbin/zabbix_server -R config_cache_reload
 <% if @pidfile %>PIDFile=<%= @pidfile %><% end %>
 Restart=on-abnormal
-PrivateDevices=yes
 PrivateTmp=yes
 ProtectSystem=full
 ProtectHome=yes


### PR DESCRIPTION
#### Pull Request (PR) description
Delete PrivateDevices attribute in systemd service template file to avoid problems with fping execution permissions. 

#### This Pull Request (PR) fixes the following issues
Fixes #609 