### PR TITLE
drop legacy puppetlabs/pe_gem dependency & cleanup code

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,6 @@ fixtures:
     postgresql: "git://github.com/puppetlabs/puppet-postgresql.git"
     mysql: "git://github.com/puppetlabs/puppetlabs-mysql.git"
     ruby: "git://github.com/puppetlabs/puppetlabs-ruby.git"
-    pe_gem: "git://github.com/puppetlabs/puppetlabs-pe_gem.git"
     systemd: "git://github.com/camptocamp/puppet-systemd.git"
     selinux: "git://github.com/voxpupuli/puppet-selinux.git"
     yumrepo_core:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -379,21 +379,6 @@ class zabbix::params {
     $additional_service_params = '--foreground'
     $service_type              = 'simple'
   }
-  # Gem provider may vary based on version/type of puppet install.
-  # This can be a little complicated and may need revisited over time.
-  if str2bool($facts['is_pe']) {
-    if $facts['pe_version'] and versioncmp($facts['pe_version'], '3.7.0') >= 0 { # lint:ignore:only_variable_string
-      $puppetgem = 'pe_puppetserver_gem'
-    } else {
-      $puppetgem = 'pe_gem'
-    }
-  } else {
-    if $facts['puppetversion'] and versioncmp($facts['puppetversion'], '4.0.0') >= 0 {
-      $puppetgem = 'puppet_gem'
-    } else {
-      $puppetgem = 'gem'
-    }
-  }
 
   $default_web_config_owner = $facts['os']['name'] ? {
     /(Ubuntu|Debian)/ => 'www-data',
@@ -425,4 +410,8 @@ class zabbix::params {
     # getvar returned undef
     $web_config_group = $default_web_config_owner
   }
+
+  # the package provider we use to install the zabbixapi gem
+  # The puppet agent needs to access it. So it's `puppet_gem` for AIO systems.
+  $puppetgem = 'puppet_gem'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -25,10 +25,6 @@
       "version_requirement": ">= 1.7.0 < 3.0.0"
     },
     {
-      "name": "puppetlabs/pe_gem",
-      "version_requirement": ">= 0.2.0 < 2.0.0"
-    },
-    {
       "name": "puppetlabs/apt",
       "version_requirement": ">= 2.1.0 < 8.0.0"
     },

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -148,21 +148,6 @@ describe 'zabbix::web' do
           it { is_expected.to contain_file('/etc/zabbix/imported_templates').with_ensure('directory') }
         end
 
-        describe 'when manage_resources and is_pe are true' do
-          let :facts do
-            facts.merge(
-              is_pe: true,
-              pe_version: '3.7.0'
-            )
-          end
-
-          let :params do
-            super().merge(manage_resources: true)
-          end
-
-          it { is_expected.to contain_package('zabbixapi').with_provider('pe_puppetserver_gem') }
-        end
-
         describe 'when manage_resources is false' do
           let :params do
             super().merge(manage_resources: false)


### PR DESCRIPTION
This module was required to support EOL Puppet/Puppet Enterprise
versions. We don't support them since a long time, so we can remove the
dependency + related code.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
