### PR TITLE
add 'VirtuozzoLinux' support

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -34,7 +34,7 @@ class zabbix::database::postgresql (
     /^(3|4).\d+$/: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         case $facts['os']['name'] {
-          'CentOS', 'RedHat', 'OracleLinux': {
+          'CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux': {
             $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/"
           }
           default : {
@@ -60,7 +60,7 @@ class zabbix::database::postgresql (
     default: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         case $facts['os']['name'] {
-          'CentOS', 'RedHat', 'OracleLinux': {
+          'CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux': {
             $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/create"
           }
           default : {

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -522,7 +522,7 @@ class zabbix::proxy (
 
   # Now we are going to install the correct packages.
   case $facts['os']['name'] {
-    'redhat', 'centos', 'oraclelinux' : {
+    'redhat', 'centos', 'oraclelinux', 'VirtuozzoLinux': {
       #There is no zabbix-proxy package in 3.0
       if versioncmp('3.0',$zabbix_version) > 0 {
         package { 'zabbix-proxy':

--- a/metadata.json
+++ b/metadata.json
@@ -134,6 +134,13 @@
       ]
     },
     {
+      "operatingsystem": "VirtuozzoLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
       "operatingsystem": "Archlinux"
     },
     {


### PR DESCRIPTION
`facter` 3.14 adds support for `os.name` *VirtuozzoLinux* (https://puppet.com/docs/puppet/latest/release_notes_facter.html). This means `os.name` won't resolve to *RedHat* anymore.