### PR TITLE
Add support for adding a JMX interface to a host

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -51,19 +51,34 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     proxy_hostid = @resource[:proxy].nil? || @resource[:proxy].empty? ? nil : zbx.proxies.get_id(host: @resource[:proxy])
 
     # Now we create the host
-    zbx.hosts.create(
-      host: @resource[:hostname],
-      proxy_hostid: proxy_hostid,
-      interfaces: [
+    default_interface = [
+      {
+        type: 1,
+        main: 1,
+        ip: @resource[:ipaddress],
+        dns: @resource[:hostname],
+        port: @resource[:port],
+        useip: @resource[:use_ip] ? 1 : 0
+      }
+    ]
+    if jmx_port != 0 and !jmx_port.nil?
+      host_interfaces = default_interface + [
         {
-          type: 1,
+          type: 4,
           main: 1,
           ip: @resource[:ipaddress],
           dns: @resource[:hostname],
-          port: @resource[:port],
+          port: @resource[:jmx_port],
           useip: @resource[:use_ip] ? 1 : 0
         }
-      ],
+      ]
+    else
+      host_interfaces = default_interface
+    end
+    zbx.hosts.create(
+      host: @resource[:hostname],
+      proxy_hostid: proxy_hostid,
+      interfaces: host_interfaces,
       templates: templates,
       groups: groups
     )

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -61,20 +61,20 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         useip: @resource[:use_ip] ? 1 : 0
       }
     ]
-    if jmx_port != 0 and !jmx_port.nil?
-      host_interfaces = default_interface + [
-        {
-          type: 4,
-          main: 1,
-          ip: @resource[:ipaddress],
-          dns: @resource[:hostname],
-          port: @resource[:jmx_port],
-          useip: @resource[:use_ip] ? 1 : 0
-        }
-      ]
-    else
-      host_interfaces = default_interface
-    end
+    host_interfaces = if jmx_port != 0 && !jmx_port.nil?
+                        default_interface + [
+                          {
+                            type: 4,
+                            main: 1,
+                            ip: @resource[:ipaddress],
+                            dns: @resource[:hostname],
+                            port: @resource[:jmx_port],
+                            useip: @resource[:use_ip] ? 1 : 0
+                          }
+                        ]
+                      else
+                        default_interface
+                      end
     zbx.hosts.create(
       host: @resource[:hostname],
       proxy_hostid: proxy_hostid,

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -101,6 +101,10 @@ Puppet::Type.newtype(:zabbix_host) do
     desc 'Whether it is monitored by an proxy or not.'
   end
 
+  newproperty(:jmx_port) do
+    desc 'Should a JMX interface be added and which port should it connect to.'
+  end
+
   autorequire(:file) { '/etc/zabbix/api.conf' }
 
   validate do

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -192,6 +192,9 @@
 # [*manage_startup_script*]
 #  If the init script should be managed by this module. Attention: This might cause problems with some config options of this module (e.g agent_configfile_path)
 #
+# [*jmx_port*]
+#  When specified, a JMX interface will be created which will connect to the port specified here
+#
 # === Example
 #
 #  Basic installation:
@@ -282,6 +285,7 @@ class zabbix::agent (
   String $additional_service_params               = $zabbix::params::additional_service_params,
   String $service_type                            = $zabbix::params::service_type,
   Boolean $manage_startup_script                  = $zabbix::params::manage_startup_script,
+  Integer $jmx_port                               = $zabbix::params::agent_jmx_port,
 ) inherits zabbix::params {
 
   # the following two codeblocks are a bit blargh. The correct default value for
@@ -357,6 +361,7 @@ class zabbix::agent (
       group_create => $zbx_group_create,
       templates    => $zbx_templates,
       proxy        => $use_proxy,
+      jmx_port     => $jmx_port,
     }
   }
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -285,7 +285,7 @@ class zabbix::agent (
   String $additional_service_params               = $zabbix::params::additional_service_params,
   String $service_type                            = $zabbix::params::service_type,
   Boolean $manage_startup_script                  = $zabbix::params::manage_startup_script,
-  Integer $jmx_port                               = $zabbix::params::agent_jmx_port,
+  Stdlib::Port $jmx_port                          = $zabbix::params::agent_jmx_port,
 ) inherits zabbix::params {
 
   # the following two codeblocks are a bit blargh. The correct default value for

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -278,6 +278,7 @@ class zabbix::params {
     $agent_logfile                          = '/var/log/zabbix/zabbix_agentd.log'
     $agent_logfilesize                      = '100'
   }
+  $agent_jmx_port                           = 0
 
   # Proxy specific params
   $proxy_allowroot                          = '0'

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -23,6 +23,7 @@ class zabbix::resources::agent (
   $group_create            = undef,
   $templates               = undef,
   $proxy                   = undef,
+  $jmx_port                = undef,
 ) {
   if $group and $groups {
     fail("Got group and groups. This isn't support! Please use groups only.")
@@ -43,5 +44,6 @@ class zabbix::resources::agent (
     group_create => $group_create,
     templates    => $templates,
     proxy        => $proxy,
+    jmx_port     => $jmx_port,
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for adding a JMX interface to host

Just add this to your hiera:
```
zabbix::agent::jmx_port: 9999
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
