### PR TITLE
Implement self.prefetch for zabbix_proxy

### DIFF
--- a/lib/puppet/provider/zabbix_proxy/ruby.rb
+++ b/lib/puppet/provider/zabbix_proxy/ruby.rb
@@ -1,6 +1,37 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'zabbix'))
+require_relative '../zabbix'
 Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix) do
   confine feature: :zabbixapi
+
+  def self.instances
+    proxies = zbx.query(
+      method: 'proxy.get',
+      params: {
+        output: 'extend',
+        selectInterface: %w[interfaceid type main ip port useip]
+      }
+    )
+
+    proxies.map do |p|
+      # p['interface'] is an Array if the host is a active proxy
+      # p['interface'] is a Hash if the host is a passive proxy
+      new(
+        ensure: :present,
+        name: p['host'],
+        ipaddress: p['interface'].is_a?(Hash) ? p['interface']['ip'] : nil,
+        use_ip: p['interface'].is_a?(Hash) ? p['interface']['use_ip'] : nil,
+        mode: p['status'].to_i - 5,
+        port: p['interface'].is_a?(Hash) ? p['interface']['port'] : nil
+      )
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if (resource = resources[prov.name])
+        resource.provider = prov
+      end
+    end
+  end
 
   def create
     # Set some vars
@@ -12,18 +43,6 @@ Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix
 
     use_ip = @resource[:use_ip]
     port = @resource[:port]
-    templates = @resource[:templates]
-
-    # Get the template ids.
-    template_array = []
-    if templates.is_a?(Array) == true
-      templates.each do |template|
-        template_id = get_template_id(zbx, template)
-        template_array.push template_id
-      end
-    else
-      template_array.push templates
-    end
 
     # Check if we need to connect via ip or fqdn
     use_ip = use_ip ? 1 : 0
@@ -43,4 +62,6 @@ Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix
   def exists?
     check_proxy(@resource[:hostname])
   end
+
+  mk_resource_methods
 end

--- a/lib/puppet/type/zabbix_proxy.rb
+++ b/lib/puppet/type/zabbix_proxy.rb
@@ -8,24 +8,20 @@ Puppet::Type.newtype(:zabbix_proxy) do
     desc 'FQDN of the machine.'
   end
 
-  newparam(:ipaddress) do
+  newproperty(:ipaddress) do
     desc 'The IP address of the machine running zabbix proxy.'
   end
 
-  newparam(:use_ip) do
+  newproperty(:use_ip) do
     desc 'Using ipadress instead of dns to connect. Is used by the zabbix-api command.'
   end
 
-  newparam(:mode) do
+  newproperty(:mode) do
     desc 'The kind of mode the proxy running. Active (0) or passive (1).'
   end
 
-  newparam(:port) do
+  newproperty(:port) do
     desc 'The port that the zabbix proxy is listening on.'
-  end
-
-  newparam(:templates) do
-    desc 'Template which should be loaded for this host.'
   end
 
   autorequire(:file) { '/etc/zabbix/api.conf' }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -455,7 +455,6 @@ class zabbix::proxy (
       use_ip    => $use_ip,
       mode      => $mode,
       port      => $listenport,
-      templates => $zbx_templates,
     }
 
     zabbix::userparameters { 'Zabbix_Proxy': template => 'Template App Zabbix Proxy', }

--- a/manifests/resources/proxy.pp
+++ b/manifests/resources/proxy.pp
@@ -18,13 +18,11 @@ class zabbix::resources::proxy (
   $use_ip    = undef,
   $mode      = undef,
   $port      = undef,
-  $templates = undef,
 ) {
   @@zabbix_proxy { $hostname:
     ipaddress => $ipaddress,
     use_ip    => $use_ip,
     mode      => $mode,
     port      => $port,
-    templates => $templates,
   }
 }

--- a/spec/unit/puppet/provider/zabbix_proxy/ruby.rb
+++ b/spec/unit/puppet/provider/zabbix_proxy/ruby.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:zabbix_proxy).provider(:ruby) do
+  let(:resource) do
+    Puppet::Type.type(:zabbix_proxy).new(
+      name: 'Testproxy'
+    )
+  end
+  let(:provider) { resource.provider }
+
+  it 'be an instance of the correct provider' do
+    expect(provider).to be_an_instance_of Puppet::Type::Zabbix_proxy::ProviderRuby
+  end
+
+  [:instances, :prefetch].each do |method|
+    it "should respond to the class method #{method}" do
+      expect(described_class).to respond_to(method)
+    end
+  end
+
+  [:create, :exists?].each do |method|
+    it "should respond to the instance method #{method}" do
+      expect(described_class.new).to respond_to(method)
+    end
+  end
+end

--- a/spec/unit/puppet/type/zabbix_proxy_spec.rb
+++ b/spec/unit/puppet/type/zabbix_proxy_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:zabbix_proxy) do
+  describe 'when validating params' do
+    [
+      :hostname,
+      :provider
+    ].each do |param|
+      it "should have a #{param} parameter" do
+        expect(described_class.attrtype(param)).to eq(:param)
+      end
+    end
+  end
+
+  describe 'when validating properties' do
+    [
+      :ipaddress,
+      :use_ip,
+      :mode,
+      :port
+    ].each do |param|
+      it "should have a #{param} property" do
+        expect(described_class.attrtype(param)).to eq(:property)
+      end
+    end
+  end
+
+  describe 'namevar' do
+    it 'has :hostname as its namevar' do
+      expect(described_class.key_attributes).to eq([:hostname])
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
The template parameter got removed because it had no function and just added additional API calls. I therefore labeled this PR `backwards-incompatible`.

#### This Pull Request (PR) fixes the following issues
This is another change for #570.
