### PR TITLE
Pin CentOS acceptance tests 7.6.1810

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,7 +3,7 @@
   docker_sets:
     - set: ubuntu1404-64
     - set: ubuntu1604-64
-    - set: centos7-64
+    - set: 'centos7-64{image=centos:7.6.1810}'
     - set: debian8-64
   secure: "ijm7hKPYWr1eg7151g5oK6MzZL4ojrgWjKlxgoBHXAdXdY88opMgvixfSJK5IMUbtanPfWRkqqABx+MYO78nfQBWDlghUzZ8sQXFeO2Ie0PgWl4nFV0kKWz+ejVaZC4dKSZlWha5pO1ek+sx7KnjIBZY82OXs/GXbjwhHx6d56YugXLuCyvfFxC7mXC9wF58bPwcYRCBSZt9CRl0OMBAFybxjdwsFMloRRhdz7f3hhlqF8Nrs1sxG1HhgiMcnrZqovNfb3Tw9K1RPYATazXxQrjcI7YHvJx0AvtHFUsn+/A0GtpKUuuPbaVdkYgE1Tye0AsAcey6RW4xhJywZglKrzDk7vfyUiU5CObeLh4/dhub3k111rDPL8v6v9t40fteduJoFLziHotQwdl37UALL7PwWZY5HuJvaBqHY2LsGs/ptGMB9ZCzxA85jfDw8lrZQ7P97SAoC34Ihs8D6vkKT9HUKHIXh19O5AAa70jReru0ej179IBjvs8m9nDwDNdY3sIsdhUU8WQ3BftDF6M8OzvgyLKDvjSs1Izag+Asl2Ze7RAQfQ2RvbfkDm9KEFnDQtXtzF4Cu1Ed6io2j1zI71JFQpIf6zb1qeNrhqulbJ15owGkQmHBgD8K+bDd1CCU4kA26axypV00XDsjfwdtFHgtUO3AlUVUim0QTMk9ATc="
 Gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ matrix:
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{image=centos:7.6.1810} BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64{image=centos:7.6.1810} BEAKER_HYPERVISOR=docker CHECK=beaker
     services: docker
   - rvm: 2.5.3
     bundler_args: --without development release


### PR DESCRIPTION
#### Pull Request (PR) description
This is needed because of https://github.com/docker/for-linux/issues/835
and https://github.com/moby/moby/issues/38749.

Long story short: systemd on CentOS 7.7 is broken with current versions
of Docker.

#### This Pull Request (PR) fixes the following issues
#645
