### PR TITLE
zabbix.com repository for Raspbian Linux

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -123,7 +123,11 @@ class zabbix::repo (
             ,
           }
         } else {
-          $operatingsystem = downcase($facts['os']['name'])
+          if ($facts['os']['distro'][id] == 'Raspbian') {
+            $operatingsystem = 'raspbian'
+          } else {
+            $operatingsystem = downcase($facts['os']['name'])
+          }
           case $facts['os']['release']['full'] {
             /\/sid$/ : { $releasename = regsubst($facts['os']['release']['full'], '/sid$', '') }
             default  : { $releasename = $facts['os']['distro']['codename'] }

--- a/metadata.json
+++ b/metadata.json
@@ -144,6 +144,13 @@
     },
     {
       "operatingsystem": "Gentoo"
+    },
+    {
+      "operatingsystem": "Raspbian",
+      "operatingsystemrelease": [
+        "9",
+        "10"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Zabbix.com provides a repository for Raspbian Linux under http://repo.zabbix.com/zabbix/<version>/raspbian/

The puppet-zabbix module uses the fact os.name for determining the URL of the used repository which is "Debian" for Raspbian Linux. The Debian repositiry is not providing "armhf" deb packages so the installation of zabbix fails.

This patch is an if condition which sets the variable $operatingsystem to 'raspbian' if the fact os.distro.id is 'Raspbian'. Otherwise the behaviour is not modified.

This way puppet-zabbix is choosing the right repository for installing zabbix on a Raspbian Linux.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
