### PR TITLE
Allow to delete a zabbix_proxy

### DIFF
--- a/lib/puppet/provider/zabbix_proxy/ruby.rb
+++ b/lib/puppet/provider/zabbix_proxy/ruby.rb
@@ -63,5 +63,9 @@ Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix
     check_proxy(@resource[:hostname])
   end
 
+  def destroy
+    zbx.proxies.delete(zbx.proxies.get_id(host: @resource[:hostname]))
+  end
+
   mk_resource_methods
 end

--- a/spec/unit/puppet/provider/zabbix_proxy/ruby.rb
+++ b/spec/unit/puppet/provider/zabbix_proxy/ruby.rb
@@ -18,7 +18,7 @@ describe Puppet::Type.type(:zabbix_proxy).provider(:ruby) do
     end
   end
 
-  %i[create exists?].each do |method|
+  %i[create exists? destroy].each do |method|
     it "should respond to the instance method #{method}" do
       expect(described_class.new).to respond_to(method)
     end


### PR DESCRIPTION
#### Pull Request (PR) description
This allows to set a `zabbix_proxy` resource to `absent`.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
