### PR TITLE
Remove concat dependency from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,10 +29,6 @@
       "version_requirement": ">= 2.1.0 < 8.0.0"
     },
     {
-      "name": "puppetlabs/concat",
-      "version_requirement": ">= 4.1.0 < 7.0.0"
-    },
-    {
       "name": "camptocamp/systemd",
       "version_requirement": ">= 0.4.0 < 3.0.0"
     },


### PR DESCRIPTION
We don't use it directly in this module.  It *is* a dependency of at
least one of our dependencies, so it needs to remain in .fixtures.yml.

Fixes #658