### PR TITLE
Fix type error on zabbix_proxy delete

### DIFF
--- a/lib/puppet/provider/zabbix_proxy/ruby.rb
+++ b/lib/puppet/provider/zabbix_proxy/ruby.rb
@@ -64,7 +64,7 @@ Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix
   end
 
   def destroy
-    zbx.proxies.delete(zbx.proxies.get_id(host: @resource[:hostname]))
+    zbx.proxies.delete([zbx.proxies.get_id(host: @resource[:hostname])].flatten)
   end
 
   mk_resource_methods


### PR DESCRIPTION
zbx.proxies.delete expects an array, we handed over a string. This fixes
it a adds proper tests.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
