### PR TITLE
Improve `zabbix_proxy` type

### DIFF
--- a/lib/puppet/provider/zabbix.rb
+++ b/lib/puppet/provider/zabbix.rb
@@ -76,13 +76,6 @@ class Puppet::Provider::Zabbix < Puppet::Provider
     false
   end
 
-  # Check if proxy exists. When error raised, return false.
-  def check_proxy(host)
-    zbx.proxies.get_id(host: host)
-  rescue Puppet::ExecutionFailure
-    false
-  end
-
   # Get the template id from the name.
   def get_template_id(zbx, template)
     return template if a_number?(template)

--- a/lib/puppet/provider/zabbix_proxy/ruby.rb
+++ b/lib/puppet/provider/zabbix_proxy/ruby.rb
@@ -2,26 +2,16 @@ require_relative '../zabbix'
 Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix) do
   confine feature: :zabbixapi
 
-  def self.instances
-    proxies = zbx.query(
-      method: 'proxy.get',
-      params: {
-        output: 'extend',
-        selectInterface: %w[interfaceid type main ip port useip]
-      }
-    )
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
 
+  mk_resource_methods
+
+  def self.instances
     proxies.map do |p|
-      # p['interface'] is an Array if the host is a active proxy
-      # p['interface'] is a Hash if the host is a passive proxy
-      new(
-        ensure: :present,
-        name: p['host'],
-        ipaddress: p['interface'].is_a?(Hash) ? p['interface']['ip'] : nil,
-        use_ip: p['interface'].is_a?(Hash) ? p['interface']['use_ip'] : nil,
-        mode: p['status'].to_i - 5,
-        port: p['interface'].is_a?(Hash) ? p['interface']['port'] : nil
-      )
+      new(proxy_properties_hash(p))
     end
   end
 
@@ -33,39 +23,178 @@ Puppet::Type.type(:zabbix_proxy).provide(:ruby, parent: Puppet::Provider::Zabbix
     end
   end
 
-  def create
-    # Set some vars
-    host = @resource[:hostname]
-    ipaddress = @resource[:ipaddress]
-
-    # Normally 0 is active and 1 is passive, in the API, its 5 and 6
-    proxy_mode = @resource[:mode] + 5
-
-    use_ip = @resource[:use_ip]
-    port = @resource[:port]
-
-    # Check if we need to connect via ip or fqdn
-    use_ip = use_ip ? 1 : 0
-
-    zbx.proxies.create_or_update(
-      host: host,
-      status: proxy_mode,
-      interfaces: [
-        ip: ipaddress,
-        dns: host,
-        useip: use_ip,
-        port: port
-      ]
+  def self.proxies(proxyids = nil)
+    zbx.query(
+      method: 'proxy.get',
+      params: {
+        proxyids: proxyids,
+        output: 'extend',
+        selectInterface: %w[interfaceid type main ip port useip]
+      }.compact
     )
   end
 
+  # Convert from proxy hash returned by API into a resource properties hash
+  def self.proxy_properties_hash(p)
+    {
+      ensure: :present,
+      # Proxy object properties
+      proxyid: p['proxyid'].to_i,
+      name:    p['host'],
+      mode:    status_to_mode(p['status']),
+      # Proxy Interface object properties
+      interfaceid: p['interface'].is_a?(Hash) ? p['interface']['interfaceid'] : nil,
+      ipaddress:   p['interface'].is_a?(Hash) ? p['interface']['ip'] : nil,
+      use_ip:      if p['interface'].is_a?(Hash) then p['interface']['useip'] == '1' ? :true : :false end,
+      port:        p['interface'].is_a?(Hash) ? p['interface']['port'].to_i : nil
+    }
+  end
+
+  def create
+    mode = @resource[:mode] || :active
+
+    if mode == :passive
+      useip = if @resource[:use_ip].nil?
+                1
+              else
+                @resource[:use_ip] == :true ? 1 : 0
+              end
+      interface = {
+        ip: @resource[:ipaddress] || '127.0.0.1',
+        dns: @resource[:hostname],
+        useip: useip,
+        port: @resource[:port] || 10_051
+      }
+    else
+      interface = nil
+    end
+
+    zbx.proxies.create(
+      {
+        host: @resource[:hostname],
+        status: self.class.mode_to_status(mode),
+        interface: interface
+      }.compact
+    )
+    @property_flush[:created] = true
+  end
+
   def exists?
-    check_proxy(@resource[:hostname])
+    @property_hash[:ensure] == :present
   end
 
   def destroy
     zbx.proxies.delete([zbx.proxies.get_id(host: @resource[:hostname])].flatten)
+    @property_flush[:destroyed] = true
   end
 
-  mk_resource_methods
+  def flush
+    update unless @property_flush[:created] || @property_flush[:destroyed]
+
+    # Update @property_hash so that the output of puppet resource is correct
+    if @property_flush[:destroyed]
+      @property_hash.clear
+      @property_hash[:ensure] = :absent
+    else
+      proxy = self.class.proxies(@property_hash[:proxyid]).find { |p| p['host'] == @resource[:hostname] }
+      @property_hash = self.class.proxy_properties_hash(proxy)
+    end
+  end
+
+  def mode=(value)
+    @property_flush[:mode] = value
+  end
+
+  def change_to_passive_proxy
+    Puppet.debug("We're changing to a passive proxy")
+    # We need to call zbx.proxies.update with an `interface` hash.
+
+    useip = if @resource[:use_ip].nil?
+              1 # Default to true
+            else
+              @resource[:use_ip] == :true ? 1 : 0
+            end
+
+    interface = {
+      ip: @resource[:ipaddress] || @property_hash[:ipaddress] || '127.0.0.1',
+      dns: @resource[:hostname], # This is the namevar and will always exist
+      useip: useip,
+      port: @resource[:port] || @property_hash[:port] || 10_051
+    }
+
+    zbx.proxies.update(
+      {
+        proxyid: @property_hash[:proxyid],
+        status: self.class.mode_to_status(:passive),
+        interface: interface
+      },
+      true
+    )
+  end
+
+  def change_to_active_proxy
+    Puppet.debug("We're changing to an active proxy")
+    zbx.proxies.update(
+      {
+        proxyid: @property_hash[:proxyid],
+        status: self.class.mode_to_status(:active)
+      },
+      true
+    )
+  end
+
+  def update_interface_properties
+    useip = if @resource[:use_ip].nil?
+              nil # Don't provide a default. Keep use_ip unmanaged.
+            else
+              @resource[:use_ip] == :true ? 1 : 0
+            end
+
+    interface = {
+      interfaceid: @property_hash[:interfaceid],
+      ip: @resource[:ipaddress],
+      useip: useip,
+      port: @resource[:port]
+    }.compact
+
+    zbx.proxies.update(
+      {
+        proxyid: @property_hash[:proxyid],
+        interface: interface
+      },
+      true
+    )
+  end
+
+  def update
+    if @property_flush[:mode] == :passive
+      change_to_passive_proxy
+      return
+    end
+
+    if @property_flush[:mode] == :active
+      change_to_active_proxy
+      return
+    end
+
+    # At present, the only properties other than mode that can be updated are the interface properties applicable to passive proxies only.
+    raise Puppet::Error, "Can't update proxy interface properties for an active proxy" unless @property_hash[:mode] == :passive
+    update_interface_properties
+  end
+
+  def self.status_to_mode(status)
+    case status.to_i
+    when 5
+      :active
+    when 6
+      :passive
+    else
+      raise Puppet::Error, 'zabbix API returned invalid value for `status`'
+    end
+  end
+
+  def self.mode_to_status(mode)
+    return 5 if mode == :active
+    6
+  end
 end

--- a/lib/puppet/type/zabbix_proxy.rb
+++ b/lib/puppet/type/zabbix_proxy.rb
@@ -4,24 +4,91 @@ Puppet::Type.newtype(:zabbix_proxy) do
     defaultto :present
   end
 
+  def munge_boolean_to_symbol(value)
+    # insync? doesn't work with actual booleans
+    # see https://tickets.puppetlabs.com/browse/PUP-2368
+    value = value.downcase if value.respond_to? :downcase
+
+    case value
+    when true, :true, 'true', :yes, 'yes'
+      :true
+    when false, :false, 'false', :no, 'no'
+      :false
+    else
+      raise ArgumentError, 'expected a boolean value'
+    end
+  end
+
+  # Standard properties
   newparam(:hostname, namevar: true) do
-    desc 'FQDN of the machine.'
-  end
-
-  newproperty(:ipaddress) do
-    desc 'The IP address of the machine running zabbix proxy.'
-  end
-
-  newproperty(:use_ip) do
-    desc 'Using ipadress instead of dns to connect. Is used by the zabbix-api command.'
+    desc 'FQDN of the proxy.'
   end
 
   newproperty(:mode) do
     desc 'The kind of mode the proxy running. Active (0) or passive (1).'
+
+    newvalues(:active, :passive, 0, 1, '0', '1')
+
+    munge do |value|
+      case value
+      when 0, '0'
+        :active
+      when 1, '1'
+        :passive
+      else
+        super(value)
+      end
+    end
+  end
+
+  newproperty(:proxyid) do
+    desc '(readonly) ID of the proxy'
+    validate { |_val| raise Puppet::Error, 'proxyid is read-only' }
+  end
+
+  # Interface properties (applicable to passive proxies)
+  newproperty(:ipaddress) do
+    desc 'The IP address of the machine running zabbix proxy.'
+
+    validate do |value|
+      require 'ipaddr'
+
+      begin
+        IPAddr.new(value)
+      rescue => e
+        raise Puppet::Error, e.to_s
+      end
+    end
+  end
+
+  newproperty(:use_ip) do
+    desc 'Using ipadress instead of dns to connect. Is used by the zabbix-api command.'
+
+    munge { |value| @resource.munge_boolean_to_symbol(value) }
   end
 
   newproperty(:port) do
     desc 'The port that the zabbix proxy is listening on.'
+
+    validate do |value|
+      if value.is_a?(String)
+        raise Puppet::Error, 'invalid port' unless value =~ %r{^\d+$}
+        raise Puppet::Error, 'invalid port' unless value.to_i.between?(1, 65_535)
+        return
+      end
+      if value.is_a?(Integer)
+        raise Puppet::Error, 'invalid port' unless value.between?(1, 65_535)
+        return
+      end
+      raise Puppet::Error, 'invalid port'
+    end
+
+    munge(&:to_i)
+  end
+
+  newproperty(:interfaceid) do
+    desc '(readonly) ID of the interface'
+    validate { |_val| raise Puppet::Error, 'interfaceid is read-only' }
   end
 
   autorequire(:file) { '/etc/zabbix/api.conf' }

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -3,48 +3,58 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_proxy type' do
   context 'create zabbix_proxy resources' do
-    it 'runs successfully' do
-      # This will deploy a running Zabbix setup (server, web, db) which we can
-      # use for custom type tests
-      pp = <<-EOS
-        class { 'apache':
-            mpm_module => 'prefork',
-        }
-        include apache::mod::php
-        include postgresql::server
+    # This will deploy a running Zabbix setup (server, web, db) which we can
+    # use for custom type tests
+    pp1 = <<-EOS
+      $compile_packages = $facts['os']['family'] ? {
+        'RedHat' => [ 'make', 'gcc-c++', 'rubygems', 'ruby'],
+        'Debian' => [ 'make', 'g++', 'ruby-dev', 'ruby', 'pkg-config',],
+        default  => [],
+      }
+      ensure_packages($compile_packages, { before => Package['zabbixapi'], })
+      class { 'apache':
+        mpm_module => 'prefork',
+      }
+      include apache::mod::php
+      include postgresql::server
 
-        class { 'zabbix':
-          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
-          zabbix_url       => 'localhost',
-          zabbix_api_user  => 'Admin',
-          zabbix_api_pass  => 'zabbix',
-          apache_use_ssl   => false,
-          manage_resources => true,
-          require          => [ Class['postgresql::server'], Class['apache'], ],
-        }
+      class { 'zabbix':
+        zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+        zabbix_url       => 'localhost',
+        zabbix_api_user  => 'Admin',
+        zabbix_api_pass  => 'zabbix',
+        apache_use_ssl   => false,
+        manage_resources => true,
+        require          => [ Class['postgresql::server'], Class['apache'], ],
+      }
+    EOS
 
-        zabbix_proxy { 'ZabbixProxy1':
-          ipaddress => '127.0.0.1',
-          use_ip    => true,
-          mode      => 0,
-          port      => 10051,
-          require   => [ Service['zabbix-server'], Package['zabbixapi'], ],
-        }
-        zabbix_proxy { 'ZabbixProxy2':
-          ipaddress => '127.0.0.3',
-          use_ip    => false,
-          mode      => 1,
-          port      => 10055,
-          require   => [ Service['zabbix-server'], Package['zabbixapi'], ],
-        }
-      EOS
+    # Cleanup old database
+    cleanup_zabbix
 
-      shell('yum clean metadata') if fact('os.family') == 'RedHat'
+    it 'works idempotently with no errors' do
+      # Run it twice and test for idempotency
+      apply_manifest(pp1, catch_failures: true)
+      apply_manifest(pp1, catch_changes: true)
+    end
 
-      # Cleanup old database
-      cleanup_zabbix
+    # setup proxies within zabbix
+    pp2 = <<-EOS
+      zabbix_proxy { 'ZabbixProxy1':
+        mode => 0,
+      }
+      zabbix_proxy { 'ZabbixProxy2':
+        ipaddress => '127.0.0.3',
+        use_ip    => false,
+        mode      => 1,
+        port      => 10055,
+      }
+    EOS
 
-      apply_manifest(pp, catch_failures: true)
+    it 'works idempotently with no errors' do
+      # Run it twice and test for idempotency
+      apply_manifest(pp2, catch_failures: true)
+      apply_manifest(pp2, catch_changes: true)
     end
 
     let(:result_proxies) do
@@ -87,27 +97,81 @@ describe 'zabbix_proxy type' do
     end
   end
 
-  context 'delete zabbix_proxy resources' do
-    it 'runs successfully' do
-      # This will delete the Zabbix proxies create above
-      pp = <<-EOS
-        zabbix_proxy { 'ZabbixProxy1':
-          ensure    => absent,
-          ipaddress => '127.0.0.1',
-          use_ip    => true,
-          mode      => 0,
-          port      => 10051,
-        }
-        zabbix_proxy { 'ZabbixProxy2':
-          ensure    => absent,
-          ipaddress => '127.0.0.3',
-          use_ip    => false,
-          mode      => 1,
-          port      => 10055,
-        }
-      EOS
+  context 'update zabbix_proxy resources' do
+    # This will update the Zabbix proxies created above by switching their configuration
+    pp_update = <<-EOS
+      zabbix_proxy { 'ZabbixProxy1':
+        ipaddress => '127.0.0.3',
+        use_ip    => false,
+        mode      => 1,
+        port      => 10055,
+      }
+      zabbix_proxy { 'ZabbixProxy2':
+        mode => 0,
+      }
+    EOS
 
-      apply_manifest(pp, catch_failures: true)
+    it 'works idempotently with no errors' do
+      # Run it twice and test for idempotency
+      apply_manifest(pp_update, catch_failures: true)
+      apply_manifest(pp_update, catch_changes: true)
+    end
+
+    let(:result_proxies) do
+      zabbixapi('localhost', 'Admin', 'zabbix', 'proxy.get', selectInterface: %w[dns ip port useip],
+                                                             output: ['host']).result
+    end
+
+    context 'ZabbixProxy1' do
+      let(:proxy1) { result_proxies.select { |h| h['host'] == 'ZabbixProxy1' }.first }
+
+      it 'is created' do
+        expect(proxy1['host']).to eq('ZabbixProxy1')
+      end
+
+      it 'has a interfaces dns configured' do
+        expect(proxy1['interface']['dns']).to eq('ZabbixProxy1')
+      end
+      it 'has a interfaces ip configured' do
+        expect(proxy1['interface']['ip']).to eq('127.0.0.3')
+      end
+      it 'has a interfaces port configured' do
+        expect(proxy1['interface']['port']).to eq('10055')
+      end
+      it 'has a interfaces useip configured' do
+        expect(proxy1['interface']['useip']).to eq('0')
+      end
+    end
+
+    context 'ZabbixProxy2' do
+      let(:proxy2) { result_proxies.select { |h| h['host'] == 'ZabbixProxy2' }.first }
+
+      it 'is created' do
+        expect(proxy2['host']).to eq('ZabbixProxy2')
+      end
+
+      it 'has no interfaces configured' do
+        # Active proxies do not have interface
+        expect(proxy2['interface']).to eq([])
+      end
+    end
+  end
+
+  context 'delete zabbix_proxy resources' do
+    # This will delete the Zabbix proxies create above
+    pp_delete = <<-EOS
+      zabbix_proxy { 'ZabbixProxy1':
+        ensure => absent,
+      }
+      zabbix_proxy { 'ZabbixProxy2':
+        ensure => absent,
+      }
+    EOS
+
+    it 'works idempotently with no errors' do
+      # Run it twice and test for idempotency
+      apply_manifest(pp_delete, catch_failures: true)
+      apply_manifest(pp_delete, catch_changes: true)
     end
 
     let(:result_proxies) do

--- a/spec/unit/puppet/type/zabbix_proxy_spec.rb
+++ b/spec/unit/puppet/type/zabbix_proxy_spec.rb
@@ -30,4 +30,77 @@ describe Puppet::Type.type(:zabbix_proxy) do
       expect(described_class.key_attributes).to eq([:hostname])
     end
   end
+
+  describe 'port' do
+    ['678', 573, 1, 65_535].each do |value|
+      it "supports #{value} as a value to `port`" do
+        expect { described_class.new(name: 'example_proxy', port: value) }.not_to raise_error
+      end
+    end
+    ['foo', true, false, 1_000_000].each do |value|
+      it "rejects #{value}" do
+        expect { described_class.new(name: 'example_proxy', port: value) }.to raise_error(Puppet::Error, %r{invalid port})
+      end
+    end
+  end
+
+  describe 'ipaddress' do
+    ['127.0.0.1', '2001:0db8:85a3:0000:0000:8a2e:0370:7334'].each do |value|
+      it "supports #{value} as a value to `ipaddress`" do
+        expect { described_class.new(name: 'example_proxy', ipaddress: value) }.not_to raise_error
+      end
+    end
+    ['foo', true, false, 1_000_000, '192.463.0.1', '127.0.0.0.1'].each do |value|
+      it "rejects #{value}" do
+        expect { described_class.new(name: 'example_proxy', ipaddress: value) }.to raise_error(Puppet::Error, %r{Parameter ipaddress failed})
+      end
+    end
+  end
+
+  describe 'mode' do
+    describe 'munging' do
+      ['0', 0, 'active'].each do |value|
+        it "#{value} is munged to :active" do
+          proxy = described_class.new(title: 'example_proxy', mode: value)
+          expect(proxy[:mode]).to eq(:active)
+        end
+      end
+      ['1', 1, 'passive'].each do |value|
+        it "#{value} is munged to :passive" do
+          proxy = described_class.new(title: 'example_proxy', mode: value)
+          expect(proxy[:mode]).to eq(:passive)
+        end
+      end
+    end
+  end
+
+  describe 'autorequiring' do
+    let(:config_file) do
+      Puppet::Type.type(:file).new(name: '/etc/zabbix/api.conf', ensure: :file)
+    end
+    let(:catalog) do
+      Puppet::Resource::Catalog.new
+    end
+    let(:resource) do
+      described_class.new(name: 'example_proxy')
+    end
+    let(:relationships) do
+      resource.autorequire
+    end
+
+    before do
+      catalog.add_resource config_file
+      catalog.add_resource resource
+    end
+
+    it 'resource has one relationship' do
+      expect(relationships.size).to eq(1)
+    end
+    it 'relationship target is the zabbix_proxy resource' do
+      expect(relationships[0].target).to eq(resource)
+    end
+    it 'relationship source is the config file' do
+      expect(relationships[0].source).to eq(config_file)
+    end
+  end
 end


### PR DESCRIPTION
- It is now possible to manage individual `zabbix_proxy` resource properties.
- The type has been improved to do enhanced validation of all properties.
- Switching between active and passive proxies (and vice-versa) is now supported.
- Improved acceptance tests (Thanks @baurmatt )
- Improved type unit tests.