### PR TITLE
Change database collation to utf8_bin as it is stated in official docs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -194,7 +194,7 @@ class zabbix::params {
   $server_config_owner                      = 'zabbix'
   $server_configfile_path                   = '/etc/zabbix/zabbix_server.conf'
   $server_database_charset                  = 'utf8'
-  $server_database_collate                  = 'utf8_general_ci'
+  $server_database_collate                  = 'utf8_bin'
   $server_database_host                     = 'localhost'
   $server_database_host_ip                  = '127.0.0.1'
   $server_database_name                     = 'zabbix_server'


### PR DESCRIPTION
#### Pull Request (PR) description
https://www.zabbix.com/documentation/current/manual/appendix/install/db_scripts

In Zabbix 4.4 (at least 4.4.7) proper collation is enforced and various things ceases to work properly.

This PR changes default collation of database from utf8_general_ci to utf8_bin