### PR TITLE
Drop ruby < 2.3 fakefs gem dependency

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -10,12 +10,6 @@ Gemfile:
   optional:
     ':test':
       - gem: 'fakefs'
-        version: '0.13.3'
-        ruby-operator: '<'
-        ruby-version: '2.3.0'
-      - gem: 'fakefs'
-        ruby-operator: '>='
-        ruby-version: '2.3.0'
       - gem: 'zabbixapi'
 spec/spec_helper.rb:
   mock_with: ':mocha'

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,7 @@ group :test do
   gem 'voxpupuli-test', '>= 1.0.0',  :require => false
   gem 'coveralls',                   :require => false
   gem 'simplecov-console',           :require => false
-  gem 'fakefs', '0.13.3',            :require => false if RUBY_VERSION < '2.3.0'
-  gem 'fakefs',                      :require => false if RUBY_VERSION >= '2.3.0'
+  gem 'fakefs',                      :require => false
   gem 'zabbixapi',                   :require => false
   gem 'rspec-puppet-facts',          :require => false, :git => 'https://github.com/mcanevet/rspec-puppet-facts', :ref => '9541292d4fc35db3be1badace673c1108154b571'
 end


### PR DESCRIPTION
This is no longer needed since we don't test on those old Ruby versions anymore.