### PR TITLE
Fix for zabbix::agent manage_firewall when multiple servers are specified

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -471,15 +471,18 @@ class zabbix::agent (
 
   # Manage firewall
   if $manage_firewall {
-    firewall { '150 zabbix-agent':
-      dport  => $listenport,
-      proto  => 'tcp',
-      action => 'accept',
-      source => $server,
-      state  => [
-        'NEW',
-        'RELATED',
-        'ESTABLISHED'],
+    $servers = split($server, ',')
+    $servers.each |$_server| {
+      firewall { "150 zabbix-agent from ${_server}":
+        dport  => $listenport,
+        proto  => 'tcp',
+        action => 'accept',
+        source => $_server,
+        state  => [
+          'NEW',
+          'RELATED',
+          'ESTABLISHED'],
+      }
     }
   }
   # the agent doesn't work perfectly fine with selinux

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -167,24 +167,50 @@ describe 'zabbix::agent' do
         it { is_expected.to contain_file(config_path).with_content %r{^HostInterface=testinterface$} }
       end
 
-      context 'when declaring manage_firewall is true' do
+      context 'when declaring manage_firewall is true with single server' do
         let :params do
           {
+            server: '192.168.1.1',
             manage_firewall: true
           }
         end
 
-        it { is_expected.to contain_firewall('150 zabbix-agent') }
+        it { is_expected.to contain_firewall('150 zabbix-agent from 192.168.1.1') }
       end
 
-      context 'when declaring manage_firewall is false' do
+      context 'when declaring manage_firewall is false with single server' do
         let :params do
           {
+            server: '192.168.1.1',
             manage_firewall: false
           }
         end
 
-        it { is_expected.not_to contain_firewall('150 zabbix-agent') }
+        it { is_expected.not_to contain_firewall('150 zabbix-agent from 192.168.1.1') }
+      end
+
+      context 'when declaring manage_firewall is true with multiple servers' do
+        let :params do
+          {
+            server: '192.168.1.1,10.11.12.13',
+            manage_firewall: true
+          }
+        end
+
+        it { is_expected.to contain_firewall('150 zabbix-agent from 192.168.1.1') }
+        it { is_expected.to contain_firewall('150 zabbix-agent from 10.11.12.13') }
+      end
+
+      context 'when declaring manage_firewall is false with multiple servers' do
+        let :params do
+          {
+            server: '192.168.1.1,10.11.12.13',
+            manage_firewall: false
+          }
+        end
+
+        it { is_expected.not_to contain_firewall('150 zabbix-agent from 192.168.1.1') }
+        it { is_expected.not_to contain_firewall('150 zabbix-agent from 10.11.12.13') }
       end
 
       context 'it creates a startup script' do


### PR DESCRIPTION
#### Pull Request (PR) description
This makes the zabbix::agent's manage_firewall option work when you have multiple Zabbix servers configured in the server setting.

#### This Pull Request (PR) fixes the following issues
Fixes https://github.com/voxpupuli/puppet-zabbix/issues/199
