### PR TITLE
opsgenie integration plugin needs ProtectHome = no

### DIFF
--- a/templates/zabbix-server-systemd.init.erb
+++ b/templates/zabbix-server-systemd.init.erb
@@ -19,7 +19,7 @@ ExecReload=/usr/sbin/zabbix_server -R config_cache_reload
 Restart=on-abnormal
 PrivateTmp=yes
 ProtectSystem=full
-ProtectHome=yes
+ProtectHome=no
 <% if @zabbix_user %>User=<%= @zabbix_user %><% end %>
 
 [Install]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

For opsgenie integration plugins it is needed that on systemd enabled systems the setting "ProtectHome" is "no". The reason is that the integration plugin is tightly coupled in /home/opsgenie.

<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
