### PR TITLE
Zabbix database creation on zabbix version 5.x

### DIFF
--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -30,7 +30,7 @@ class zabbix::database::mysql (
   #
   # Adjustments for version 3.0/4.0 - structure of package with sqls differs from previous versions
   case $zabbix_version {
-    /^(3|4).\d+$/: {
+    /^[345]\.\d+$/: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         $schema_path   = '/usr/share/doc/zabbix-*-mysql*'
       }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -31,7 +31,7 @@ class zabbix::database::postgresql (
   #
   # Adjustments for version 3.0/4.0 - structure of package with sqls differs from previous versions
   case $zabbix_version {
-    /^(3|4).\d+$/: {
+    /^[345]\.\d+$/: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         case $facts['os']['name'] {
           'CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux': {


### PR DESCRIPTION
#### Pull Request (PR) description
Zabbix 5.x is out. This means that the regex in the database creation files is no longer valid (it checks for v3/4). It needs to include version 5 as well.

#### This Pull Request (PR) fixes the following issues
Zabbix database creation on version 5.x