### PR TITLE
Add option to specify type of interface in agent class

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -18,6 +18,10 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     api_hosts.map do |h|
       interface = h['interfaces'].select { |i| i['main'].to_i == 1 }.first
       use_ip = !interface['useip'].to_i.zero?
+      proxy_select = proxies.select { |_name, id| id == h['proxy_hostid'] }.keys.first
+      if proxy_select == nil
+          proxy_select = ''
+      end
       new(
         ensure: :present,
         id: h['hostid'].to_i,
@@ -30,8 +34,8 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         group_create: nil,
         templates: h['parentTemplates'].map { |x| x['host'] },
         macros: h['macros'].map { |macro| { macro['macro'] => macro['value'] } },
-        proxy: proxies.select { |_name, id| id == h['proxy_hostid'] }.keys.first,
-        type: interface['type'].to_i
+        proxy: proxy_select,
+        interfacetype: interface['type'].to_i,
       )
     end
   end

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -16,6 +16,8 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     )
 
     api_hosts.map do |h|
+      # only select the default interface for given host
+      # there is only 1 interface that can be default
       interface = h['interfaces'].select { |i| i['main'].to_i == 1 }.first
       use_ip = !interface['useip'].to_i.zero?
       proxy_select = proxies.select { |_name, id| id == h['proxy_hostid'] }.keys.first

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         templates: h['parentTemplates'].map { |x| x['host'] },
         macros: h['macros'].map { |macro| { macro['macro'] => macro['value'] } },
         proxy: proxies.select { |_name, id| id == h['proxy_hostid'] }.keys.first,
-        type: interface['type'].to_i,
+        type: interface['type'].to_i
       )
     end
   end

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -21,9 +21,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       interface = h['interfaces'].select { |i| i['main'].to_i == 1 }.first
       use_ip = !interface['useip'].to_i.zero?
       proxy_select = proxies.select { |_name, id| id == h['proxy_hostid'] }.keys.first
-      if proxy_select == nil
-          proxy_select = ''
-      end
+      proxy_select = '' if proxy_select.nil?
       new(
         ensure: :present,
         id: h['hostid'].to_i,
@@ -37,7 +35,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         templates: h['parentTemplates'].map { |x| x['host'] },
         macros: h['macros'].map { |macro| { macro['macro'] => macro['value'] } },
         proxy: proxy_select,
-        interfacetype: interface['type'].to_i,
+        interfacetype: interface['type'].to_i
       )
     end
   end

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -48,6 +48,10 @@ Puppet::Type.newtype(:zabbix_host) do
     desc 'The IP address of the machine running zabbix agent.'
   end
 
+  newproperty(:interfacetype, int: 1) do
+    desc 'Interface type. 1 for zabbix agent.'
+  end
+
   newproperty(:use_ip, boolean: true) do
     desc 'Using ipadress instead of dns to connect.'
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -256,7 +256,7 @@ class zabbix::agent (
   $zbx_group_create                               = $zabbix::params::agent_zbx_group_create,
   $zbx_templates                                  = $zabbix::params::agent_zbx_templates,
   Array[Hash] $zbx_macros                         = [],
-  Integer $zbx_interface_type                     = 1,
+  Integer[1,4] $zbx_interface_type                = 1,
   $agent_configfile_path                          = $zabbix::params::agent_configfile_path,
   $pidfile                                        = $zabbix::params::agent_pidfile,
   $servicename                                    = $zabbix::params::agent_servicename,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -61,6 +61,9 @@
 # [*zbx_macros*]
 #   List of macros which will be added when host is configured.
 #
+# [*zbx_interface_type*]
+#   Integer specifying type of interface to be created
+#
 # [*agent_configfile_path*]
 #   Agent config file path defaults to /etc/zabbix/zabbix_agentd.conf
 #
@@ -253,6 +256,7 @@ class zabbix::agent (
   $zbx_group_create                               = $zabbix::params::agent_zbx_group_create,
   $zbx_templates                                  = $zabbix::params::agent_zbx_templates,
   Array[Hash] $zbx_macros                         = [],
+  Integer $zbx_interface_type                     = 1,
   $agent_configfile_path                          = $zabbix::params::agent_configfile_path,
   $pidfile                                        = $zabbix::params::agent_pidfile,
   $servicename                                    = $zabbix::params::agent_servicename,
@@ -374,15 +378,16 @@ class zabbix::agent (
     $_hostname = pick($hostname, $facts['networking']['fqdn'])
 
     class { 'zabbix::resources::agent':
-      hostname     => $_hostname,
-      ipaddress    => $listen_ip,
-      use_ip       => $agent_use_ip,
-      port         => $listenport,
-      groups       => [$groups].flatten(),
-      group_create => $zbx_group_create,
-      templates    => $zbx_templates,
-      macros       => $zbx_macros,
-      proxy        => $use_proxy,
+      hostname       => $_hostname,
+      ipaddress      => $listen_ip,
+      use_ip         => $agent_use_ip,
+      port           => $listenport,
+      groups         => [$groups].flatten(),
+      group_create   => $zbx_group_create,
+      templates      => $zbx_templates,
+      macros         => $zbx_macros,
+      interfacetype  => $zbx_interface_type,
+      proxy          => $use_proxy,
     }
   }
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -378,16 +378,16 @@ class zabbix::agent (
     $_hostname = pick($hostname, $facts['networking']['fqdn'])
 
     class { 'zabbix::resources::agent':
-      hostname       => $_hostname,
-      ipaddress      => $listen_ip,
-      use_ip         => $agent_use_ip,
-      port           => $listenport,
-      groups         => [$groups].flatten(),
-      group_create   => $zbx_group_create,
-      templates      => $zbx_templates,
-      macros         => $zbx_macros,
-      interfacetype  => $zbx_interface_type,
-      proxy          => $use_proxy,
+      hostname      => $_hostname,
+      ipaddress     => $listen_ip,
+      use_ip        => $agent_use_ip,
+      port          => $listenport,
+      groups        => [$groups].flatten(),
+      group_create  => $zbx_group_create,
+      templates     => $zbx_templates,
+      macros        => $zbx_macros,
+      interfacetype => $zbx_interface_type,
+      proxy         => $use_proxy,
     }
   }
 

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -38,14 +38,14 @@ class zabbix::resources::agent (
   }
 
   @@zabbix_host { $hostname:
-    ipaddress      => $ipaddress,
-    use_ip         => $use_ip,
-    port           => $port,
-    groups         => $groups,
-    group_create   => $group_create,
-    templates      => $templates,
-    macros         => $macros,
-    proxy          => $proxy,
-    interfacetype  => $interfacetype,
+    ipaddress     => $ipaddress,
+    use_ip        => $use_ip,
+    port          => $port,
+    groups        => $groups,
+    group_create  => $group_create,
+    templates     => $templates,
+    macros        => $macros,
+    proxy         => $proxy,
+    interfacetype => $interfacetype,
   }
 }

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -24,6 +24,7 @@ class zabbix::resources::agent (
   $templates               = undef,
   $macros                  = undef,
   $proxy                   = undef,
+  $interfacetype           = 1,
 ) {
   if $group and $groups {
     fail("Got group and groups. This isn't support! Please use groups only.")
@@ -37,13 +38,14 @@ class zabbix::resources::agent (
   }
 
   @@zabbix_host { $hostname:
-    ipaddress    => $ipaddress,
-    use_ip       => $use_ip,
-    port         => $port,
-    groups       => $groups,
-    group_create => $group_create,
-    templates    => $templates,
-    macros       => $macros,
-    proxy        => $proxy,
+    ipaddress      => $ipaddress,
+    use_ip         => $use_ip,
+    port           => $port,
+    groups         => $groups,
+    group_create   => $group_create,
+    templates      => $templates,
+    macros         => $macros,
+    proxy          => $proxy,
+    interfacetype  => $interfacetype,
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

This pull request adds option to specify interface type in agent.pp, so you can create an agent that is purely SNMP/JMX/IPMI.
