### PR TITLE
Purging of Templates flag, IPMI Interface support, PSK Authentication

### DIFF
--- a/lib/puppet/provider/zabbix.rb
+++ b/lib/puppet/provider/zabbix.rb
@@ -90,7 +90,7 @@ class Puppet::Provider::Zabbix < Puppet::Provider
   end
 
   def transform_to_array_hash(key, value_array)
-    value_array.map { |a| { key => a } }
+    value_array.map { |a| { key => a.to_s } }
   end
 
   # Is it a number?

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     )
 
     api_hosts.map do |h|
-      interface = h['interfaces'].select { |i| i['type'].to_i == 1 && i['main'].to_i == 1 }.first
+      interface = h['interfaces'].select { |i| i['main'].to_i == 1 }.first
       use_ip = !interface['useip'].to_i.zero?
       new(
         ensure: :present,

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -58,6 +58,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     groups = transform_to_array_hash('groupid', gids)
 
     proxy_hostid = @resource[:proxy].nil? || @resource[:proxy].empty? ? nil : zbx.proxies.get_id(host: @resource[:proxy])
+    interfacetype = @resource[:interfacetype].nil? ? 1 : @resource[:interfacetype]
 
     # Now we create the host
     zbx.hosts.create(
@@ -65,7 +66,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       proxy_hostid: proxy_hostid,
       interfaces: [
         {
-          type: @resource[:interfacetype],
+          type: interfacetype,
           main: 1,
           ip: @resource[:ipaddress],
           dns: @resource[:hostname],

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -185,6 +185,16 @@ Puppet::Type.newtype(:zabbix_host) do
     desc 'The PSK identity to identify this host.'
   end
 
+  newproperty(:purge_templates, boolean: true) do
+    desc 'Should we remove additional templates.'
+
+    newvalues(true, false)
+
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
+  end
+
   autorequire(:file) { '/etc/zabbix/api.conf' }
 
   validate do

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -323,6 +323,7 @@ class zabbix::agent (
   String $additional_service_params               = $zabbix::params::additional_service_params,
   String $service_type                            = $zabbix::params::service_type,
   Boolean $manage_startup_script                  = $zabbix::params::manage_startup_script,
+  Optional[Boolean] $purge_templates              = $zabbix::params::agent_purge_templates,
 ) inherits zabbix::params {
 
   # the following two codeblocks are a bit blargh. The correct default value for
@@ -428,6 +429,7 @@ class zabbix::agent (
       tls_subject      => $tlscertsubject,
       tls_psk_identity => $tlspskidentity,
       tls_psk          => $tlspsk,
+      purge_templates  => $purge_templates,
     }
   }
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -172,6 +172,14 @@
 # [*tlscertfile*]
 #   Full pathname of a file containing the proxy certificate or certificate chain.
 #
+# [*tlscertissuer*]
+#   If you want to configure the resource (i.e. manage_resources is true) you have to specifiy the issuer.
+#   it must match the issuer of tlscertfile.
+#
+# [*tlscertsubject*]
+#   If you want to configure the resource (i.e. manage_resources is true) you have to specifiy the subject.
+#   it must match the subject of tlscertfile.
+#
 # [*tlsconnect*]
 #   How the proxy should connect to Zabbix server. Used for an active proxy, ignored on a passive proxy.
 #
@@ -183,6 +191,10 @@
 #
 # [*tlspskfile*]
 #   Full pathname of a file containing the pre-shared key.
+#
+# [*tlspsk*]
+#   If you want to configure the resource (i.e manage_resources is true) you have to specifiy the PSK that.
+#   tlspskfile will be created with the correct content.
 #
 # [*tlspskidentity*]
 #   Unique, case sensitive string used to identify the pre-shared key.
@@ -293,10 +305,13 @@ class zabbix::agent (
   $tlsaccept                                      = $zabbix::params::agent_tlsaccept,
   $tlscafile                                      = $zabbix::params::agent_tlscafile,
   $tlscertfile                                    = $zabbix::params::agent_tlscertfile,
+  $tlscertissuer                                  = $zabbix::params::agent_tlscertissuer,
+  $tlscertsubject                                 = $zabbix::params::agent_tlscertsubject,
   $tlsconnect                                     = $zabbix::params::agent_tlsconnect,
   $tlscrlfile                                     = $zabbix::params::agent_tlscrlfile,
   $tlskeyfile                                     = $zabbix::params::agent_tlskeyfile,
   $tlspskfile                                     = $zabbix::params::agent_tlspskfile,
+  $tlspsk                                         = $zabbix::params::agent_tlspsk,
   $tlspskidentity                                 = $zabbix::params::agent_tlspskidentity,
   $tlsservercertissuer                            = $zabbix::params::agent_tlsservercertissuer,
   $tlsservercertsubject                           = $zabbix::params::agent_tlsservercertsubject,
@@ -346,6 +361,29 @@ class zabbix::agent (
     default => $listenip,
   }
 
+  # If the user specified a psk but no file we will use the default filename.
+  # If only the file is specified we configure it.
+  # If neither file nor psk is specified nothing is configured.
+  if $tlspsk and ! $tlspskfile {
+    $real_tlspskfile = $zabbix::params::default_pskfile_path
+  }else{
+    $real_tlspskfile = $tlspskfile
+  }
+
+  # Ensure the content of the psk file
+  if $real_tlspskfile and $tlspsk {
+    file { $real_tlspskfile:
+      ensure  => file,
+      owner   => $agent_config_owner,
+      group   => $agent_config_group,
+      mode    => '0440',
+      notify  => Service[$servicename],
+      require => Package[$zabbix_package_agent],
+      replace => true,
+      content => $tlspsk,
+    }
+  }
+
   # So if manage_resources is set to true, we can send some data
   # to the puppetdb. We will include an class, otherwise when it
   # is set to false, you'll get warnings like this:
@@ -375,15 +413,21 @@ class zabbix::agent (
     $_hostname = pick($hostname, $facts['networking']['fqdn'])
 
     class { 'zabbix::resources::agent':
-      hostname     => $_hostname,
-      ipaddress    => $listen_ip,
-      use_ip       => $agent_use_ip,
-      port         => $listenport,
-      groups       => [$groups].flatten(),
-      group_create => $zbx_group_create,
-      templates    => $zbx_templates,
-      macros       => $zbx_macros,
-      proxy        => $use_proxy,
+      hostname         => $_hostname,
+      ipaddress        => $listen_ip,
+      use_ip           => $agent_use_ip,
+      port             => $listenport,
+      groups           => [$groups].flatten(),
+      group_create     => $zbx_group_create,
+      templates        => $zbx_templates,
+      macros           => $zbx_macros,
+      proxy            => $use_proxy,
+      tls_accept       => $tlsaccept,
+      tls_connect      => $tlsconnect,
+      tls_issuer       => $tlscertissuer,
+      tls_subject      => $tlscertsubject,
+      tls_psk_identity => $tlspskidentity,
+      tls_psk          => $tlspsk,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class zabbix::params {
       $manage_choco             = false
       $zabbix_package_agent     = 'zabbix-agent'
       $agent_configfile_path    = '/etc/zabbix/zabbix_agentd.conf'
+      $default_pskfile_path     = '/etc/zabbix/tlspskfile.key'
       $agent_config_owner       = 'zabbix'
       $agent_zabbix_user        = 'zabbix'
       $agent_config_group       = 'zabbix'
@@ -53,6 +54,7 @@ class zabbix::params {
       $manage_choco             = false
       $zabbix_package_agent     = 'zabbix-agent'
       $agent_configfile_path    = '/etc/zabbix/zabbix_agentd.conf'
+      $default_pskfile_path     = '/etc/zabbix/tlspskfile.key'
       $agent_config_owner       = 'zabbix-agent'
       $agent_zabbix_user        = 'zabbix-agent'
       $agent_config_group       = 'zabbix-agent'
@@ -72,6 +74,7 @@ class zabbix::params {
       $manage_choco             = false
       $zabbix_package_agent     = 'zabbix-agent'
       $agent_configfile_path    = '/etc/zabbix_agentd.conf'
+      $default_pskfile_path     = '/etc/zabbix_tlspskfile.key'
       $agent_config_owner       = 'zabbix'
       $agent_zabbix_user        = 'zabbix'
       $agent_config_group       = 'zabbix'
@@ -91,6 +94,7 @@ class zabbix::params {
       $manage_choco             = false
       $zabbix_package_agent     = 'zabbix'
       $agent_configfile_path    = '/etc/zabbix/zabbix_agentd.conf'
+      $default_pskfile_path     = '/etc/zabbix/tlspskfile.key'
       $agent_config_owner       = 'zabbix'
       $agent_zabbix_user        = 'zabbix'
       $agent_config_group       = 'zabbix'
@@ -107,6 +111,7 @@ class zabbix::params {
       $zabbix_package_agent    = 'zabbix-agent'
       $zabbix_package_provider = 'chocolatey'
       $agent_configfile_path   = 'C:/ProgramData/zabbix/zabbix_agentd.conf'
+      $default_pskfile_path    = 'C:/ProgramData/zabbix/tlspskfile.key'
       $agent_config_owner      = undef
       $agent_zabbix_user       = undef
       $agent_config_group      = undef
@@ -124,6 +129,7 @@ class zabbix::params {
       $manage_choco             = false
       $zabbix_package_agent     = 'zabbix-agent'
       $agent_configfile_path    = '/etc/zabbix/zabbix_agentd.conf'
+      $default_pskfile_path     = '/etc/zabbix/tlspskfile.key'
       $agent_config_owner       = 'zabbix'
       $agent_zabbix_user        = 'zabbix'
       $agent_config_group       = 'zabbix'
@@ -317,10 +323,13 @@ class zabbix::params {
   $agent_tlsconnect                         = undef
   $agent_tlscrlfile                         = undef
   $agent_tlskeyfile                         = undef
+  $agent_tlspsk                             = undef
   $agent_tlspskfile                         = undef
   $agent_tlspskidentity                     = undef
   $agent_tlsservercertissuer                = undef
   $agent_tlsservercertsubject               = undef
+  $agent_tlscertissuer                      = undef
+  $agent_tlscertsubject                     = undef
   $agent_unsafeuserparameters               = '0'
   $agent_use_ip                             = true
   $agent_userparameter                      = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -358,6 +358,7 @@ class zabbix::params {
     $agent_logfile                          = '/var/log/zabbix/zabbix_agentd.log'
     $agent_logfilesize                      = '100'
   }
+  $agent_purge_templates                    = true
 
   # Proxy specific params
   $proxy_allowroot                          = '0'

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -24,6 +24,12 @@ class zabbix::resources::agent (
   $templates               = undef,
   $macros                  = undef,
   $proxy                   = undef,
+  $tls_connect             = undef,
+  $tls_accept              = undef,
+  $tls_issuer              = undef,
+  $tls_subject             = undef,
+  $tls_psk_identity        = undef,
+  $tls_psk                 = undef,
 ) {
   if $group and $groups {
     fail("Got group and groups. This isn't support! Please use groups only.")
@@ -37,13 +43,19 @@ class zabbix::resources::agent (
   }
 
   @@zabbix_host { $hostname:
-    ipaddress    => $ipaddress,
-    use_ip       => $use_ip,
-    port         => $port,
-    groups       => $groups,
-    group_create => $group_create,
-    templates    => $templates,
-    macros       => $macros,
-    proxy        => $proxy,
+    ipaddress        => $ipaddress,
+    use_ip           => $use_ip,
+    port             => $port,
+    groups           => $_groups,
+    group_create     => $group_create,
+    templates        => $templates,
+    macros           => $macros,
+    proxy            => $proxy,
+    tls_connect      => $tls_connect,
+    tls_accept       => $tls_accept,
+    tls_issuer       => $tls_issuer,
+    tls_subject      => $tls_subject,
+    tls_psk_identity => $tls_psk_identity,
+    tls_psk          => $tls_psk,
   }
 }

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -30,6 +30,7 @@ class zabbix::resources::agent (
   $tls_subject             = undef,
   $tls_psk_identity        = undef,
   $tls_psk                 = undef,
+  $purge_templates         = undef,
 ) {
   if $group and $groups {
     fail("Got group and groups. This isn't support! Please use groups only.")
@@ -57,5 +58,6 @@ class zabbix::resources::agent (
     tls_subject      => $tls_subject,
     tls_psk_identity => $tls_psk_identity,
     tls_psk          => $tls_psk,
+    purge_templates  => $purge_templates,
   }
 }

--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -359,5 +359,5 @@ LoadModulePath=<%= @loadmodulepath %>
 # Mandatory: no
 # Default:
 # TLSPSKFile=
-<% if @tlspskfile %>TLSPSKFile=<%= @tlspskfile %><% end %>
+<% if @real_tlspskfile %>TLSPSKFile=<%= @real_tlspskfile %><% end %>
 <% end %>


### PR DESCRIPTION
#### Pull Request (PR) description
This Pull request implements three Features:

1. It adds a new parameter `purge_templates` to zabbix_agent that controls if additional templates configured in the server for the zabbix_host resource should be deleted.
2. it implements psk authentication for zabbix_host resources
3. it fixes a problem with zabbix_host resources with only IPMI interfaces 

I found no easy way to split these commits into three PRs. If you know how to do this I would highly appreciate this.

#### This Pull Request (PR) fixes the following issues
