### PR TITLE
Reduce configuration on agent service

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -432,24 +432,19 @@ class zabbix::agent (
   }
 
   # Controlling the 'zabbix-agent' service
-  if str2bool(getvar('::systemd')) {
-    $service_provider = 'systemd'
-    $service_path = undef
-  } elsif $facts['os']['name'] == 'AIX' {
-    $service_provider = 'init'
-    $service_path = '/etc/rc.d/init.d'
-  } else {
-    $service_provider = undef
-    $service_path = undef
-  }
   service { $servicename:
-    ensure     => $service_ensure,
-    enable     => $service_enable,
-    path       => $service_path,
-    provider   => $service_provider,
-    hasstatus  => true,
-    hasrestart => true,
-    require    => Package[$zabbix_package_agent],
+    ensure  => $service_ensure,
+    enable  => $service_enable,
+    require => Package[$zabbix_package_agent],
+  }
+
+  # Override the service provider on AIX
+  # Doing it this way allows overriding it on other platforms
+  if $facts['os']['name'] == 'AIX' {
+    Service[$servicename] {
+      service_provider => 'init',
+      service_path     => '/etc/rc.d/init.d',
+    }
   }
 
   # Configuring the zabbix-agent configuration file

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -68,24 +68,21 @@ describe 'zabbix::agent' do
           end
         else
           it do
-            is_expected.to contain_package(package_name).with(
-              ensure:   'present',
-              require:  'Class[Zabbix::Repo]',
-              tag:      'zabbix'
-            )
+            is_expected.to contain_package(package_name).
+              with_ensure('present').
+              with_tag('zabbix').
+              that_requires('Class[zabbix::repo]')
           end
           it do
-            is_expected.to contain_service(service_name).with(
-              ensure:     'running',
-              enable:     true,
-              hasstatus:  true,
-              hasrestart: true,
-              require:    "Package[#{package_name}]"
-            )
+            is_expected.to contain_service(service_name).
+              with_ensure('running').
+              with_enable(true).
+              with_service_provider(facts[:osfamily] == 'AIX' ? 'init' : nil).
+              that_requires("Package[#{package_name}]")
           end
 
           it { is_expected.to contain_file(include_dir).with_ensure('directory') }
-          it { is_expected.to contain_zabbix__startup(service_name).with(require: "Package[#{package_name}]") }
+          it { is_expected.to contain_zabbix__startup(service_name).that_requires("Package[#{package_name}]") }
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('zabbix::params') }
         end
@@ -104,11 +101,11 @@ describe 'zabbix::agent' do
         when 'Debian'
           # rubocop:disable RSpec/RepeatedExample
           it { is_expected.to contain_class('zabbix::repo').with_zabbix_version(zabbix_version) }
-          it { is_expected.to contain_package('zabbix-agent').with_require('Class[Zabbix::Repo]') }
+          it { is_expected.to contain_package('zabbix-agent').that_requires('Class[Zabbix::Repo]') }
           it { is_expected.to contain_apt__source('zabbix') }
         when 'RedHat'
           it { is_expected.to contain_class('zabbix::repo').with_zabbix_version(zabbix_version) }
-          it { is_expected.to contain_package('zabbix-agent').with_require('Class[Zabbix::Repo]') }
+          it { is_expected.to contain_package('zabbix-agent').that_requires('Class[Zabbix::Repo]') }
           it { is_expected.to contain_yumrepo('zabbix-nonsupported') }
           it { is_expected.to contain_yumrepo('zabbix') }
           # rubocop:enable RSpec/RepeatedExample
@@ -347,11 +344,10 @@ describe 'zabbix::agent' do
         end
 
         it do
-          is_expected.to contain_service(service_name).with(
-            ensure:     'stopped',
-            enable:     false,
-            require:    "Package[#{package_name}]"
-          )
+          is_expected.to contain_service(service_name).
+            with_ensure('stopped').
+            with_enable(false).
+            that_requires("Package[#{package_name}]")
         end
       end
     end


### PR DESCRIPTION
This avoids setting parameters as much as possible.

hasstatus and hasrestart have defaulted to true since Puppet 2.7 so there's no need to set those.

The systemd fact is defined as $fact['service_provider'] == 'systemd' so there's no need to set that either.

Then there's AIX left. It sets it this was because it allows users to override it in site.pp via service defaults. It now only sets the service_provider and not the path. This path is set in the provider since [Puppet 4.6.0](https://github.com/puppetlabs/puppet/commit/34e45ab3f562d1029bfeaafe9a11757ea3b3e92c).

I didn't verify this and only did it by theory so review carefully.