### PR TITLE
Allow special characters in zabbixapi zabbix_pass & postgresql database_password

### DIFF
--- a/lib/puppet/provider/zabbix.rb
+++ b/lib/puppet/provider/zabbix.rb
@@ -49,7 +49,7 @@ class Puppet::Provider::Zabbix < Puppet::Provider
     zbx = ZabbixApi.connect(
       url: "#{protocol}://#{api_config['default']['zabbix_url']}/api_jsonrpc.php",
       user: api_config['default']['zabbix_user'],
-      password: api_config['default']['zabbix_pass'],
+      password: "#{api_config['default']['zabbix_pass']}",
       http_user: api_config['default']['zabbix_user'],
       http_password: api_config['default']['zabbix_pass']
     )

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -84,7 +84,7 @@ class zabbix::database::postgresql (
   }
 
   exec { 'update_pgpass':
-    command => "echo ${database_host}:5432:${database_name}:${database_user}:${database_password} >> /root/.pgpass",
+    command => "echo '${database_host}:5432:${database_name}:${database_user}:${database_password}' >> /root/.pgpass",
     path    => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
     unless  => "grep \"${database_host}:5432:${database_name}:${database_user}:${database_password}\" /root/.pgpass",
     require => File['/root/.pgpass'],

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -31,7 +31,7 @@ describe 'zabbix::database::postgresql' do
           end
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
+          it { is_expected.to contain_exec('update_pgpass').with_command('echo 'node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server' >> /root/.pgpass') }
           it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f schema.sql && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_exec('zabbix_server_images.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f images.sql.gz ]; then gunzip -f images.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f images.sql && touch /etc/zabbix/.images.done") }
           it { is_expected.to contain_exec('zabbix_server_data.sql').with_command("cd /usr/share/doc/zabbix-*-pgsql-2.4*/create && if [ -f data.sql.gz ]; then gunzip -f data.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f data.sql && touch /etc/zabbix/.data.done") }


### PR DESCRIPTION
This pull request fixes a couple of issues I came across regarding passwords with special characters not being handled correctly.

1. Zabbixapi not accepting passwords with special characters (I'm not too familiar with ruby, but this fix works in my tests)
2. postgresql echo exec not handling passwords with special characters correctly