### PR TITLE
zabbix5: dbtls support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -212,6 +212,8 @@ class zabbix::params {
   $server_database_name                     = 'zabbix_server'
   $server_database_password                 = 'zabbix_server'
   $server_database_port                     = undef
+  $server_database_tlsconnect               = undef
+  $server_database_tlscafile                = undef
   $server_database_schema                   = undef
   $server_database_socket                   = undef
   $server_database_user                     = 'zabbix_server'
@@ -357,6 +359,8 @@ class zabbix::params {
   $proxy_database_name                      = 'zabbix_proxy'
   $proxy_database_password                  = 'zabbix-proxy'
   $proxy_database_port                      = undef
+  $proxy_database_tlsconnect                = undef
+  $proxy_database_tlscafile                 = undef
   $proxy_database_schema                    = undef
   $proxy_database_socket                    = undef
   $proxy_database_user                      = 'zabbix-proxy'

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -108,6 +108,17 @@
 # [*database_port*]
 #   Database port when not using local socket. Ignored for sqlite.
 #
+# [*database_tlsconnect*]
+#   Setting this option enforces the use of TLS on connection to the database:
+#   required - connect using TLS
+#   verify_ca - connect using TLS and verify certificate
+#   verify_full - connect using TLS, verify certificate and verify that database identity specified by DBHost matches its certificate
+#   This parameter is supported since Zabbix 5.0.0.
+#
+# [*database_tlscafile*]
+#   Full pathname of a file containing the top-level CA(s) certificates for database certificate verification.
+#   This parameter is supported since Zabbix 5.0.0.
+#
 # [*localbuffer*]
 #   Proxy will keep data locally for N hours, even if the data have already been synced with the server
 #
@@ -367,6 +378,8 @@ class zabbix::proxy (
   $database_password               = $zabbix::params::proxy_database_password,
   $database_socket                 = $zabbix::params::proxy_database_socket,
   $database_port                   = $zabbix::params::proxy_database_port,
+  $database_tlsconnect             = $zabbix::params::proxy_database_tlsconnect,
+  $database_tlscafile              = $zabbix::params::proxy_database_tlscafile,
   $localbuffer                     = $zabbix::params::proxy_localbuffer,
   $offlinebuffer                   = $zabbix::params::proxy_offlinebuffer,
   $heartbeatfrequency              = $zabbix::params::proxy_heartbeatfrequency,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -83,6 +83,17 @@
 # [*database_port*]
 #   Database port when not using local socket. Ignored for sqlite.
 #
+# [*database_tlsconnect*]
+#   Setting this option enforces the use of TLS on connection to the database:
+#   required - connect using TLS
+#   verify_ca - connect using TLS and verify certificate
+#   verify_full - connect using TLS, verify certificate and verify that database identity specified by DBHost matches its certificate
+#   This parameter is supported since Zabbix 5.0.0.
+#
+# [*database_tlscafile*]
+#   Full pathname of a file containing the top-level CA(s) certificates for database certificate verification.
+#   This parameter is supported since Zabbix 5.0.0.
+#
 # [*startpollers*]
 #   Number of pre-forked instances of pollers.
 #
@@ -323,6 +334,8 @@ class zabbix::server (
   $database_password                         = $zabbix::params::server_database_password,
   $database_socket                           = $zabbix::params::server_database_socket,
   $database_port                             = $zabbix::params::server_database_port,
+  $database_tlsconnect                       = $zabbix::params::server_database_tlsconnect,
+  $database_tlscafile                        = $zabbix::params::server_database_tlscafile,
   $startpollers                              = $zabbix::params::server_startpollers,
   $startipmipollers                          = $zabbix::params::server_startipmipollers,
   $startpollersunreachable                   = $zabbix::params::server_startpollersunreachable,

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -215,6 +215,8 @@ class zabbix::web (
   $database_password                                                  = $zabbix::params::server_database_password,
   $database_socket                                                    = $zabbix::params::server_database_socket,
   $database_port                                                      = $zabbix::params::server_database_port,
+  $database_tlsconnect                                                = $zabbix::params::server_database_tlsconnect,
+  $database_tlscafile                                                 = $zabbix::params::server_database_tlscafile,
   $zabbix_server                                                      = $zabbix::params::zabbix_server,
   Optional[String] $zabbix_server_name                                = $zabbix::params::zabbix_server,
   $zabbix_listenport                                                  = $zabbix::params::server_listenport,

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -124,6 +124,8 @@ DBUser=<%= @database_user %>
 #	Comment this line if no password is used.
 #
 DBPassword=<%= @database_password %>
+<% if @database_tlsconnect %>DBTLSConnect=<%= @database_tlsconnect %><% end %>
+<% if @database_tlscafile %>DBTLSCAFile=<%= @database_tlscafile %><% end %>
 
 ### Option: DBSocket
 #	Path to MySQL socket.

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -105,6 +105,8 @@ DBUser=<%= @database_user %>
 #	Comment this line if no password is used.
 #
 DBPassword=<%= @database_password %>
+<% if @database_tlsconnect %>DBTLSConnect=<%= @database_tlsconnect %><% end %>
+<% if @database_tlscafile %>DBTLSCAFile=<%= @database_tlscafile %><% end %>
 
 ### Option: DBSocket
 #	Path to MySQL socket.


### PR DESCRIPTION
Adds new zabbix server & proxy parameters for TLS connection to the database

Does not deploy the cafile - that is left as a manual task for now.