### PR TITLE
new param to specify database import timeout

### DIFF
--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -16,14 +16,16 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix::database::mysql (
-  $zabbix_type          = '',
-  $zabbix_version       = $zabbix::params::zabbix_version,
-  $database_schema_path = '',
-  $database_name        = '',
-  $database_user        = '',
-  $database_password    = '',
-  $database_host        = '',
-  $database_path        = $zabbix::params::database_path,
+  $zabbix_type                = '',
+  $zabbix_version             = $zabbix::params::zabbix_version,
+  $database_schema_path       = '',
+  $database_name              = '',
+  $database_user              = '',
+  $database_password          = '',
+  $database_host              = '',
+  $database_path              = $zabbix::params::database_path,
+  $database_import_timeout    = $zabbix::params::database_import_timeout,
+
 ) inherits zabbix::params {
   assert_private()
 
@@ -84,6 +86,7 @@ class zabbix::database::mysql (
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.schema.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
       }
     }
     'server' : {
@@ -92,18 +95,21 @@ class zabbix::database::mysql (
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.schema.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
       }
       -> exec { 'zabbix_server_images.sql':
         command  => $zabbix_server_images_sql,
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.images.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
       }
       -> exec { 'zabbix_server_data.sql':
         command  => $zabbix_server_data_sql,
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.data.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
       }
     }
     default  : {

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -16,14 +16,15 @@
 # Copyright 2014 Werner Dijkerman
 #
 class zabbix::database::postgresql (
-  $zabbix_type          = '',
-  $zabbix_version       = $zabbix::params::zabbix_version,
-  $database_schema_path = '',
-  $database_name        = '',
-  $database_user        = '',
-  $database_password    = '',
-  $database_host        = '',
-  $database_path        = $zabbix::params::database_path,
+  $zabbix_type                = '',
+  $zabbix_version             = $zabbix::params::zabbix_version,
+  $database_schema_path       = '',
+  $database_name              = '',
+  $database_user              = '',
+  $database_password          = '',
+  $database_host              = '',
+  $database_path              = $zabbix::params::database_path,
+  $database_import_timeout    = $zabbix::params::database_import_timeout,
 ) inherits zabbix::params {
   assert_private()
 
@@ -104,6 +105,7 @@ class zabbix::database::postgresql (
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.schema.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
         require  => Exec['update_pgpass'],
       }
     }
@@ -113,6 +115,7 @@ class zabbix::database::postgresql (
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.schema.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
         require  => Exec['update_pgpass'],
       }
       -> exec { 'zabbix_server_images.sql':
@@ -120,6 +123,7 @@ class zabbix::database::postgresql (
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.images.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
         require  => Exec['update_pgpass'],
       }
       -> exec { 'zabbix_server_data.sql':
@@ -127,6 +131,7 @@ class zabbix::database::postgresql (
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.data.done',
         provider => 'shell',
+        timeout  => $database_import_timeout,
         require  => Exec['update_pgpass'],
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -169,6 +169,7 @@ class zabbix::params {
   $manage_resources                         = false
   $manage_vhost                             = true
   $database_path                            = '/usr/sbin'
+  $database_import_timeout                  = '600'
   $database_schema_path                     = false
   $database_type                            = 'postgresql'
   $apache_php_always_populate_raw_post_data = '-1'


### PR DESCRIPTION
Configures a timeout param for the database import execs. The default timeout of 300 seconds causes database creation to fail on some systems. Have set default to 600, but haven't tested to determine the optimal value.

fixes #667