### PR TITLE
Fix for apache config for Zabbix 5.0 and CentOS 7

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -105,6 +105,12 @@ class zabbix::repo (
               gpgkey   => $gpgkey_zabbix,
               priority => '1',
             }
+            #scl repos are required for Zabbix 5 on EL7
+            if $facts['os']['name'] == 'CentOS' {
+              package { 'centos-release-scl':
+                ensure => present,
+              }
+            }
           }
         }
       }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -92,6 +92,21 @@ class zabbix::repo (
           gpgkey   => $gpgkey_nonsupported,
           priority => '1',
         }
+
+        # Zabbix 5.0 for Centos/RHEL 7 puts the frontend packages in a separate repo called frontend
+        # under the main repo due to the php 7.2 requirement
+        if defined('zabbix::web') {
+          if versioncmp($facts['os']['release']['major'], '7') == 0 and versioncmp($zabbix_version, '5') >= 0 {
+            yumrepo { 'zabbix-frontend':
+              name     => "Zabbix_${majorrelease}_${facts['os']['architecture']}_frontend",
+              descr    => "Zabbix_${majorrelease}_${facts['os']['architecture']}_frontend",
+              baseurl  => "${_repo_location}/frontend",
+              gpgcheck => '1',
+              gpgkey   => $gpgkey_zabbix,
+              priority => '1',
+            }
+          }
+        }
       }
       'Debian' : {
         if ($manage_apt) {

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -369,7 +369,6 @@ class zabbix::web (
         require => Class['zabbix::repo'],
         tag     => 'zabbix',
       }
-
     }
   } # END case $facts['os']['name']
 
@@ -401,7 +400,7 @@ class zabbix::web (
   # Is set to true, it will create the apache vhost.
   if $manage_vhost {
     include apache
-    if facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') == 0 and versioncmp($zabbix_version, '5') >= 0 {
+    if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') == 0 and versioncmp($zabbix_version, '5') >= 0 {
       include apache::mod::proxy
       include apache::mod::proxy_fcgi
       $apache_vhost_custom_fragment = ''

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -410,17 +410,17 @@ class zabbix::web (
         content => epp('zabbix/web/php-fpm.d.zabbix.conf.epp'),
       }
       $fcgi_filematch = {
-          path     => '/usr/share/zabbix',
-          provider => 'directory',
-          addhandlers => [
-            {
-              extensions => [
-                'php',
-                'phar',
-              ],
-              handler => 'proxy:unix:/var/opt/rh/rh-php72/run/php-fpm/zabbix.sock|fcgi://localhost',
-            },
-          ],
+        path     => '/usr/share/zabbix',
+        provider => 'directory',
+        addhandlers => [
+          {
+            extensions => [
+              'php',
+              'phar',
+            ],
+            handler => 'proxy:unix:/var/opt/rh/rh-php72/run/php-fpm/zabbix.sock|fcgi://localhost',
+          },
+        ],
       }
       $proxy_directory = {
         path => 'fcgi://localhost:9000',
@@ -488,13 +488,13 @@ class zabbix::web (
         $proxy_directory,
         merge(
           merge( {
-            path     => '/usr/share/zabbix',
-            provider => 'directory',
+              path     => '/usr/share/zabbix',
+              provider => 'directory',
           }, $directory_allow),
         $fcgi_filematch),
         merge( {
-          path     => '/usr/share/zabbix/conf',
-          provider => 'directory',
+            path     => '/usr/share/zabbix/conf',
+            provider => 'directory',
         }, $directory_deny),
         merge( {
             path     => '/usr/share/zabbix/api',
@@ -512,7 +512,7 @@ class zabbix::web (
       aliases         => [
         { alias => '/zabbix',
           path  => '/usr/share/zabbix',
-        }
+        },
       ],
       custom_fragment => $apache_vhost_custom_fragment,
       rewrites        => [

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -337,37 +337,27 @@ class zabbix::web (
         ],
       }
     }
-    'CentOS': {
+    'CentOS', 'RedHat': {
       if versioncmp($facts['os']['release']['major'], '7') == 0 and versioncmp($zabbix_version, '5') >= 0 {
         #fix for rh-php72
         $zabbix_web_package = 'zabbix-web'
+
         package { "zabbix-web-${db}-scl":
           ensure  => $zabbix_package_state,
           before  => Package[$zabbix_web_package],
           require => Class['zabbix::repo'],
           tag     => 'zabbix',
         }
+      }
+      else {
+        $zabbix_web_package = 'zabbix-web'
 
-        include apache::mod::proxy
-        include apache::mod::proxy_fcgi
-        $apache_vhost_custom_fragment = ''
-      }
-      $fcgi_filematch = {
-          path     => '/usr/share/zabbix',
-          provider => 'directory',
-          addhandlers => [
-            {
-              extensions => [
-                'php',
-                'phar',
-              ],
-              handler => 'proxy:unix:/var/opt/rh/rh-php72/run/php-fpm/zabbix.sock|fcgi://localhost',
-            },
-          ],
-      }
-      $proxy_directory = {
-        path => 'fcgi://localhost:9000',
-        provider => 'proxy',
+        package { "zabbix-web-${db}":
+          ensure  => $zabbix_package_state,
+          before  => Package[$zabbix_web_package],
+          require => Class['zabbix::repo'],
+          tag     => 'zabbix',
+        }
       }
     }
     default: {
@@ -380,18 +370,6 @@ class zabbix::web (
         tag     => 'zabbix',
       }
 
-      $apache_vhost_custom_fragment = "
-   php_value max_execution_time ${apache_php_max_execution_time}
-   php_value memory_limit ${apache_php_memory_limit}
-   php_value post_max_size ${apache_php_post_max_size}
-   php_value upload_max_filesize ${apache_php_upload_max_filesize}
-   php_value max_input_time ${apache_php_max_input_time}
-   php_value always_populate_raw_post_data ${apache_php_always_populate_raw_post_data}
-   php_value max_input_vars ${apache_php_max_input_vars}
-   # Set correct timezone
-   php_value date.timezone ${zabbix_timezone}"
-    $fcgi_filematch = {}
-    $proxy_directory = {}
     }
   } # END case $facts['os']['name']
 
@@ -423,6 +401,47 @@ class zabbix::web (
   # Is set to true, it will create the apache vhost.
   if $manage_vhost {
     include apache
+    if facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') == 0 and versioncmp($zabbix_version, '5') >= 0 {
+      include apache::mod::proxy
+      include apache::mod::proxy_fcgi
+      $apache_vhost_custom_fragment = ''
+      #php parameters are moved to /etc/opt/rh/rh-php72/php-fpm.d/zabbix.conf per package zabbix-web-deps-scl
+      file { '/etc/opt/rh/rh-php72/php-fpm.d/zabbix.conf':
+        ensure  => file,
+        content => epp('zabbix/web/php-fpm.d.zabbix.conf.epp'),
+      }
+      $fcgi_filematch = {
+          path     => '/usr/share/zabbix',
+          provider => 'directory',
+          addhandlers => [
+            {
+              extensions => [
+                'php',
+                'phar',
+              ],
+              handler => 'proxy:unix:/var/opt/rh/rh-php72/run/php-fpm/zabbix.sock|fcgi://localhost',
+            },
+          ],
+      }
+      $proxy_directory = {
+        path => 'fcgi://localhost:9000',
+        provider => 'proxy',
+      }
+    }
+    else {
+      $apache_vhost_custom_fragment = "
+        php_value max_execution_time ${apache_php_max_execution_time}
+        php_value memory_limit ${apache_php_memory_limit}
+        php_value post_max_size ${apache_php_post_max_size}
+        php_value upload_max_filesize ${apache_php_upload_max_filesize}
+        php_value max_input_time ${apache_php_max_input_time}
+        php_value always_populate_raw_post_data ${apache_php_always_populate_raw_post_data}
+        php_value max_input_vars ${apache_php_max_input_vars}
+        # Set correct timezone
+        php_value date.timezone ${zabbix_timezone}"
+      $fcgi_filematch = {}
+      $proxy_directory = {}
+    }
     # Check if we use ssl. If so, we also create an non ssl
     # vhost for redirect traffic from non ssl to ssl site.
     if $apache_use_ssl {
@@ -469,12 +488,12 @@ class zabbix::web (
       directories     => [
         $proxy_directory,
         merge(
-          merge({
+          merge( {
             path     => '/usr/share/zabbix',
             provider => 'directory',
           }, $directory_allow),
         $fcgi_filematch),
-        merge({
+        merge( {
           path     => '/usr/share/zabbix/conf',
           provider => 'directory',
         }, $directory_deny),

--- a/spec/acceptance/web_spec.rb
+++ b/spec/acceptance/web_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper_acceptance'
+
+def frontend_supported(version)
+  return version != ('2.4'||'5.0') if default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64}
+  return version >= '4.0' if default[:platform] =~ %r{debian-10-amd64}
+  true
+end
+
+['2.4', '3.2', '3.4', '4.0', '4.2', '4.4', '5.0'].each do |version|
+  describe "zabbix::web class with zabbix_version #{version}", if: frontend_supported(version) do
+    case fact('os.family')
+    when 'RedHat'
+      apache_package = 'httpd'
+      apache_service = 'httpd'
+    when 'Debian'
+      apache_package = 'apache2'
+      apache_service = 'apache2'
+    end
+
+    it 'works idempotently with no errors' do
+
+      pp = <<-EOS
+        class { 'apache':
+          mpm_module => 'prefork',
+        }
+        include apache::mod::php
+        class { 'zabbix::web':
+          zabbix_version => '#{version}',
+          require        => Class['apache'],
+        }
+      EOS
+
+      prepare_host
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    # do some basic checks
+    describe 'ensure packages installed' do
+
+      it { is_expected.to contain_package(apache_package) }
+
+      pgsqlpackage = case fact('operatingsystem')
+      when 'Ubuntu'
+        if fact('os.release.major') >= '16.04'
+          'php-pgsql'
+        else
+          'php5-pgsql'
+        end
+      when 'Debian'
+        if fact('os.release.major').to_i >= 9
+          'php-pgsql'
+        else
+          'php5-pgsql'
+        end
+      else
+        'php5-pgsql'
+      end
+
+      if default[:platform] =~ %r{el-7-amd64}
+        if :version == '5.0'
+          packages = ['zabbix-web-pgsql-scl', 'zabbix-web']
+        else
+          packages = ['zabbix-web-pgsql', 'zabbix-web']
+        end
+      else
+          packages = ['zabbix-frontend-php', pgsqlpackage]
+      end
+      packages.each do |package|
+        it { is_expected.to contain_package(package) }
+      end
+    end
+
+    describe service(apache_service) do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
+    context 'Zabbix frontend should be running on port 80 with an appropriate php handler' do
+
+      describe port(80) do
+        it { should be_listening }
+      end
+
+      describe command('curl http://localhost:80') do
+        its(:stdout) { should match /!DOCTYPE html/ }
+      end
+    end
+
+  end
+end

--- a/spec/acceptance/web_spec.rb
+++ b/spec/acceptance/web_spec.rb
@@ -32,7 +32,8 @@ end
 
       prepare_host
 
-      # Run it twice and test for idempotency
+      # Works without changes on the third apply
+      apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_failures: true)
       apply_manifest(pp, catch_changes: true)
     end
@@ -84,6 +85,7 @@ end
         it { should be_listening }
       end
 
+      #if this comes back as <?php, the php handler for the frontend is not configured correctly
       describe command('curl http://localhost:80') do
         its(:stdout) { should match /!DOCTYPE html/ }
       end

--- a/spec/acceptance/web_spec.rb
+++ b/spec/acceptance/web_spec.rb
@@ -1,21 +1,13 @@
 require 'spec_helper_acceptance'
 
 def frontend_supported(version)
-  return version != ('2.4'||'5.0') if default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64}
+  return version >= '2.4' && version < '5.0' if default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64}
   return version >= '4.0' if default[:platform] =~ %r{debian-10-amd64}
   true
 end
 
 ['2.4', '3.2', '3.4', '4.0', '4.2', '4.4', '5.0'].each do |version|
   describe "zabbix::web class with zabbix_version #{version}", if: frontend_supported(version) do
-    case fact('os.family')
-    when 'RedHat'
-      apache_package = 'httpd'
-      apache_service = 'httpd'
-    when 'Debian'
-      apache_package = 'apache2'
-      apache_service = 'apache2'
-    end
 
     it 'works idempotently with no errors' do
 
@@ -40,8 +32,6 @@ end
 
     # do some basic checks
     describe 'ensure packages installed' do
-
-      it { is_expected.to contain_package(apache_package) }
 
       pgsqlpackage = case fact('operatingsystem')
       when 'Ubuntu'
@@ -72,11 +62,6 @@ end
       packages.each do |package|
         it { is_expected.to contain_package(package) }
       end
-    end
-
-    describe service(apache_service) do
-      it { is_expected.to be_running }
-      it { is_expected.to be_enabled }
     end
 
     context 'Zabbix frontend should be running on port 80 with an appropriate php handler' do

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -218,14 +218,14 @@ describe 'zabbix::web' do
             context 'when zabbix_version is 5.0 and OS is CentOS 7 validate php-fpm.d configuration'
               let :params do
                 super().merge(
-                  apache_php_max_execution_time: '300'
-                  apache_php_memory_limit: '128M'
-                  apache_php_post_max_size: '16M'
-                  apache_php_upload_max_filesize: '2M'
-                  apache_php_max_input_time: '300'
-                  apache_php_always_populate_raw_post_data: '-1'
-                  apache_php_max_input_vars: 10000
-                  zabbix_timezone: 'America/New_York'
+                  apache_php_max_execution_time: '300',
+                  apache_php_memory_limit: '128M',
+                  apache_php_post_max_size: '16M',
+                  apache_php_upload_max_filesize: '2M',
+                  apache_php_max_input_time: '300',
+                  apache_php_always_populate_raw_post_data: '-1',
+                  apache_php_max_input_vars: 10000,
+                  zabbix_timezone: 'America/New_York',
                   zabbix_version: '5.0'
                 )
               end

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -75,7 +75,7 @@ describe 'zabbix::web' do
                            'php5-pgsql'
                          end
 
-          packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-pgsql', 'zabbix-web'] : ['zabbix-frontend-php', pgsqlpackage]
+          packages = (facts[:operatingsystem] == 'CentOS' and facts[:operatingsystemmajrelease] == 7 and :zabbix_version >= 5) ? ['zabbix-web-pgsql-scl', 'zabbix-web'] : (facts[:osfamily] == 'RedHat' ? ['zabbix-web-pgsql', 'zabbix-web'] : ['zabbix-frontend-php', pgsqlpackage])
           packages.each do |package|
             it { is_expected.to contain_package(package) }
           end
@@ -104,7 +104,7 @@ describe 'zabbix::web' do
                            'php5-mysql'
                          end
 
-          packages = facts[:osfamily] == 'RedHat' ? ['zabbix-web-mysql', 'zabbix-web'] : ['zabbix-frontend-php', mysqlpackage]
+          packages = (facts[:operatingsystem] == 'CentOS' and facts[:operatingsystemmajrelease] == 7 and :zabbix_version >= 5) ? ['zabbix-web-mysql-scl', 'zabbix-web'] : (facts[:osfamily] == 'RedHat' ? ['zabbix-web-mysql', 'zabbix-web'] : ['zabbix-frontend-php', pgsqlpackage])
           packages.each do |package|
             it { is_expected.to contain_package(package) }
           end

--- a/spec/support/acceptance/prepare_host.rb
+++ b/spec/support/acceptance/prepare_host.rb
@@ -10,7 +10,15 @@ def prepare_host
   cleanup_script = <<-SHELL
   /opt/puppetlabs/bin/puppet resource service zabbix-server ensure=stopped
   /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged
+  /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql-scl ensure=purged
+  /opt/puppetlabs/bin/puppet resource package zabbix-web ensure=purged
+  /opt/puppetlabs/bin/puppet resource package zabbix-frontend-php ensure=purged
+  /opt/puppetlabs/bin/puppet resource package apache2 ensure=purged
+  /opt/puppetlabs/bin/puppet resource package httpd ensure=purged
   rm -f /etc/zabbix/.*done
+  rm -rf /etc/httpd
+  rm -rf /etc/apache2
+  rm -rf /var/www
   if id postgres > /dev/null 2>&1; then
     su - postgres -c "psql -c 'drop database if exists zabbix_server;'"
   fi

--- a/templates/web/php-fpm.d.zabbix.conf.epp
+++ b/templates/web/php-fpm.d.zabbix.conf.epp
@@ -16,12 +16,12 @@ pm.max_spare_servers = 35
 php_value[session.save_handler] = files
 php_value[session.save_path]    = /var/opt/rh/rh-php72/lib/php/session/
 
-php_value max_execution_time <%= $apache_php_max_execution_time %>
-php_value memory_limit <%= $apache_php_memory_limit %>
-php_value post_max_size <%= $apache_php_post_max_size %>
-php_value upload_max_filesize <%= $apache_php_upload_max_filesize %>
-php_value max_input_time <%= $apache_php_max_input_time %>
-php_value always_populate_raw_post_data <%= $apache_php_always_populate_raw_post_data %>
-php_value max_input_vars <%= $apache_php_max_input_vars %>
+php_value max_execution_time <%= $zabbix::web::apache_php_max_execution_time %>
+php_value memory_limit <%= $zabbix::web::apache_php_memory_limit %>
+php_value post_max_size <%= $zabbix::web::apache_php_post_max_size %>
+php_value upload_max_filesize <%= $zabbix::web::apache_php_upload_max_filesize %>
+php_value max_input_time <%= $zabbix::web::apache_php_max_input_time %>
+php_value always_populate_raw_post_data <%= $zabbix::web::apache_php_always_populate_raw_post_data %>
+php_value max_input_vars <%= $zabbix::web::apache_php_max_input_vars %>
 # Set correct timezone
-php_value date.timezone <%= $zabbix_timezone %>
+php_value date.timezone <%= $zabbix::web::zabbix_timezone %>

--- a/templates/web/php-fpm.d.zabbix.conf.epp
+++ b/templates/web/php-fpm.d.zabbix.conf.epp
@@ -1,0 +1,26 @@
+[zabbix]
+user = apache
+group = apache
+
+listen = /var/opt/rh/rh-php72/run/php-fpm/zabbix.sock
+listen.acl_users = apache
+listen.allowed_clients = 127.0.0.1
+
+pm = dynamic
+pm.max_children = 50
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 35
+
+php_value[session.save_handler] = files
+php_value[session.save_path]    = /var/opt/rh/rh-php72/lib/php/session/
+
+php_value max_execution_time <%= $apache_php_max_execution_time %>
+php_value memory_limit <%= $apache_php_memory_limit %>
+php_value post_max_size <%= $apache_php_post_max_size %>
+php_value upload_max_filesize <%= $apache_php_upload_max_filesize %>
+php_value max_input_time <%= $apache_php_max_input_time %>
+php_value always_populate_raw_post_data <%= $apache_php_always_populate_raw_post_data %>
+php_value max_input_vars <%= $apache_php_max_input_vars %>
+# Set correct timezone
+php_value date.timezone <%= $zabbix_timezone %>

--- a/templates/web/php-fpm.d.zabbix.conf.epp
+++ b/templates/web/php-fpm.d.zabbix.conf.epp
@@ -1,3 +1,4 @@
+# THIS FILE IS MANAGED BY PUPPET
 [zabbix]
 user = apache
 group = apache


### PR DESCRIPTION
Changes the apache::vhost configuration to work with the changes in Zabbix 5.0 regarding minimum PHP version and CentOS 7 by utilizing the up-to-date package names for the official packages.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR makes changes to support the updated frontend configuration required as detailed in the official documentation: https://www.zabbix.com/documentation/current/manual/installation/frontend/frontend_on_rhel7

The test portion is kind of sketchy without re-writing the entire spec to test for specific values of zabbix_version, however, will hopefully work correctly if the default zabbix_version changes.

#### This Pull Request (PR) fixes the following issues
n/a 
