### PR TITLE
Fix $hostinterfaceitem to not be an Fqdn.

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -275,7 +275,7 @@ class zabbix::agent (
   $hostmetadata                                   = $zabbix::params::agent_hostmetadata,
   $hostmetadataitem                               = $zabbix::params::agent_hostmetadataitem,
   Optional[Stdlib::Fqdn] $hostinterface           = $zabbix::params::agent_hostinterface,
-  Optional[Stdlib::Fqdn] $hostinterfaceitem       = $zabbix::params::agent_hostinterfaceitem,
+  $hostinterfaceitem                              = $zabbix::params::agent_hostinterfaceitem,
   $refreshactivechecks                            = $zabbix::params::agent_refreshactivechecks,
   $buffersend                                     = $zabbix::params::agent_buffersend,
   $buffersize                                     = $zabbix::params::agent_buffersize,


### PR DESCRIPTION
#### Pull Request (PR) description
As per #725 and the [upstream documentation](https://www.zabbix.com/documentation/5.0/manual/appendix/config/zabbix_agentd), `zabbix::agent::hostinterfaceitem` should not be an FQDN as it refers to a Zabbix item.

I did not set a type, to match the similar `$hostmetadataitem`. Let me know if I should instead set it to be something like `Optional[String]`.

#### This Pull Request (PR) fixes the following issues
Fixes #725
