### PR TITLE
Bugfixes

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -256,6 +256,7 @@ class zabbix::params {
   $server_sshkeylocation                    = undef
   $server_sslcertlocation                   = '/usr/lib/zabbix/ssl/certs'
   $server_sslkeylocation                    = '/usr/lib/zabbix/ssl/keys'
+  $server_sslcalocation                     = undef
   $server_startdbsyncers                    = '4'
   $server_startdiscoverers                  = '1'
   $server_starthttppollers                  = '1'
@@ -267,6 +268,7 @@ class zabbix::params {
   $server_startproxypollers                 = '1'
   $server_startsnmptrapper                  = '0'
   $server_starttimers                       = '1'
+  $server_startescalators                   = '1'
   $server_starttrappers                     = '5'
   $server_startvmwarecollectors             = '0'
   $server_timeout                           = '3'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -418,7 +418,7 @@ class zabbix::params {
   $proxy_tmpdir                             = '/tmp'
   $proxy_trappertimeout                     = '300'
   $proxy_unavailabledelay                   = '60'
-  $proxy_unreachabedelay                    = '15'
+  $proxy_unreachabledelay                    = '15'
   $proxy_unreachableperiod                  = '45'
   $proxy_use_ip                             = true
   $proxy_vmwarecachesize                    = '8M'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -417,7 +417,7 @@ class zabbix::params {
   $proxy_tlsservercertsubject               = undef
   $proxy_tmpdir                             = '/tmp'
   $proxy_trappertimeout                     = '300'
-  $proxy_unavaliabledelay                   = '60'
+  $proxy_unavailabledelay                   = '60'
   $proxy_unreachabedelay                    = '15'
   $proxy_unreachableperiod                  = '45'
   $proxy_use_ip                             = true

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -415,7 +415,7 @@ class zabbix::proxy (
   $trappertimeout                           = $zabbix::params::proxy_trappertimeout,
   $unreachableperiod                        = $zabbix::params::proxy_unreachableperiod,
   $unavailabledelay                         = $zabbix::params::proxy_unavailabledelay,
-  $unreachabedelay                          = $zabbix::params::proxy_unreachabedelay,
+  $unreachabledelay                          = $zabbix::params::proxy_unreachabledelay,
   $externalscripts                          = $zabbix::params::proxy_externalscripts,
   $fpinglocation                            = $zabbix::params::proxy_fpinglocation,
   $fping6location                           = $zabbix::params::proxy_fping6location,

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -414,7 +414,7 @@ class zabbix::proxy (
   $tlsservercertsubject                     = $zabbix::params::proxy_tlsservercertsubject,
   $trappertimeout                           = $zabbix::params::proxy_trappertimeout,
   $unreachableperiod                        = $zabbix::params::proxy_unreachableperiod,
-  $unavaliabledelay                         = $zabbix::params::proxy_unavaliabledelay,
+  $unavailabledelay                         = $zabbix::params::proxy_unavailabledelay,
   $unreachabedelay                          = $zabbix::params::proxy_unreachabedelay,
   $externalscripts                          = $zabbix::params::proxy_externalscripts,
   $fpinglocation                            = $zabbix::params::proxy_fpinglocation,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -107,6 +107,9 @@
 # [*starttimers*]
 #   Number of pre-forked instances of timers.
 #
+# [*startescalators*]
+#   Number of pre-forked instances of escalators.
+#
 # [*javagateway*]
 #   IP address (or hostname) of zabbix java gateway.
 #
@@ -258,6 +261,9 @@
 # [*sslkeylocation_dir*]
 #   Location of SSL private key files for client authentication.
 #
+# [*sslcalocation_dir*]
+#   Override the location of certificate authority (CA) files for SSL server certificate verification.
+#
 # [*manage_startup_script*]
 #  If the init script should be managed by this module. Attention: This might cause problems with some config options of this module (e.g server_configfile_path)
 #
@@ -335,6 +341,7 @@ class zabbix::server (
   $startdiscoverers                          = $zabbix::params::server_startdiscoverers,
   $starthttppollers                          = $zabbix::params::server_starthttppollers,
   $starttimers                               = $zabbix::params::server_starttimers,
+  $startescalators                           = $zabbix::params::server_startescalators,
   $javagateway                               = $zabbix::params::server_javagateway,
   $javagatewayport                           = $zabbix::params::server_javagatewayport,
   $startjavapollers                          = $zabbix::params::server_startjavapollers,
@@ -383,6 +390,7 @@ class zabbix::server (
   $loadmodule                                = $zabbix::params::server_loadmodule,
   $sslcertlocation_dir                       = $zabbix::params::server_sslcertlocation,
   $sslkeylocation_dir                        = $zabbix::params::server_sslkeylocation,
+  $sslcalocation_dir                         = $zabbix::params::server_sslcalocation
   Boolean $manage_selinux                    = $zabbix::params::manage_selinux,
   String $additional_service_params          = $zabbix::params::additional_service_params,
   Optional[String[1]] $zabbix_user           = $zabbix::params::server_zabbix_user,

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -260,7 +260,7 @@ describe 'zabbix::proxy' do
               timeout: '20',
               tmpdir: '/tmp',
               trappertimeout: '16',
-              unavaliabledelay: '60',
+              unavailabledelay: '60',
               unreachabedelay: '15',
               unreachableperiod: '45',
               vmwarecachesize: '8M',

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -261,7 +261,7 @@ describe 'zabbix::proxy' do
               tmpdir: '/tmp',
               trappertimeout: '16',
               unavailabledelay: '60',
-              unreachabedelay: '15',
+              unreachabledelay: '15',
               unreachableperiod: '45',
               vmwarecachesize: '8M',
               vmwarefrequency: '60',

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -372,12 +372,12 @@ UnreachablePeriod=<%= @unreachableperiod %>
 ### Option: UnavailableDelay
 #	How often host is checked for availability during the unavailability period, in seconds.
 #
-UnavailableDelay=<%= @unavaliabledelay %>
+UnavailableDelay=<%= @unavailabledelay %>
 
 ### Option: UnreachableDelay
 #	How often host is checked for availability during the unreachability period, in seconds.
 #
-UnreachableDelay=<%= @unreachabedelay %>
+UnreachableDelay=<%= @unreachabledelay %>
 
 ### Option: ExternalScripts
 #	Full path to location of external scripts.


### PR DESCRIPTION
Update server.pp to allow setting 'startescalators' and 'sslcalocation_dir' variables
Update proxy.pp to correct spellings of 'unavailabledelay' and 'unreachabledelay' variables

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues

Fixes #340
