### PR TITLE
Bump zabbixapi version

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -276,8 +276,11 @@ class zabbix::web (
       '3.2' : {
         $zabbixapi_version = '3.2.1'
       }
-      default : {
+      '3.4' : {
         $zabbixapi_version = '4.0.0'
+      }
+      default : {
+        $zabbixapi_version = '4.2.0'
       }
     }
 

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -20,7 +20,7 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{debian-10-a
       include postgresql::server
 
       class { 'zabbix':
-        zabbix_version   => '3.0',
+        zabbix_version   => '4.0', # Only run tests on LTS releases.
         zabbix_url       => 'localhost',
         zabbix_api_user  => 'Admin',
         zabbix_api_pass  => 'zabbix',

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -20,7 +20,7 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{debian-10-a
       include postgresql::server
 
       class { 'zabbix':
-        zabbix_version   => '4.0', # Only run tests on LTS releases.
+        zabbix_version   => '4.4',
         zabbix_url       => 'localhost',
         zabbix_api_user  => 'Admin',
         zabbix_api_pass  => 'zabbix',
@@ -33,7 +33,7 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{debian-10-a
 
     pp2 = <<-EOS
       zabbix_application { 'TestApplication1':
-        template => 'Template OS Linux',
+        template => 'Template OS Linux by Zabbix agent',
       }
     EOS
     # setup zabbix. Apache module isn't idempotent and requires a second run
@@ -62,9 +62,9 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{debian-10-a
   end
 
   context 'TestApplication1' do
-    let(:template1) { result_templates.select { |t| t['host'] == 'Template OS Linux' }.first }
+    let(:template1) { result_templates.select { |t| t['host'] == 'Template OS Linux by Zabbix agent' }.first }
 
-    it 'is attached to Template OS Linux' do
+    it 'is attached to Template OS Linux by Zabbix agent' do
       expect(template1['applications'].map { |a| a['name'] }).to include('TestApplication1')
     end
   end

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -56,7 +56,7 @@ zabbix_host { 'test2.example.com':
   use_ip    => false,
   port      => 1050,
   groups    => ['Virtual machines'],
-  templates => [ 'Template OS Linux', 'Template ICMP Ping', ],
+  templates => [ 'Template OS Linux', 'Template Module ICMP Ping', ],
   macros    => [],
 }
     EOS
@@ -134,7 +134,7 @@ zabbix_host { 'test2.example.com':
         expect(test2['interfaces'][0]['useip']).to eq('0')
       end
       it 'has templates attached' do
-        expect(test2['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template ICMP Ping', 'Template OS Linux'])
+        expect(test2['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template Module ICMP Ping', 'Template OS Linux'])
       end
     end
   end

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -20,7 +20,7 @@ include apache::mod::php
 include postgresql::server
 
 class { 'zabbix':
-  zabbix_version   => '4.0', # Only run tests on LTS releases.
+  zabbix_version   => '4.4',
   zabbix_url       => 'localhost',
   zabbix_api_user  => 'Admin',
   zabbix_api_pass  => 'zabbix',
@@ -48,7 +48,7 @@ zabbix_host { 'test1.example.com':
   port         => 10050,
   groups       => ['TestgroupOne'],
   group_create => true,
-  templates    => [ 'Template OS Linux', ],
+  templates    => [ 'Template OS Linux by Zabbix agent', ],
   macros       => [],
 }
 zabbix_host { 'test2.example.com':
@@ -56,7 +56,7 @@ zabbix_host { 'test2.example.com':
   use_ip    => false,
   port      => 1050,
   groups    => ['Virtual machines'],
-  templates => [ 'Template OS Linux', 'Template Module ICMP Ping', ],
+  templates => [ 'Template OS Linux by Zabbix agent', 'Template Module ICMP Ping', ],
   macros    => [],
 }
     EOS
@@ -102,7 +102,7 @@ zabbix_host { 'test2.example.com':
         expect(test1['interfaces'][0]['useip']).to eq('1')
       end
       it 'has templates attached' do
-        expect(test1['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template OS Linux'])
+        expect(test1['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template OS Linux by Zabbix agent'])
       end
     end
 
@@ -134,7 +134,7 @@ zabbix_host { 'test2.example.com':
         expect(test2['interfaces'][0]['useip']).to eq('0')
       end
       it 'has templates attached' do
-        expect(test2['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template Module ICMP Ping', 'Template OS Linux'])
+        expect(test2['parentTemplates'].map { |t| t['host'] }.sort).to eq(['Template Module ICMP Ping', 'Template OS Linux by Zabbix agent'])
       end
     end
   end

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -20,7 +20,7 @@ include apache::mod::php
 include postgresql::server
 
 class { 'zabbix':
-  zabbix_version   => '3.0',
+  zabbix_version   => '4.0', # Only run tests on LTS releases.
   zabbix_url       => 'localhost',
   zabbix_api_user  => 'Admin',
   zabbix_api_pass  => 'zabbix',

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -15,7 +15,7 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{debian-10-amd
         include postgresql::server
 
         class { 'zabbix':
-          zabbix_version   => '4.0', # Only run tests on LTS releases.
+          zabbix_version   => '4.4',
           zabbix_url       => 'localhost',
           zabbix_api_user  => 'Admin',
           zabbix_api_pass  => 'zabbix',

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -15,7 +15,7 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{debian-10-amd
         include postgresql::server
 
         class { 'zabbix':
-          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_version   => '4.0', # Only run tests on LTS releases.
           zabbix_url       => 'localhost',
           zabbix_api_user  => 'Admin',
           zabbix_api_pass  => 'zabbix',

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -20,7 +20,7 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{debian-10-amd64} 
       include postgresql::server
 
       class { 'zabbix':
-        zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+        zabbix_version   => '4.0', # Only run tests on LTS releases.
         zabbix_url       => 'localhost',
         zabbix_api_user  => 'Admin',
         zabbix_api_pass  => 'zabbix',

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -20,7 +20,7 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{debian-10-amd64} 
       include postgresql::server
 
       class { 'zabbix':
-        zabbix_version   => '4.0', # Only run tests on LTS releases.
+        zabbix_version   => '4.4',
         zabbix_url       => 'localhost',
         zabbix_api_user  => 'Admin',
         zabbix_api_pass  => 'zabbix',

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -15,7 +15,7 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{debian-10
         include postgresql::server
 
         class { 'zabbix':
-          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_version   => '4.0', # Only run tests on LTS releases.
           zabbix_url       => 'localhost',
           zabbix_api_user  => 'Admin',
           zabbix_api_pass  => 'zabbix',
@@ -44,7 +44,7 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{debian-10
         }
       EOS
 
-      shell("echo '<?xml version=\"1.0\" encoding=\"UTF-8\"?><zabbix_export><version>3.0</version><date>2018-12-13T15:00:46Z</date><groups><group><name>Templates/Applications</name></group></groups><templates><template><template>TestTemplate1</template><name>TestTemplate1</name><description/><groups><group><name>Templates/Applications</name></group></groups><applications/><items/><discovery_rules/><macros/><templates/><screens/></template></templates></zabbix_export>' > /root/TestTemplate1.xml")
+      shell("echo '<?xml version=\"1.0\" encoding=\"UTF-8\"?><zabbix_export><version>4.0</version><date>2018-12-13T15:00:46Z</date><groups><group><name>Templates/Applications</name></group></groups><templates><template><template>TestTemplate1</template><name>TestTemplate1</name><description/><groups><group><name>Templates/Applications</name></group></groups><applications/><items/><discovery_rules/><macros/><templates/><screens/></template></templates></zabbix_export>' > /root/TestTemplate1.xml")
 
       # Cleanup old database
       prepare_host

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -15,7 +15,7 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{debian-10
         include postgresql::server
 
         class { 'zabbix':
-          zabbix_version   => '4.0', # Only run tests on LTS releases.
+          zabbix_version   => '4.4',
           zabbix_url       => 'localhost',
           zabbix_api_user  => 'Admin',
           zabbix_api_pass  => 'zabbix',
@@ -30,7 +30,7 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{debian-10
           port         => 10050,
           group        => 'TestgroupOne',
           group_create => true,
-          templates    => [ 'Template OS Linux', ],
+          templates    => [ 'Template OS Linux by Zabbix agent', ],
           require      => [ Service['zabbix-server'], Package['zabbixapi'], ],
         }
 

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -15,7 +15,7 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{debian-10-amd6
         include postgresql::server
 
         class { 'zabbix':
-          zabbix_version   => '4.0', # Only run tests on LTS releases.
+          zabbix_version   => '4.4',
           zabbix_url       => 'localhost',
           zabbix_api_user  => 'Admin',
           zabbix_api_pass  => 'zabbix',

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -15,7 +15,7 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{debian-10-amd6
         include postgresql::server
 
         class { 'zabbix':
-          zabbix_version   => '3.0', # zabbixapi gem doesn't currently support higher versions
+          zabbix_version   => '4.0', # Only run tests on LTS releases.
           zabbix_url       => 'localhost',
           zabbix_api_user  => 'Admin',
           zabbix_api_pass  => 'zabbix',
@@ -30,7 +30,7 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{debian-10-amd6
         }
       EOS
 
-      shell("echo '<?xml version=\"1.0\" encoding=\"UTF-8\"?><zabbix_export><version>3.0</version><date>2018-12-13T15:00:46Z</date><groups><group><name>Templates/Applications</name></group></groups><templates><template><template>TestTemplate1</template><name>TestTemplate1</name><description/><groups><group><name>Templates/Applications</name></group></groups><applications/><items/><discovery_rules/><macros/><templates/><screens/></template></templates></zabbix_export>' > /root/TestTemplate1.xml")
+      shell("echo '<?xml version=\"1.0\" encoding=\"UTF-8\"?><zabbix_export><version>4.0</version><date>2018-12-13T15:00:46Z</date><groups><group><name>Templates/Applications</name></group></groups><templates><template><template>TestTemplate1</template><name>TestTemplate1</name><description/><groups><group><name>Templates/Applications</name></group></groups><applications/><items/><discovery_rules/><macros/><templates/><screens/></template></templates></zabbix_export>' > /root/TestTemplate1.xml")
 
       # Cleanup old database
       prepare_host


### PR DESCRIPTION
#### Pull Request (PR) description
This is a re-submission of #623, because the original PR was probably abandoned.

* Re-submission of #623 (with latest version of zabbixapi)
* Rebased against latest master branch
* Bumps acceptance tests to Zabbix LTS release 4.4 (it's too early for 5.x)

#### This Pull Request (PR) fixes the following issues
Fixes #621 (Zabbix 4.2 support)
Fixes #544 (Zabbix 3.4 support)
Fixes #689 (Zabbix 5.0 support; partially, should be considered the first step)
