### PR TITLE
Better CentOS7 / Zabbix5.0 support

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -92,6 +92,22 @@ class zabbix::repo (
           gpgkey   => $gpgkey_nonsupported,
           priority => '1',
         }
+
+        if ($facts['os']['name'] == 'CentOS' and $majorrelease == '7'){
+          $_frontend_repo_location = $frontend_repo_location ? {
+            undef   => "https://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/\$basearch/frontend",
+            default => $frontend_repo_location,
+          }
+
+          yumrepo { 'zabbix-frontend':
+            name     => "Zabbix_frontend_${majorrelease}_${facts['os']['architecture']}",
+            descr    => "Zabbix_frontend_${majorrelease}_${facts['os']['architecture']}",
+            baseurl  => $_frontend_repo_location,
+            gpgcheck => '1',
+            gpgkey   => $gpgkey_zabbix,
+            priority => '1',
+          }        
+        }
       }
       'Debian' : {
         if ($manage_apt) {

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -340,6 +340,33 @@ class zabbix::web (
         ],
       }
     }
+    'CentOS': {
+      $zabbix_web_package = 'zabbix-web'
+      if ($facts['os']['release']['major'] == '7'){
+
+        package { 'zabbix-required-scl-repo':
+          name => 'centos-release-scl',
+          ensure => 'latest'
+        }
+
+        package { "zabbix-web-${db}-scl":
+          ensure  => $zabbix_package_state,
+          before  => Package[$zabbix_web_package],
+          require => Class['zabbix::repo'],
+          tag     => 'zabbix',
+        }
+      
+      } else {
+       
+        package { "zabbix-web-${db}":
+          ensure  => $zabbix_package_state,
+          before  => Package[$zabbix_web_package],
+          require => Class['zabbix::repo'],
+          tag     => 'zabbix',
+        }
+      
+      }
+    }
     default: {
       $zabbix_web_package = 'zabbix-web'
 

--- a/templates/web/php-fpm.d.zabbix.conf.epp
+++ b/templates/web/php-fpm.d.zabbix.conf.epp
@@ -1,4 +1,4 @@
-# THIS FILE IS MANAGED BY PUPPET
+; THIS FILE IS MANAGED BY PUPPET
 [zabbix]
 user = apache
 group = apache
@@ -16,12 +16,12 @@ pm.max_spare_servers = 35
 php_value[session.save_handler] = files
 php_value[session.save_path]    = /var/opt/rh/rh-php72/lib/php/session/
 
-php_value max_execution_time <%= $zabbix::web::apache_php_max_execution_time %>
-php_value memory_limit <%= $zabbix::web::apache_php_memory_limit %>
-php_value post_max_size <%= $zabbix::web::apache_php_post_max_size %>
-php_value upload_max_filesize <%= $zabbix::web::apache_php_upload_max_filesize %>
-php_value max_input_time <%= $zabbix::web::apache_php_max_input_time %>
-php_value always_populate_raw_post_data <%= $zabbix::web::apache_php_always_populate_raw_post_data %>
-php_value max_input_vars <%= $zabbix::web::apache_php_max_input_vars %>
-# Set correct timezone
-php_value date.timezone <%= $zabbix::web::zabbix_timezone %>
+php_value [max_execution_time] = <%= $zabbix::web::apache_php_max_execution_time %>
+php_value [memory_limit] = <%= $zabbix::web::apache_php_memory_limit %>
+php_value [post_max_size] = <%= $zabbix::web::apache_php_post_max_size %>
+php_value [upload_max_filesize] = <%= $zabbix::web::apache_php_upload_max_filesize %>
+php_value [max_input_time] = <%= $zabbix::web::apache_php_max_input_time %>
+php_value [always_populate_raw_post_data] = <%= $zabbix::web::apache_php_always_populate_raw_post_data %>
+php_value [max_input_vars] = <%= $zabbix::web::apache_php_max_input_vars %>
+; Set correct timezone
+php_value [date.timezone] = <%= $zabbix::web::zabbix_timezone %>

--- a/templates/web/php-fpm.d.zabbix.conf.epp
+++ b/templates/web/php-fpm.d.zabbix.conf.epp
@@ -1,0 +1,27 @@
+# THIS FILE IS MANAGED BY PUPPET
+[zabbix]
+user = apache
+group = apache
+
+listen = /var/opt/rh/rh-php72/run/php-fpm/zabbix.sock
+listen.acl_users = apache
+listen.allowed_clients = 127.0.0.1
+
+pm = dynamic
+pm.max_children = 50
+pm.start_servers = 5
+pm.min_spare_servers = 5
+pm.max_spare_servers = 35
+
+php_value[session.save_handler] = files
+php_value[session.save_path]    = /var/opt/rh/rh-php72/lib/php/session/
+
+php_value max_execution_time <%= $zabbix::web::apache_php_max_execution_time %>
+php_value memory_limit <%= $zabbix::web::apache_php_memory_limit %>
+php_value post_max_size <%= $zabbix::web::apache_php_post_max_size %>
+php_value upload_max_filesize <%= $zabbix::web::apache_php_upload_max_filesize %>
+php_value max_input_time <%= $zabbix::web::apache_php_max_input_time %>
+php_value always_populate_raw_post_data <%= $zabbix::web::apache_php_always_populate_raw_post_data %>
+php_value max_input_vars <%= $zabbix::web::apache_php_max_input_vars %>
+# Set correct timezone
+php_value date.timezone <%= $zabbix::web::zabbix_timezone %>


### PR DESCRIPTION
This PR more fully addresses #689 by including the 'frontend' repo that's required for CentOS7 to include PHP72. Also ensures the SCL repo is present and installs the appropriate Zabbix Web package instead of the previous (and current) generic one.