### PR TITLE
Adds 5.x in the version check for which schema path to use

### DIFF
--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -28,9 +28,9 @@ class zabbix::database::mysql (
   assert_private()
 
   #
-  # Adjustments for version 3.0/4.0 - structure of package with sqls differs from previous versions
+  # Adjustments for version 3.0 and onwards - structure of package with sqls differs from previous versions
   case $zabbix_version {
-    /^(3|4).\d+$/: {
+    /^(3|4|5).\d+$/: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         $schema_path   = '/usr/share/doc/zabbix-*-mysql*'
       }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -28,9 +28,9 @@ class zabbix::database::postgresql (
   assert_private()
 
   #
-  # Adjustments for version 3.0/4.0 - structure of package with sqls differs from previous versions
+  # Adjustments for version 3.0 and onwards - structure of package with sqls differs from previous versions
   case $zabbix_version {
-    /^(3|4).\d+$/: {
+    /^(3|4|5).\d+$/: {
       if ($database_schema_path == false) or ($database_schema_path == '') {
         case $facts['os']['name'] {
           'CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux': {


### PR DESCRIPTION
Helps address #689 by allowing for the correct database schema path to be used when doing the initial installation for a 5.0 install.

Also just realised that this is a dupe of both #715 and #694 and we're in the same holding pattern now because of the acceptance tests. Maybe a maintainer (@bastelfreak?) can assist in pointing @aclarkee, @stanhva and myself in the right direction?