### PR TITLE
acceptance tests: move package setup into helper

### DIFF
--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -18,6 +18,8 @@ describe 'zabbix::server class' do
         class { 'postgresql::globals':
           encoding => 'UTF-8',
           locale   => 'en_US.UTF-8',
+          manage_package_repo => true,
+          version => '12',
         }
         -> class { 'postgresql::server': }
         -> class { 'zabbix::database': }

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -15,9 +15,13 @@ describe 'zabbix::server class' do
 
       # this will actually deploy apache + postgres + zabbix-server + zabbix-web
       pp = <<-EOS
-        class { 'postgresql::server': } ->
-        class { 'zabbix::database': } ->
-        class { 'zabbix::server': }
+        class { 'postgresql::globals':
+          encoding => 'UTF-8',
+          locale   => 'en_US.UTF-8',
+        }
+        -> class { 'postgresql::server': }
+        -> class { 'zabbix::database': }
+        -> class { 'zabbix::server': }
       EOS
 
       prepare_host

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -20,6 +20,8 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{debian-10-a
       class { 'postgresql::globals':
         encoding => 'UTF-8',
         locale   => 'en_US.UTF-8',
+        manage_package_repo => true,
+        version => '12',
       }
       -> class { 'postgresql::server': }
 

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -17,7 +17,11 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{debian-10-a
           mpm_module => 'prefork',
       }
       include apache::mod::php
-      include postgresql::server
+      class { 'postgresql::globals':
+        encoding => 'UTF-8',
+        locale   => 'en_US.UTF-8',
+      }
+      -> class { 'postgresql::server': }
 
       class { 'zabbix':
         zabbix_version   => '4.4',

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -7,12 +7,6 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{debian-10-amd64} d
     # This will deploy a running Zabbix setup (server, web, db) which we can
     # use for custom type tests
     pp1 = <<-EOS
-$compile_packages = $facts['os']['family'] ? {
-  'RedHat' => [ 'make', 'gcc-c++', 'rubygems', 'ruby'],
-  'Debian' => [ 'make', 'g++', 'ruby-dev', 'ruby', 'pkg-config',],
-  default  => [],
-}
-ensure_packages($compile_packages, { before => Package['zabbixapi'], })
 class { 'apache':
   mpm_module => 'prefork',
 }

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -20,6 +20,8 @@ include apache::mod::php
 class { 'postgresql::globals':
   encoding => 'UTF-8',
   locale   => 'en_US.UTF-8',
+  manage_package_repo => true,
+  version => '12',
 }
 -> class { 'postgresql::server': }
 

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -17,7 +17,11 @@ class { 'apache':
   mpm_module => 'prefork',
 }
 include apache::mod::php
-include postgresql::server
+class { 'postgresql::globals':
+  encoding => 'UTF-8',
+  locale   => 'en_US.UTF-8',
+}
+-> class { 'postgresql::server': }
 
 class { 'zabbix':
   zabbix_version   => '4.4',

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -15,6 +15,8 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{debian-10-amd
         class { 'postgresql::globals':
           encoding => 'UTF-8',
           locale   => 'en_US.UTF-8',
+          manage_package_repo => true,
+          version => '12',
         }
         -> class { 'postgresql::server': }
 

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -12,7 +12,11 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{debian-10-amd
             mpm_module => 'prefork',
         }
         include apache::mod::php
-        include postgresql::server
+        class { 'postgresql::globals':
+          encoding => 'UTF-8',
+          locale   => 'en_US.UTF-8',
+        }
+        -> class { 'postgresql::server': }
 
         class { 'zabbix':
           zabbix_version   => '4.4',

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -17,7 +17,11 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{debian-10-amd64} 
         mpm_module => 'prefork',
       }
       include apache::mod::php
-      include postgresql::server
+      class { 'postgresql::globals':
+        encoding => 'UTF-8',
+        locale   => 'en_US.UTF-8',
+      }
+      -> class { 'postgresql::server': }
 
       class { 'zabbix':
         zabbix_version   => '4.4',

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -20,6 +20,8 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{debian-10-amd64} 
       class { 'postgresql::globals':
         encoding => 'UTF-8',
         locale   => 'en_US.UTF-8',
+        manage_package_repo => true,
+        version => '12',
       }
       -> class { 'postgresql::server': }
 

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -7,12 +7,6 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{debian-10-amd64} 
     # This will deploy a running Zabbix setup (server, web, db) which we can
     # use for custom type tests
     pp1 = <<-EOS
-      $compile_packages = $facts['os']['family'] ? {
-        'RedHat' => [ 'make', 'gcc-c++', 'rubygems', 'ruby'],
-        'Debian' => [ 'make', 'g++', 'ruby-dev', 'ruby', 'pkg-config',],
-        default  => [],
-      }
-      ensure_packages($compile_packages, { before => Package['zabbixapi'], })
       class { 'apache':
         mpm_module => 'prefork',
       }

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -15,6 +15,8 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{debian-10
         class { 'postgresql::globals':
           encoding => 'UTF-8',
           locale   => 'en_US.UTF-8',
+          manage_package_repo => true,
+          version => '12',
         }
         -> class { 'postgresql::server': }
 

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -12,7 +12,11 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{debian-10
             mpm_module => 'prefork',
         }
         include apache::mod::php
-        include postgresql::server
+        class { 'postgresql::globals':
+          encoding => 'UTF-8',
+          locale   => 'en_US.UTF-8',
+        }
+        -> class { 'postgresql::server': }
 
         class { 'zabbix':
           zabbix_version   => '4.4',

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -12,7 +12,11 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{debian-10-amd6
             mpm_module => 'prefork',
         }
         include apache::mod::php
-        include postgresql::server
+        class { 'postgresql::globals':
+          encoding => 'UTF-8',
+          locale   => 'en_US.UTF-8',
+        }
+        -> class { 'postgresql::server': }
 
         class { 'zabbix':
           zabbix_version   => '4.4',

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -15,6 +15,8 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{debian-10-amd6
         class { 'postgresql::globals':
           encoding => 'UTF-8',
           locale   => 'en_US.UTF-8',
+          manage_package_repo => true,
+          version => '12',
         }
         -> class { 'postgresql::server': }
 

--- a/spec/support/acceptance/prepare_host.rb
+++ b/spec/support/acceptance/prepare_host.rb
@@ -16,4 +16,15 @@ def prepare_host
   fi
   SHELL
   shell(cleanup_script)
+  install_deps = <<-SHELL
+      $compile_packages = $facts['os']['family'] ? {
+        'RedHat' => [ 'make', 'gcc-c++', 'rubygems', 'ruby'],
+        'Debian' => [ 'make', 'g++', 'ruby-dev', 'ruby', 'pkg-config',],
+        default  => [],
+      }
+      package { $compile_packages:
+        ensure => 'present',
+      }
+  SHELL
+  apply_manifest(install_deps)
 end


### PR DESCRIPTION
We rely on those packages in most tests. To be able to run them
independently, we need to manage them in the helper.