### PR TITLE
database: use namespaced postgresql_password function; bump puppetlabs/postgresql lower dependency 4.4.2->6.4.0

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -149,7 +149,7 @@ class zabbix::database (
         postgresql::server::db { $database_name:
           user       => $database_user,
           owner      => $database_user,
-          password   => postgresql_password($database_user, $database_password),
+          password   => postgresql::postgresql_password($database_user, $database_password),
           require    => Class['postgresql::server'],
           tablespace => $database_tablespace,
         }

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 4.4.2 < 7.0.0"
+      "version_requirement": ">= 6.4.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Fixes deprecation warning.

Also increased minimum postgresql module version to when namespaced postgresql_password function was introduced.