### PR TITLE
Bump default Zabbix version on linux 3.4->5.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -138,10 +138,8 @@ class zabbix::params {
 
   if downcase($facts['kernel']) == 'windows' {
     $zabbix_version = '4.4.5'
-  } elsif $facts['os']['name'] == 'Debian' and Integer($facts['os']['release']['major']) == 10 {
-    $zabbix_version =  '4.0'
   } else {
-    $zabbix_version = '3.4'
+    $zabbix_version = '5.0'
   }
 
   $manage_startup_script = downcase($facts['kernel']) ? {

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -34,11 +34,8 @@ describe 'zabbix::agent' do
                     else
                       '/etc/zabbix/zabbix_agentd.d'
                     end
-      zabbix_version = if facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'].to_i == 10
-                         '4.0'
-                       else
-                         '3.4'
-                       end
+      zabbix_version = '5.0'
+
       let :facts do
         facts.merge(systemd_fact)
       end

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -25,7 +25,6 @@ describe 'zabbix::proxy' do
         let :params do
           {
             zabbix_server_host: '192.168.1.1',
-            zabbix_version: '2.4'
           }
         end
 
@@ -45,23 +44,22 @@ describe 'zabbix::proxy' do
             }
           end
 
-          it { is_expected.to contain_class('zabbix::repo').with_zabbix_version('3.4') }
+          it { is_expected.to contain_class('zabbix::repo').with_zabbix_version('5.0') }
           it { is_expected.to contain_package('zabbix-proxy-pgsql').with_require('Class[Zabbix::Repo]') }
           it { is_expected.to contain_yumrepo('zabbix-nonsupported') }
           it { is_expected.to contain_yumrepo('zabbix') }
         end
 
-        describe 'when manage_repo is true and zabbix version is 2.4' do
+        describe 'when manage_repo is true and zabbix version is 4.0' do
           let :params do
             {
               manage_repo: true,
-              zabbix_version: '2.4'
+              zabbix_version: '4.0'
             }
           end
 
-          it { is_expected.to contain_class('zabbix::repo').with_zabbix_version('2.4') }
+          it { is_expected.to contain_class('zabbix::repo').with_zabbix_version('4.0') }
           it { is_expected.to contain_package('zabbix-proxy-pgsql').with_require('Class[Zabbix::Repo]') }
-          it { is_expected.to contain_package('zabbix-proxy').with_ensure('present') }
         end
 
         describe 'with enabled selinux' do
@@ -117,7 +115,7 @@ describe 'zabbix::proxy' do
           end
 
           it { is_expected.to contain_class('zabbix::database::postgresql').with_zabbix_type('proxy') }
-          it { is_expected.to contain_class('zabbix::database::postgresql').with_zabbix_version('3.4') }
+          it { is_expected.to contain_class('zabbix::database::postgresql').with_zabbix_version('5.0') }
           it { is_expected.to contain_class('zabbix::database::postgresql').with_database_name('zabbix_proxy') }
           it { is_expected.to contain_class('zabbix::database::postgresql').with_database_user('zabbix-proxy') }
           it { is_expected.to contain_class('zabbix::database::postgresql').with_database_password('zabbix-proxy') }
@@ -137,7 +135,7 @@ describe 'zabbix::proxy' do
           end
 
           it { is_expected.to contain_class('zabbix::database::mysql').with_zabbix_type('proxy') }
-          it { is_expected.to contain_class('zabbix::database::mysql').with_zabbix_version('3.4') }
+          it { is_expected.to contain_class('zabbix::database::mysql').with_zabbix_version('5.0') }
           it { is_expected.to contain_class('zabbix::database::mysql').with_database_name('zabbix_proxy') }
           it { is_expected.to contain_class('zabbix::database::mysql').with_database_user('zabbix-proxy') }
           it { is_expected.to contain_class('zabbix::database::mysql').with_database_password('zabbix-proxy') }
@@ -267,7 +265,7 @@ describe 'zabbix::proxy' do
               vmwarefrequency: '60',
               zabbix_server_host: '192.168.1.1',
               zabbix_server_port: '10051',
-              zabbix_version: '2.2'
+              zabbix_version: '5.0'
             }
           end
 
@@ -310,7 +308,6 @@ describe 'zabbix::proxy' do
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^CacheSize=8M$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartDBSyncers=4$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^HistoryCacheSize=16M$} }
-          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^HistoryTextCacheSize=8M$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^Timeout=20$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TrapperTimeout=16$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^UnreachablePeriod=45$} }
@@ -328,7 +325,7 @@ describe 'zabbix::proxy' do
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LoadModule=pizza$} }
         end
 
-        context 'with zabbix_proxy.conf and version 3.0' do
+        context 'with zabbix_proxy.conf and version 4.0' do
           let :params do
             {
               tlsaccept: 'cert',
@@ -340,7 +337,7 @@ describe 'zabbix::proxy' do
               tlsservercertsubject: 'MyZabbix',
               tlspskidentity: '/etc/zabbix/keys/identity.file',
               tlspskfile: '/etc/zabbix/keys/file.key',
-              zabbix_version: '3.0'
+              zabbix_version: '4.0'
             }
           end
 
@@ -353,19 +350,6 @@ describe 'zabbix::proxy' do
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TLSServerCertSubject=MyZabbix$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TLSPSKIdentity=/etc/zabbix/keys/identity.file$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TLSPSKFile=/etc/zabbix/keys/file.key$} }
-        end
-
-        context 'with zabbix_proxy.conf and version 3.4' do
-          let :params do
-            {
-              enableremotecommands: 1,
-              logremotecommands: 1,
-              zabbix_version: '3.4'
-            }
-          end
-
-          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^EnableRemoteCommands=1$} }
-          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogRemoteCommands=1$} }
         end
 
         context 'with zabbix_proxy.conf and version 5.0' do

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -28,16 +28,16 @@ describe 'zabbix::repo' do
         end
 
         case facts[:os]['release']['major']
-        when '6'
-          context 'on Debian 6 and Zabbix 2.0' do
+        when '10'
+          context 'on Debian 10 and Zabbix 4.0' do
             let :params do
               {
-                zabbix_version: '2.0',
+                zabbix_version: '4.0',
                 manage_repo: true
               }
             end
 
-            it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/2.0/debian/') }
+            it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/4.0/debian/') }
           end
 
         when '7'

--- a/spec/classes/sender_spec.rb
+++ b/spec/classes/sender_spec.rb
@@ -30,12 +30,7 @@ describe 'zabbix::sender' do
         if %w[Archlinux Gentoo].include?(facts[:osfamily])
           it { is_expected.not_to compile.with_all_deps }
         else
-          zabbix_version = if facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'].to_i == 10
-                             '4.0'
-                           else
-                             '3.4'
-                           end
-          it { is_expected.to contain_class('zabbix::repo').with_zabbix_version(zabbix_version) }
+          it { is_expected.to contain_class('zabbix::repo').with_zabbix_version('5.0') }
           it { is_expected.to contain_package('zabbix-sender').with_require('Class[Zabbix::Repo]') }
         end
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -20,11 +20,7 @@ describe 'zabbix::server' do
         facts.merge(systemd_fact)
       end
 
-      zabbix_version = if facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'].to_i == 10
-                         '4.0'
-                       else
-                         '3.4'
-                       end
+      zabbix_version = '5.0'
 
       describe 'with default settings' do
         it { is_expected.to contain_class('zabbix::repo') }


### PR DESCRIPTION
3.4 is EOL and we will remove code for it in https://github.com/voxpupuli/puppet-zabbix/pull/750

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
