### PR TITLE
Fix templates importing in Zabbix 5.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,15 @@ zabbix::template { 'Template App MySQL':
 }
 ```
 
+`zabbix::template` class accepts `zabbix_version` parameter, by default is set to module's default Zabbix version.
+Please override if you are using a different version.
+```ruby
+zabbix::template { 'Template App MySQL':
+  templ_source   => 'puppet:///modules/zabbix/MySQL.xml',
+  zabbix_version => '5.2'
+}
+```
+
 ## Zabbix Upgrades
 
 It is possible to do upgrades via this module. An example for the zabbix agent:
@@ -502,6 +511,7 @@ There are some zabbix specific parameters, please check them by opening the mani
 
 * `templ_name`: The name of the template. This name will be found in the Web interface.
 * `templ_source`: The location of the XML file wich needs to be imported.
+* `zabbix_version`: The Zabbix version on which the template will be installed on.
 
 ## Limitations
 

--- a/lib/puppet/provider/zabbix_template/ruby.rb
+++ b/lib/puppet/provider/zabbix_template/ruby.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
           createMissing: true,
           updateExisting: true
         },
-        templateScreens: {
+        (@resource[:zabbix_version] =~ %r{5\.[^0]} ? :templateDashboards : :templateScreens) => {
           createMissing: true,
           updateExisting: true
         },

--- a/lib/puppet/type/zabbix_template.rb
+++ b/lib/puppet/type/zabbix_template.rb
@@ -35,5 +35,9 @@ Puppet::Type.newtype(:zabbix_template) do
     desc 'Template source file.'
   end
 
+  newparam(:zabbix_version) do
+    desc 'Zabbix version that the template will be installed on.'
+  end
+
   autorequire(:file) { '/etc/zabbix/api.conf' }
 end

--- a/manifests/resources/template.pp
+++ b/manifests/resources/template.pp
@@ -17,6 +17,7 @@ define zabbix::resources::template (
   $template_dir    = $zabbix::params::zabbix_template_dir,
   $template_name   = $title,
   $template_source = '',
+  $zabbix_version  = $zabbix::params::zabbix_version,
 ) {
   file { "${template_dir}/${template_name}.xml":
     ensure => file,
@@ -28,6 +29,7 @@ define zabbix::resources::template (
   @@zabbix_template { $template_name:
     #template_source => $template_source,
     template_source => "${template_dir}/${template_name}.xml",
+    zabbix_version  => $zabbix_version,
     require         => File["${template_dir}/${template_name}.xml"],
   }
 }

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -12,6 +12,9 @@
 # [*templ_source*]
 #  The location of the XML file wich needs to be imported.
 #
+# [*zabbix_version*]
+#  The Zabbix version on which the template will be installed on.
+#
 # === Example
 #
 #  zabbix::template { 'Template App MySQL':
@@ -27,11 +30,13 @@
 # Copyright 2015  Vladislav Tkatchev
 #
 define zabbix::template (
-  $templ_name   = $title,
-  $templ_source = '',
+  $templ_name     = $title,
+  $templ_source   = '',
+  String[1] $zabbix_version = $zabbix::params::zabbix_version,
 ) {
   zabbix::resources::template { $templ_name:
     template_name   => $templ_name,
     template_source => $templ_source,
+    zabbix_version  => $zabbix_version,
   }
 }

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -52,6 +52,7 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{(ubuntu-1
 
         zabbix_template { 'TestTemplate1':
           template_source => '/root/TestTemplate1.xml',
+          zabbix_version  => "#{zabbix_version}",
         }
 
         zabbix_template_host{ "TestTemplate1@test1.example.com": }

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -35,6 +35,7 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{(ubuntu-16.04|
       pp2 = <<-EOS
           zabbix_template { 'TestTemplate1':
             template_source => '/root/TestTemplate1.xml',
+            zabbix_version  => "#{zabbix_version}",
           }
       EOS
 


### PR DESCRIPTION
Zabbix changed templateScreens option in configurations.import API call to templateDashboards.

Source: 

5.2: https://www.zabbix.com/documentation/current/manual/api/reference/configuration/import
5.0: https://www.zabbix.com/documentation/5.0/manual/api/reference/configuration/import
(rules object)