### PR TITLE
Ensure correct logfile/logfilesize values when defaulting logtype to system

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -232,16 +232,14 @@ class zabbix::params {
   $server_listenport                        = '10051'
   $server_loadmodule                        = undef
   $server_loadmodulepath                    = '/usr/lib/modules'
-  # provided by camptocamp/systemd
+  # provided by puppet/systemd
   if $facts['systemd'] {
-    $server_logtype                          = 'system'
-    $server_logfile                          = undef
-    $server_logfilesize                      = undef
+    $server_logtype                         = 'system'
   } else {
-    $server_logtype                          = 'file'
-    $server_logfile                          = '/var/log/zabbix/zabbix_server.log'
-    $server_logfilesize                      = '10'
+    $server_logtype                         = 'file'
   }
+  $server_logfile                           = '/var/log/zabbix/zabbix_server.log'
+  $server_logfilesize                       = '10'
   $server_logslowqueries                    = '0'
   $server_maxhousekeeperdelete              = '500'
   $server_pidfile                           = '/var/run/zabbix/zabbix_server.pid'
@@ -355,11 +353,11 @@ class zabbix::params {
   $agent_zbx_templates                      = ['Template OS Linux', 'Template App SSH Service']
   $apache_status                            = false
   $monitored_by_proxy                       = undef
-  # provided by camptocamp/systemd
+  # provided by puppet/systemd
   if $facts['systemd'] {
     $agent_logtype                          = 'system'
-    $agent_logfile                          = undef
-    $agent_logfilesize                      = undef
+    $agent_logfile                          = '/var/log/zabbix/zabbix_agentd.log'
+    $agent_logfilesize                      = '100'
   }
   elsif $facts['kernel'] == 'windows' {
     $agent_logtype                          = 'file'
@@ -402,16 +400,14 @@ class zabbix::params {
   $proxy_loadmodule                         = undef
   $proxy_loadmodulepath                     = '/usr/lib/modules'
   $proxy_localbuffer                        = '0'
-  # provided by camptocamp/systemd
+  # provided by puppet/systemd
   if $facts['systemd'] {
     $proxy_logtype                          = 'system'
-    $proxy_logfile                          = undef
-    $proxy_logfilesize                      = undef
   } else {
     $proxy_logtype                          = 'file'
-    $proxy_logfile                          = '/var/log/zabbix/zabbix_proxy.log'
-    $proxy_logfilesize                      = '10'
   }
+  $proxy_logfile                            = '/var/log/zabbix/zabbix_proxy.log'
+  $proxy_logfilesize                        = '10'
   $proxy_logremotecommands                  = 0
   $proxy_logslowqueries                     = '0'
   $proxy_mode                               = '0'

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -28,6 +28,13 @@ describe 'zabbix::agent' do
                     else
                       '/etc/zabbix/zabbix_agentd.conf'
                     end
+
+      log_path = case facts[:operatingsystem]
+                 when 'windows'
+                   'C:/ProgramData/zabbix/zabbix_agentd.log'
+                 else
+                   '/var/log/zabbix/zabbix_agentd.log'
+                 end
       include_dir = case facts[:operatingsystem]
                     when 'windows'
                       'C:/ProgramData/zabbix/zabbix_agentd.d'
@@ -365,8 +372,8 @@ describe 'zabbix::agent' do
         end
       end
 
-      context 'with zabbix_agentd.conf and logtype is declared' do
-        context 'declare logtype as system' do
+      context 'with zabbix_agentd.conf and logtype declared' do
+        describe 'as system' do
           let :params do
             {
               logtype: 'system'
@@ -378,7 +385,7 @@ describe 'zabbix::agent' do
           it { is_expected.to contain_file(config_path).without_content %r{^LogFileSize=} }
         end
 
-        context 'declare logtype as console' do
+        describe 'as console' do
           let :params do
             {
               logtype: 'console'
@@ -388,6 +395,18 @@ describe 'zabbix::agent' do
           it { is_expected.to contain_file(config_path).with_content %r{^LogType=console$} }
           it { is_expected.to contain_file(config_path).without_content %r{^LogFile=} }
           it { is_expected.to contain_file(config_path).without_content %r{^LogFileSize=} }
+        end
+
+        describe 'as file' do
+          let :params do
+            {
+              logtype: 'file'
+            }
+          end
+
+          it { is_expected.to contain_file(config_path).with_content %r{^LogType=file$} }
+          it { is_expected.to contain_file(config_path).with_content %r{^LogFile=#{log_path}$} }
+          it { is_expected.to contain_file(config_path).with_content %r{^LogFileSize=100$} }
         end
       end
     end

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -397,8 +397,8 @@ describe 'zabbix::proxy' do
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^SocketDir=/var/run/zabbix} }
         end
 
-        context 'with zabbix_proxy.conf and logtype' do
-          context 'declared as system' do
+        context 'with zabbix_proxy.conf and logtype declared' do
+          describe 'as system' do
             let :params do
               {
                 logtype: 'system'
@@ -410,7 +410,7 @@ describe 'zabbix::proxy' do
             it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').without_content %r{^LogFileSize=} }
           end
 
-          context 'declared as console' do
+          describe 'as console' do
             let :params do
               {
                 logtype: 'console'
@@ -420,6 +420,18 @@ describe 'zabbix::proxy' do
             it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogType=console$} }
             it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').without_content %r{^LogFile=} }
             it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').without_content %r{^LogFileSize=} }
+          end
+
+          describe 'as file' do
+            let :params do
+              {
+                logtype: 'file'
+              }
+            end
+
+            it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogType=file$} }
+            it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogFile=/var/log/zabbix/zabbix_proxy.log$} }
+            it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogFileSize=10$} }
           end
         end
       end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -360,8 +360,8 @@ describe 'zabbix::server' do
         it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SocketDir=/var/run/zabbix} }
       end
 
-      context 'with zabbix_server.conf and logtype' do
-        context 'declared as system' do
+      context 'with zabbix_server.conf and logtype declared' do
+        describe 'as system' do
           let :params do
             {
               logtype: 'system'
@@ -373,7 +373,7 @@ describe 'zabbix::server' do
           it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').without_content %r{^LogFileSize=} }
         end
 
-        context 'declared as console' do
+        describe 'as console' do
           let :params do
             {
               logtype: 'console'
@@ -383,6 +383,18 @@ describe 'zabbix::server' do
           it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogType=console$} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').without_content %r{^LogFile=} }
           it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').without_content %r{^LogFileSize=} }
+        end
+
+        describe 'as file' do
+          let :params do
+            {
+              logtype: 'file'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogType=file$} }
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogFile=/var/log/zabbix/zabbix_server.log$} }
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^LogFileSize=10$} }
         end
       end
     end


### PR DESCRIPTION

When setting `logtype` to system ensure `logfile` and `logfilesize` have correct values instead of `undef`.
Chagning logtype to file could lead to non-working agent due to these values being undef, which is not obvious.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
