### PR TITLE
Add Zabbix 5.4 support

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,6 +6,7 @@ Gemfile:
       - gem: 'zabbixapi'
 spec/spec_helper.rb:
   mock_with: ':mocha'
+  spec_overrides: "require 'support/acceptance/supported_versions'"
 spec/spec_helper_acceptance.rb:
   unmanaged: false
 .github/workflows/ci.yml:

--- a/lib/puppet/provider/zabbix.rb
+++ b/lib/puppet/provider/zabbix.rb
@@ -51,7 +51,8 @@ class Puppet::Provider::Zabbix < Puppet::Provider
       user: api_config['default']['zabbix_user'],
       password: api_config['default']['zabbix_pass'],
       http_user: api_config['default']['zabbix_user'],
-      http_password: api_config['default']['zabbix_pass']
+      http_password: api_config['default']['zabbix_pass'],
+      ignore_version: true
     )
     zbx
   end

--- a/lib/puppet/provider/zabbix_template/ruby.rb
+++ b/lib/puppet/provider/zabbix_template/ruby.rb
@@ -6,7 +6,8 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
     zbx.configurations.import(
       format: 'xml',
       rules: {
-        applications: {
+        # application parameter was removed on Zabbix 5.4
+        (@resource[:zabbix_version] =~ %r{[45]\.[02]} ? :applications : nil) => {
           createMissing: true
         },
         discoveryRules: {
@@ -32,7 +33,8 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
           createMissing: true,
           updateExisting: true
         },
-        screens: {
+        # screens parameter was removed on Zabbix 5.4
+        (@resource[:zabbix_version] =~ %r{[45]\.[02]} ? :screens : nil) => {
           createMissing: true,
           updateExisting: true
         },
@@ -43,7 +45,8 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
           createMissing: true,
           updateExisting: true
         },
-        (@resource[:zabbix_version] =~ %r{5\.[^0]} ? :templateDashboards : :templateScreens) => {
+        # templateDashboards was renamed to templateScreen on Zabbix >= 5.2
+        (@resource[:zabbix_version] =~ %r{5\.[24]} ? :templateDashboards : :templateScreens) => {
           createMissing: true,
           updateExisting: true
         },
@@ -51,7 +54,7 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
           createMissing: true,
           updateExisting: true
         }
-      },
+      }.delete_if { |key, _| key.nil? },
       source: template_contents
     )
   end

--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -34,7 +34,11 @@ class zabbix::database::mysql (
   assert_private()
 
   if ($database_schema_path == false) or ($database_schema_path == '') {
-    $schema_path   = '/usr/share/doc/zabbix-*-mysql*'
+    if versioncmp($zabbix_version, '5.4') == 0 {
+      $schema_path = '/usr/share/doc/zabbix-sql-scripts/mysql/'
+    } else {
+      $schema_path = '/usr/share/doc/zabbix-*-mysql*'
+    }
   }
   else {
     $schema_path = $database_schema_path

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -34,12 +34,17 @@ class zabbix::database::postgresql (
   assert_private()
 
   if ($database_schema_path == false) or ($database_schema_path == '') {
-    case $facts['os']['name'] {
-      'CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux': {
-        $schema_path   = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/"
+    if member(['CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux'], $facts['os']['name']) {
+      if versioncmp($zabbix_version, '5.4') == 0 {
+        $schema_path = '/usr/share/doc/zabbix-sql-scripts/postgresql/'
+      } else {
+        $schema_path = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/"
       }
-      default : {
-        $schema_path   = '/usr/share/doc/zabbix-*-pgsql'
+    } else {
+      if versioncmp($zabbix_version, '5.4') == 0 {
+        $schema_path = '/usr/share/doc/zabbix-sql-scripts/postgresql/'
+      } else {
+        $schema_path = '/usr/share/doc/zabbix-*-pgsql'
       }
     }
   } else {

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -366,7 +366,7 @@ class zabbix::web (
     }
     'CentOS', 'RedHat': {
       $zabbix_web_package = 'zabbix-web'
-      if ($facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5') >= 0) {
+      if ($facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
         package { 'zabbix-required-scl-repo':
           ensure => 'latest',
           name   => 'centos-release-scl',

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -300,7 +300,7 @@ class zabbix::web (
       '4.0': {
         $zabbixapi_version = '4.2.0'
       }
-      /^5\.[02]/: {
+      /^5\.[024]/: {
         $zabbixapi_version = '5.0.0-alpha1'
       }
       default: {

--- a/spec/acceptance/agent_spec.rb
+++ b/spec/acceptance/agent_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-['4.0', '5.0', '5.2'].each do |version|
+supported_versions.each do |version|
   describe "zabbix::agent class with zabbix_version #{version}" do
     it 'works idempotently with no errors' do
       pp = <<-EOS

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper_acceptance'
-
 describe 'zabbix::server class' do
   context 'default parameters' do
     # Using puppet_apply as a helper

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -4,6 +4,8 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{(ubuntu-16.
   %w[4.0 5.0 5.2].each do |zabbix_version|
     # 5.2 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
+    # Application API was removed in Zabbix 5.4
+    next if zabbix_version == '5.4'
 
     template = case zabbix_version
                when '4.0'

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
+
 describe 'zabbix_application type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
-  %w[4.0 5.0 5.2].each do |zabbix_version|
+  supported_versions.each do |zabbix_version|
     # 5.2 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     # Application API was removed in Zabbix 5.4

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -3,7 +3,7 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_application type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 server packages are not available for RHEL 7
+    # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     # Application API was removed in Zabbix 5.4
     next if zabbix_version == '5.4'

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -4,8 +4,9 @@ require 'serverspec_type_zabbixapi'
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 server packages are not available for RHEL 7
+    # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
+    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_host resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -3,7 +3,7 @@ require 'serverspec_type_zabbixapi'
 
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
-  %w[4.0 5.0 5.2].each do |zabbix_version|
+  supported_versions.each do |zabbix_version|
     # 5.2 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_host resources with zabbix version #{zabbix_version}" do

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
+
 describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
-  %w[4.0 5.0 5.2].each do |zabbix_version|
+  supported_versions.each do |zabbix_version|
     # 5.2 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_hostgroup resources with zabbix version #{zabbix_version}" do

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -3,8 +3,9 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 server packages are not available for RHEL 7
+    # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
+    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_hostgroup resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -3,7 +3,7 @@ require 'serverspec_type_zabbixapi'
 
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_proxy type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
-  %w[4.0 5.0 5.2].each do |zabbix_version|
+  supported_versions.each do |zabbix_version|
     # 5.2 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_proxy resources with zabbix version #{zabbix_version}" do

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -4,8 +4,9 @@ require 'serverspec_type_zabbixapi'
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_proxy type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 server packages are not available for RHEL 7
+    # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
+    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_proxy resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
+
 describe 'zabbix_template_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
-  %w[4.0 5.0 5.2].each do |zabbix_version|
+  supported_versions.each do |zabbix_version|
     # 5.2 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_template_host resources with zabbix version #{zabbix_version}" do

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -3,8 +3,9 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_template_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 server packages are not available for RHEL 7
+    # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
+    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_template_host resources with zabbix version #{zabbix_version}" do
       template = case zabbix_version
                  when '4.0'

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
+
 describe 'zabbix_template type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
-  %w[4.0 5.0 5.2].each do |zabbix_version|
+  supported_versions.each do |zabbix_version|
     # 5.2 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_template resources with zabbix version #{zabbix_version}" do

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -3,8 +3,9 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_template type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 server packages are not available for RHEL 7
+    # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
+    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
     context "create zabbix_template resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -57,7 +57,12 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{(ubuntu-16.04|
     end
 
     let(:result_templates) do
-      zabbixapi('localhost', 'Admin', 'zabbix', 'template.get', selectApplications: ['name'], output: ['host']).result
+      # selectApplications parameter was removed in Zabbix 5.4
+      if zabbix_version =~ %r{5\.[^4]}
+        zabbixapi('localhost', 'Admin', 'zabbix', 'template.get', selectApplications: ['name'], output: ['host']).result
+      else
+        zabbixapi('localhost', 'Admin', 'zabbix', 'template.get', output: ['host']).result
+      end
     end
 
     context 'TestTemplate1' do

--- a/spec/classes/database_mysql_spec.rb
+++ b/spec/classes/database_mysql_spec.rb
@@ -21,10 +21,15 @@ describe 'zabbix::database::mysql' do
           is_expected.not_to compile.with_all_deps
         end
       end
-      # path to sql files on zabbix 3.X on Debian and RedHat
-      path = '/usr/share/doc/zabbix-*-mysql*'
 
       supported_versions.each do |zabbix_version|
+        # path to sql files on Debian and RedHat
+        path = if zabbix_version == '5.4'
+                 '/usr/share/doc/zabbix-sql-scripts/mysql/'
+               else
+                 '/usr/share/doc/zabbix-*-mysql*'
+               end
+
         context "when zabbix_type is server and zabbix version is #{zabbix_version}" do
           describe 'and database_port is defined' do
             let :params do

--- a/spec/classes/database_mysql_spec.rb
+++ b/spec/classes/database_mysql_spec.rb
@@ -24,7 +24,7 @@ describe 'zabbix::database::mysql' do
       # path to sql files on zabbix 3.X on Debian and RedHat
       path = '/usr/share/doc/zabbix-*-mysql*'
 
-      %w[4.0 5.0 5.2].each do |zabbix_version|
+      supported_versions.each do |zabbix_version|
         context "when zabbix_type is server and zabbix version is #{zabbix_version}" do
           describe 'and database_port is defined' do
             let :params do

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -16,14 +16,22 @@ describe 'zabbix::database::postgresql' do
         facts
       end
 
-      %w[4.0 5.0 5.2].each do |zabbix_version|
+      supported_versions.each do |zabbix_version|
         case facts[:os]['name']
         when 'CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux'
-          # Path for versions >= 3.x on RedHat
-          path_for3_and_up = "/usr/share/doc/zabbix-*-pgsql-#{zabbix_version}*/"
+          # Path on RedHat
+          path = if zabbix_version == '5.4'
+                   '/usr/share/doc/zabbix-sql-scripts/postgresql/'
+                 else
+                   "/usr/share/doc/zabbix-*-pgsql-#{zabbix_version}*/"
+                 end
         else
-          # Path for versions >= 3.x on Debian
-          path_for3_and_up = '/usr/share/doc/zabbix-*-pgsql'
+          # Path on Debian
+          path = if zabbix_version == '5.4'
+                   '/usr/share/doc/zabbix-sql-scripts/postgresql/'
+                 else
+                   '/usr/share/doc/zabbix-*-pgsql'
+                 end
         end
 
         describe "when zabbix_type is server and version is #{zabbix_version}" do
@@ -41,7 +49,7 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path_for3_and_up} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f create.sql && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f create.sql && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
           it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
           it { is_expected.to contain_file('/root/.pgpass') }
@@ -62,7 +70,7 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path_for3_and_up} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f create.sql && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f create.sql && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
           it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
           it { is_expected.to contain_file('/root/.pgpass') }
@@ -84,7 +92,7 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path_for3_and_up} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_class('zabbix::params') }
         end
 
@@ -102,7 +110,7 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path_for3_and_up} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_class('zabbix::params') }
         end
       end

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -80,7 +80,7 @@ describe 'zabbix::web' do
           packages = if facts[:osfamily] == 'RedHat'
                        if facts[:operatingsystemmajrelease].to_i == 7 &&
                           !%w[VirtuozzoLinux OracleLinux Scientific].include?(facts[:os]['name']) &&
-                          zabbix_version == '5.0'
+                          zabbix_version =~ %r{5\.[024]}
                          ['zabbix-web-pgsql-scl', 'zabbix-web']
                        else
                          ['zabbix-web-pgsql', 'zabbix-web']

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -13,7 +13,7 @@ describe 'zabbix::web' do
   end
 
   on_supported_os.each do |os, facts|
-    %w[4.0 5.0].each do |zabbix_version|
+    supported_versions.each do |zabbix_version|
       next if facts[:os]['name'] == 'windows'
       next if facts[:os]['name'] == 'Archlinux'
       next if facts[:os]['name'] == 'Gentoo'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,5 @@ if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
     end
   end
 end
+
+require 'support/acceptance/supported_versions'

--- a/spec/support/acceptance/supported_versions.rb
+++ b/spec/support/acceptance/supported_versions.rb
@@ -1,0 +1,3 @@
+def supported_versions
+  %w[4.0 5.0 5.2 5.4]
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds Zabbix 5.4 support.
zabbixapi gem doesn't have support for 5.4 version yet. 
For now I passed `ignore_version` parameter. It seems to be working fine as there aren't any API changes that would break the gem. If we don't feel comfortable merging this I may open a PR on zabbixapi repo.

#### This Pull Request (PR) fixes the following issues
Closes #773 (Thanks for pointing out!)
