### PR TITLE
Added details to host network interface to configure SNMP hosts

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       method: 'host.get',
       params: {
         selectParentTemplates: ['host'],
-        selectInterfaces: %w[interfaceid type main ip port useip],
+        selectInterfaces: %w[interfaceid type main ip port useip details],
         selectGroups: ['name'],
         selectMacros: %w[macro value],
         output: %w[host proxy_hostid]
@@ -35,7 +35,8 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         templates: h['parentTemplates'].map { |x| x['host'] },
         macros: h['macros'].map { |macro| { macro['macro'] => macro['value'] } },
         proxy: proxy_select,
-        interfacetype: interface['type'].to_i
+        interfacetype: interface['type'].to_i,
+        interfacedetails: interface['details']
       )
     end
   end
@@ -68,7 +69,8 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
           ip: @resource[:ipaddress],
           dns: @resource[:hostname],
           port: @resource[:port],
-          useip: @resource[:use_ip] ? 1 : 0
+          useip: @resource[:use_ip] ? 1 : 0,
+          details: @resource[:interfacedetails].nil? ? {} : @resource[:interfacedetails]
         }
       ],
       templates: templates,
@@ -153,6 +155,16 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       params: {
         interfaceid: @property_hash[:interfaceid],
         type: int
+      }
+    )
+  end
+
+  def interfacedetails=(hash)
+    zbx.query(
+      method: 'hostinterface.update',
+      params: {
+        interfaceid: @property_hash[:interfaceid],
+        details: hash
       }
     )
   end

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -52,6 +52,13 @@ Puppet::Type.newtype(:zabbix_host) do
     desc 'Interface type. 1 for zabbix agent.'
   end
 
+  newproperty(:interfacedetails) do
+    desc 'Additional interface details.'
+    def insync?(is)
+      is.to_s == should.to_s
+    end
+  end
+
   newproperty(:use_ip, boolean: true) do
     desc 'Using ipadress instead of dns to connect.'
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -26,13 +26,14 @@
 # @param zbx_group_create Whether to create hostgroup if missing.
 # @param zbx_templates List of templates which will be added when host is configured.
 # @param zbx_macros List of macros which will be added when host is configured.
-# @param zbx_interface_type Integer specifying type of interface to be created
-# @param agent_configfile_path Agent config file path defaults to /etc/zabbix/zabbix_agentd.conf
+# @param zbx_interface_type Integer specifying type of interface to be created.
+# @param zbx_interface_details Hash with interface details for SNMP when interface type is 2.
+# @param agent_configfile_path Agent config file path defaults to /etc/zabbix/zabbix_agentd.conf.
 # @param pidfile Name of pid file.
 # @param servicename Zabbix's agent service name.
 # @param logfile Name of log file.
 # @param logfilesize Maximum size of log file in MB.
-# @param logtype Specifies where log messages are written to. Can be one of: console, file, system
+# @param logtype Specifies where log messages are written to. Can be one of: console, file, system.
 # @param debuglevel Specifies debug level.
 # @param sourceip Source ip address for outgoing connections.
 # @param allowkey Allow execution of item keys matching pattern.
@@ -148,6 +149,7 @@ class zabbix::agent (
   $zbx_templates                                  = $zabbix::params::agent_zbx_templates,
   Array[Hash] $zbx_macros                         = [],
   Integer[1,4] $zbx_interface_type                = 1,
+  Hash[String, Any] $zbx_interface_details        = {},
   $agent_configfile_path                          = $zabbix::params::agent_configfile_path,
   $pidfile                                        = $zabbix::params::agent_pidfile,
   $servicename                                    = $zabbix::params::agent_servicename,
@@ -251,16 +253,17 @@ class zabbix::agent (
     $_hostname = pick($hostname, $facts['networking']['fqdn'])
 
     class { 'zabbix::resources::agent':
-      hostname      => $_hostname,
-      ipaddress     => $listen_ip,
-      use_ip        => $agent_use_ip,
-      port          => $listenport,
-      groups        => [$groups].flatten(),
-      group_create  => $zbx_group_create,
-      templates     => $zbx_templates,
-      macros        => $zbx_macros,
-      interfacetype => $zbx_interface_type,
-      proxy         => $use_proxy,
+      hostname         => $_hostname,
+      ipaddress        => $listen_ip,
+      use_ip           => $agent_use_ip,
+      port             => $listenport,
+      groups           => [$groups].flatten(),
+      group_create     => $zbx_group_create,
+      templates        => $zbx_templates,
+      macros           => $zbx_macros,
+      interfacetype    => $zbx_interface_type,
+      interfacedetails => $zbx_interface_details,
+      proxy            => $use_proxy,
     }
   }
 

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -9,19 +9,21 @@
 # @param templates List of templates which should be attached to this host.
 # @param macros Array of hashes (macros) which should be attached to this host.
 # @param proxy Whether it is monitored by an proxy or not.
-# @param interfacetype Internally used identifier for the host interface
+# @param interfacetype Internally used identifier for the host interface.
+# @param interfacedetails Hash with interface details for SNMP when interface type is 2.
 class zabbix::resources::agent (
-  $hostname                = undef,
-  $ipaddress               = undef,
-  $use_ip                  = undef,
-  $port                    = undef,
-  $group                   = undef,
-  Array[String[1]] $groups = undef,
-  $group_create            = undef,
-  $templates               = undef,
-  $macros                  = undef,
-  $proxy                   = undef,
-  $interfacetype           = 1,
+  $hostname                           = undef,
+  $ipaddress                          = undef,
+  $use_ip                             = undef,
+  $port                               = undef,
+  $group                              = undef,
+  Array[String[1]] $groups            = undef,
+  $group_create                       = undef,
+  $templates                          = undef,
+  $macros                             = undef,
+  $proxy                              = undef,
+  $interfacetype                      = 1,
+  Hash[String, Any] $interfacedetails = {},
 ) {
   if $group and $groups {
     fail("Got group and groups. This isn't support! Please use groups only.")
@@ -35,14 +37,15 @@ class zabbix::resources::agent (
   }
 
   @@zabbix_host { $hostname:
-    ipaddress     => $ipaddress,
-    use_ip        => $use_ip,
-    port          => $port,
-    groups        => $_groups,
-    group_create  => $group_create,
-    templates     => $templates,
-    macros        => $macros,
-    proxy         => $proxy,
-    interfacetype => $interfacetype,
+    ipaddress        => $ipaddress,
+    use_ip           => $use_ip,
+    port             => $port,
+    groups           => $_groups,
+    group_create     => $group_create,
+    templates        => $templates,
+    macros           => $macros,
+    proxy            => $proxy,
+    interfacetype    => $interfacetype,
+    interfacedetails => $interfacedetails,
   }
 }

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -20,6 +20,15 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debi
                    ['Linux by Zabbix agent', 'ICMP Ping']
                  end
 
+      template_snmp = case zabbix_version
+                      when '4.0'
+                        ['Template OS Linux SNMPv2']
+                      when '5.0'
+                        ['Template OS Linux SNMP']
+                      else
+                        ['Linux SNMP']
+                      end
+
       pp1 = <<-EOS
         class { 'apache':
             mpm_module => 'prefork',
@@ -83,8 +92,31 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debi
         apply_manifest(pp2, catch_changes: true)
       end
 
+      # Zabbix version 4.0 doesn't support interface details hash
+      if zabbix_version != '4.0'
+        pp3 = <<-EOS
+          zabbix_host { 'test3.example.com':
+            ipaddress        => '127.0.0.3',
+            use_ip           => false,
+            port             => 161,
+            groups           => ['Virtual machines'],
+            templates        => #{template_snmp},
+            macros           => [],
+            interfacetype    => 2,
+            interfacedetails => {"version" => "2", "bulk" => "0", "community" => "public"},
+          }
+          EOS
+
+        it 'creates host with SNMP interface and details without errors' do
+          apply_manifest(pp3, catch_failures: true)
+        end
+        it 'creates host with SNMP interface and details without changes' do
+          apply_manifest(pp3, catch_changes: true)
+        end
+      end
+
       let(:result_hosts) do
-        zabbixapi('localhost', 'Admin', 'zabbix', 'host.get', selectParentTemplates: ['host'], selectInterfaces: %w[dns ip main port type useip], selectGroups: ['name'], output: ['host', '']).result
+        zabbixapi('localhost', 'Admin', 'zabbix', 'host.get', selectParentTemplates: ['host'], selectInterfaces: %w[dns ip main port type useip details], selectGroups: ['name'], output: ['host', '']).result
       end
 
       context 'test1.example.com' do
@@ -148,6 +180,44 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debi
         end
         it 'has templates attached' do
           expect(test2['parentTemplates'].map { |t| t['host'] }.sort).to eq(template.sort)
+        end
+      end
+
+      # Zabbix version 4.0 doesn't support interface details hash
+      if zabbix_version != '4.0'
+        context 'test3.example.com' do
+          let(:test3) { result_hosts.select { |h| h['host'] == 'test3.example.com' }.first }
+
+          it 'is created' do
+            expect(test3['host']).to eq('test3.example.com')
+          end
+          it 'is in group Virtual machines' do
+            expect(test3['groups'].map { |g| g['name'] }).to eq(['Virtual machines'])
+          end
+          it 'has a correct interface dns configured' do
+            expect(test3['interfaces'][0]['dns']).to eq('test3.example.com')
+          end
+          it 'has a correct interface ip configured' do
+            expect(test3['interfaces'][0]['ip']).to eq('127.0.0.3')
+          end
+          it 'has a correct interface main configured' do
+            expect(test3['interfaces'][0]['main']).to eq('1')
+          end
+          it 'has a correct interface port configured' do
+            expect(test3['interfaces'][0]['port']).to eq('161')
+          end
+          it 'has a correct interface type configured' do
+            expect(test3['interfaces'][0]['type']).to eq('2')
+          end
+          it 'has a correct interface details configured' do
+            expect(test3['interfaces'][0]['details']).to eq('version' => '2', 'bulk' => '0', 'community' => 'public')
+          end
+          it 'has a correct interface useip configured' do
+            expect(test3['interfaces'][0]['useip']).to eq('0')
+          end
+          it 'has templates attached' do
+            expect(test3['parentTemplates'].map { |t| t['host'] }.sort).to eq(template_snmp.sort)
+          end
         end
       end
     end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Following the pull request #697 we add an hash of interface options to configure some details about SNMP.
We want to use to add SNMP host with community and other details.

Example

```
  zabbix_host { 'SNMPServer':
    ipaddress     => '192.168.1.1',
    use_ip        => true,
    port          => 161,
    groups        => ['SNMP servers'],
    group_create  => true,
    templates     => ['Template Module ICMP Ping'],
    macros        => [],
    proxy         => '',
    interfacetype => 2,
    interfacedetails => {"version" => 2, "bulk" => 0, "community" => "public"},
  }
```

Using interfacetype = 2 without details we have the error

```
{"jsonrpc":"2.0","error":{"code":-32602,"message":"Invalid params.","data":"Incorrect arguments passed to function."},"id":42907}
```

#### This Pull Request (PR) fixes the following issues

No issues opened, follow pull request #697

