### PR TITLE
Add code to ensure interfacedetails is always a hash

### DIFF
--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -54,6 +54,7 @@ Puppet::Type.newtype(:zabbix_host) do
 
   newproperty(:interfacedetails) do
     desc 'Additional interface details.'
+
     def insync?(is)
       is.to_s == should.to_s
     end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -152,7 +152,7 @@ class zabbix::agent (
   $zbx_templates                                       = $zabbix::params::agent_zbx_templates,
   Array[Hash] $zbx_macros                              = [],
   Integer[1,4] $zbx_interface_type                     = 1,
-  Hash[String, Any] $zbx_interface_details             = {},
+  Variant[Array, Hash] $zbx_interface_details          = [],
   $agent_configfile_path                               = $zabbix::params::agent_configfile_path,
   $pidfile                                             = $zabbix::params::agent_pidfile,
   $servicename                                         = $zabbix::params::agent_servicename,

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -23,7 +23,7 @@ class zabbix::resources::agent (
   $macros                             = undef,
   $proxy                              = undef,
   $interfacetype                      = 1,
-  Hash[String, Any] $interfacedetails = {},
+  Variant[Array, Hash] $interfacedetails = [],
 ) {
   if $group and $groups {
     fail("Got group and groups. This isn't support! Please use groups only.")

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -107,12 +107,20 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debi
             interfacetype    => 2,
             interfacedetails => {"version" => "2", "bulk" => "0", "community" => "public"},
           }
+          zabbix_host { 'test4.example.com':
+            ipaddress        => '127.0.0.4',
+            use_ip           => false,
+            port             => 161,
+            groups           => ['Virtual machines'],
+            templates        => #{template},
+            macros           => [],
+          }
           EOS
 
-        it 'creates host with SNMP interface and details without errors' do
+        it 'creates hosts with SNMP interface and details without errors' do
           apply_manifest(pp3, catch_failures: true)
         end
-        it 'creates host with SNMP interface and details without changes' do
+        it 'creates hosts with SNMP interface and details without changes' do
           apply_manifest(pp3, catch_changes: true)
         end
       end
@@ -187,6 +195,7 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debi
 
       # Zabbix version 4.0 doesn't support interface details hash
       if zabbix_version != '4.0'
+
         context 'test3.example.com' do
           let(:test3) { result_hosts.select { |h| h['host'] == 'test3.example.com' }.first }
 
@@ -221,6 +230,42 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debi
             expect(test3['parentTemplates'].map { |t| t['host'] }.sort).to eq(template_snmp.sort)
           end
         end
+
+        context 'test4.example.com' do
+          let(:test4) { result_hosts.select { |h| h['host'] == 'test4.example.com' }.first }
+
+          it 'is created' do
+            expect(test4['host']).to eq('test4.example.com')
+          end
+          it 'is in group Virtual machines' do
+            expect(test4['groups'].map { |g| g['name'] }).to eq(['Virtual machines'])
+          end
+          it 'has a correct interface dns configured' do
+            expect(test4['interfaces'][0]['dns']).to eq('test4.example.com')
+          end
+          it 'has a correct interface ip configured' do
+            expect(test4['interfaces'][0]['ip']).to eq('127.0.0.4')
+          end
+          it 'has a correct interface main configured' do
+            expect(test4['interfaces'][0]['main']).to eq('1')
+          end
+          it 'has a correct interface port configured' do
+            expect(test4['interfaces'][0]['port']).to eq('161')
+          end
+          it 'has a correct interface type configured' do
+            expect(test4['interfaces'][0]['type']).to eq('1')
+          end
+          it 'has a correct interface details configured' do
+            expect(test4['interfaces'][0]['details']).to eq([])
+          end
+          it 'has a correct interface useip configured' do
+            expect(test4['interfaces'][0]['useip']).to eq('0')
+          end
+          it 'has templates attached' do
+            expect(test4['parentTemplates'].map { |t| t['host'] }.sort).to eq(template.sort)
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

This PR follow PR #785 to ensure the host object idempotency. When interface details are empty the zabbix API returns an empty array and I need to convert it in an empty hash.

#### Example

This is returned by the api call:

```json
      "interfaces": [
        {
          "interfaceid": "36",
          "type": "1",
          "main": "1",
          "ip": "10.10.10.1",
          "port": "10050",
          "useip": "1",
          "details": []
        }
      ]
```

and the error on puppet is:

```
interfacedetails changed [] to {} (corrective)
```