### PR TITLE
Zabbix 42 and 44 also work fine

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -192,7 +192,7 @@ class zabbix::web (
   if $manage_resources {
     # Determine correct zabbixapi version.
     case $zabbix_version {
-      '4.0': {
+      /^4\.[024]/: {
         $zabbixapi_version = '4.2.0'
       }
       /^5\.[024]/: {


### PR DESCRIPTION
#### Pull Request (PR) description
Zabbix 4.2 and 4.4 work fine with this code. Tested

It actually works a lot better with these version then the previous major release (8) because of the updated dependency of the zabbix-api gem.