### PR TITLE
Avoid deprecated hiera_hash function

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,3 @@
+lookup_options:
+  zabbix::userparameter::data:
+    merge: hash

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,8 @@
+version: 5
+defaults:
+  datadir: data
+  data_hash: yaml_data
+
+hierarchy:
+  - name: Common
+    path: common.yaml

--- a/manifests/userparameter.pp
+++ b/manifests/userparameter.pp
@@ -1,5 +1,5 @@
-# @summary This class can be used when you use hiera or The Foreman. With this tools you can't use and define. This make use of "create_resources".
-# @param data This is the data in YAML format
+# @summary Realise zabbix::userparameters with data from Hiera or The Foreman.
+# @param data
 # @example
 #   zabbix::userparameter::data:
 #     MySQL:
@@ -8,8 +8,7 @@
 class zabbix::userparameter (
   Hash $data = {},
 ) {
-  $_data = hiera_hash('zabbix::userparameter::data', $data)
-  $_data.each |$key,$value| {
+  $data.each |$key,$value| {
     zabbix::userparameters { $key:
       * => $value,
     }


### PR DESCRIPTION
#### Pull Request (PR) description
Introduce module Hiera data with pre-defined merge behaviour for zabbix::userparameter::data.

#### This Pull Request (PR) fixes the following issues
Fixes #777 

---

As of now, there are no spec tests for the newly introduced module Hiera hierarchy and merge behaviour. I've googled around a bit and could not find a solution to integrate into this module easily. Though if you have any examples where spec tests are already implemented for a voxpupuli project with static Hiera data, I'd be willing to try that myself.