### PR TITLE
Added ability to keep templates in sync (no manual changes)

### DIFF
--- a/lib/puppet/provider/zabbix_template/ruby.rb
+++ b/lib/puppet/provider/zabbix_template/ruby.rb
@@ -8,18 +8,26 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
       rules: {
         # application parameter was removed on Zabbix 5.4
         (@resource[:zabbix_version] =~ %r{[45]\.[02]} ? :applications : nil) => {
+          deleteMissing: (@resource[:delete_missing_applications].nil? ? false : @resource[:delete_missing_applications]),
           createMissing: true
         },
         discoveryRules: {
           createMissing: true,
+          deleteMissing: (@resource[:delete_missing_drules].nil? ? false : @resource[:delete_missing_drules]),
           updateExisting: true
         },
         graphs: {
           createMissing: true,
+          deleteMissing: (@resource[:delete_missing_graphs].nil? ? false : @resource[:delete_missing_graphs]),
           updateExisting: true
         },
         groups: {
           createMissing: true
+        },
+        httptests: {
+          createMissing: true,
+          deleteMissing: (@resource[:delete_missing_httptests].nil? ? false : @resource[:delete_missing_httptests]),
+          updateExisting: true
         },
         images: {
           createMissing: true,
@@ -27,6 +35,7 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
         },
         items: {
           createMissing: true,
+          deleteMissing: (@resource[:delete_missing_items].nil? ? false : @resource[:delete_missing_items]),
           updateExisting: true
         },
         maps: {
@@ -48,11 +57,16 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
         # templateDashboards was renamed to templateScreen on Zabbix >= 5.2
         (@resource[:zabbix_version] =~ %r{5\.[24]} ? :templateDashboards : :templateScreens) => {
           createMissing: true,
+          deleteMissing: (@resource[:delete_missing_templatescreens].nil? ? false : @resource[:delete_missing_templatescreens]),
           updateExisting: true
         },
         triggers: {
           createMissing: true,
+          deleteMissing: (@resource[:delete_missing_triggers].nil? ? false : @resource[:delete_missing_triggers]),
           updateExisting: true
+        },
+        valueMaps: {
+          createMissing: true
         }
       }.delete_if { |key, _| key.nil? },
       source: template_contents

--- a/lib/puppet/type/zabbix_template.rb
+++ b/lib/puppet/type/zabbix_template.rb
@@ -39,5 +39,33 @@ Puppet::Type.newtype(:zabbix_template) do
     desc 'Zabbix version that the template will be installed on.'
   end
 
+  newparam(:delete_missing_applications, boolean: true) do
+    desc 'Delete applications from zabbix which are not in the template.'
+  end
+
+  newparam(:delete_missing_drules, boolean: true) do
+    desc 'Delete discovery rules from zabbix which are not in the template.'
+  end
+
+  newparam(:delete_missing_graphs, boolean: true) do
+    desc 'Delete graphs from zabbix which are not in the template.'
+  end
+
+  newparam(:delete_missing_httptests, boolean: true) do
+    desc 'Delete web scenarios from zabbix which are not in the template.'
+  end
+
+  newparam(:delete_missing_items, boolean: true) do
+    desc 'Delete items from zabbix which are not in the template.'
+  end
+
+  newparam(:delete_missing_templatescreens, boolean: true) do
+    desc 'Delete templateScreens from zabbix which are not in the template.'
+  end
+
+  newparam(:delete_missing_triggers, boolean: true) do
+    desc 'Delete triggers from zabbix which are not in the template.'
+  end
+
   autorequire(:file) { '/etc/zabbix/api.conf' }
 end

--- a/manifests/resources/template.pp
+++ b/manifests/resources/template.pp
@@ -3,11 +3,25 @@
 # @param template_name The name of template.
 # @param template_source Template source file.
 # @param zabbix_version Zabbix version that the template will be installed on.
+# @param delete_missing_applications Deletes applications from zabbix that are not in the template when set to true
+# @param delete_missing_drules Deletes discovery rules from zabbix that are not in the template when set to true
+# @param delete_missing_graphs Deletes graphs from zabbix that are not in the template when set to true
+# @param delete_missing_httptests Deletes web-scenarios from zabbix that are not in the template when set to true
+# @param delete_missing_items Deletes items from zabbix that are not in the template when set to true
+# @param delete_missing_templatescreens Deletes template-screens from zabbix that are not in the template when set to true
+# @param delete_missing_triggers Deletes triggers from zabbix that are not in the template when set to true
 define zabbix::resources::template (
-  $template_dir    = $zabbix::params::zabbix_template_dir,
-  $template_name   = $title,
-  $template_source = '',
-  $zabbix_version  = $zabbix::params::zabbix_version,
+  $template_dir                           = $zabbix::params::zabbix_template_dir,
+  $template_name                          = $title,
+  $template_source                        = '',
+  $zabbix_version                         = $zabbix::params::zabbix_version,
+  Boolean $delete_missing_applications    = false,
+  Boolean $delete_missing_drules          = false,
+  Boolean $delete_missing_graphs          = false,
+  Boolean $delete_missing_httptests       = false,
+  Boolean $delete_missing_items           = false,
+  Boolean $delete_missing_templatescreens = false,
+  Boolean $delete_missing_triggers        = false,
 ) {
   file { "${template_dir}/${template_name}.xml":
     ensure => file,
@@ -17,9 +31,15 @@ define zabbix::resources::template (
   }
 
   @@zabbix_template { $template_name:
-    #template_source => $template_source,
-    template_source => "${template_dir}/${template_name}.xml",
-    zabbix_version  => $zabbix_version,
-    require         => File["${template_dir}/${template_name}.xml"],
+    template_source                => "${template_dir}/${template_name}.xml",
+    zabbix_version                 => $zabbix_version,
+    require                        => File["${template_dir}/${template_name}.xml"],
+    delete_missing_applications    => $delete_missing_applications,
+    delete_missing_drules          => $delete_missing_drules,
+    delete_missing_graphs          => $delete_missing_graphs,
+    delete_missing_httptests       => $delete_missing_httptests,
+    delete_missing_items           => $delete_missing_items,
+    delete_missing_templatescreens => $delete_missing_templatescreens,
+    delete_missing_triggers        => $delete_missing_triggers,
   }
 }

--- a/manifests/template.pp
+++ b/manifests/template.pp
@@ -2,19 +2,40 @@
 # @param templ_name The name of the template. This name will be found in the Web interface
 # @param templ_source The location of the XML file wich needs to be imported.
 # @param zabbix_version The Zabbix version on which the template will be installed on.
+# @param delete_missing_applications Deletes applications from zabbix that are not in the template when set to true
+# @param delete_missing_drules Deletes discovery rules from zabbix that are not in the template when set to true
+# @param delete_missing_graphs Deletes graphs from zabbix that are not in the template when set to true
+# @param delete_missing_httptests Deletes web-scenarios from zabbix that are not in the template when set to true
+# @param delete_missing_items Deletes items from zabbix that are not in the template when set to true
+# @param delete_missing_templatescreens Deletes template-screens from zabbix that are not in the template when set to true
+# @param delete_missing_triggers Deletes triggers from zabbix that are not in the template when set to true
 # @example
 #   zabbix::template { 'Template App MySQL':
 #      templ_source => 'puppet:///modules/zabbix/MySQL.xml'
 #   }
 # @author Vladislav Tkatchev <vlad.tkatchev@gmail.com>
 define zabbix::template (
-  $templ_name     = $title,
-  $templ_source   = '',
-  String[1] $zabbix_version = $zabbix::params::zabbix_version,
+  $templ_name                             = $title,
+  $templ_source                           = '',
+  String[1] $zabbix_version               = $zabbix::params::zabbix_version,
+  Boolean $delete_missing_applications    = false,
+  Boolean $delete_missing_drules          = false,
+  Boolean $delete_missing_graphs          = false,
+  Boolean $delete_missing_httptests       = false,
+  Boolean $delete_missing_items           = false,
+  Boolean $delete_missing_templatescreens = false,
+  Boolean $delete_missing_triggers        = false,
 ) {
   zabbix::resources::template { $templ_name:
-    template_name   => $templ_name,
-    template_source => $templ_source,
-    zabbix_version  => $zabbix_version,
+    template_name                  => $templ_name,
+    template_source                => $templ_source,
+    zabbix_version                 => $zabbix_version,
+    delete_missing_applications    => $delete_missing_applications,
+    delete_missing_drules          => $delete_missing_drules,
+    delete_missing_graphs          => $delete_missing_graphs,
+    delete_missing_httptests       => $delete_missing_httptests,
+    delete_missing_items           => $delete_missing_items,
+    delete_missing_templatescreens => $delete_missing_templatescreens,
+    delete_missing_triggers        => $delete_missing_triggers,
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
Added some stuff to make the template import the same as importing from the GUI. I hope you merge it.

* Added ability to configure if you want puppet to remove unmanaged items/triggers/graphs etc from Zabbix when they are not in the template
* Added valuemappings to template import
