### PR TITLE
Default denykey to undef

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -297,7 +297,7 @@ class zabbix::params {
   $agent_buffersize                         = '100'
   $agent_debuglevel                         = '3'
   $agent_allowkey                           = undef
-  $agent_denykey                            = 'system.run[*]'
+  $agent_denykey                            = undef
   $agent_enableremotecommands               = '0'
   $agent_hostmetadata                       = undef
   $agent_hostmetadataitem                   = undef


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Having a default value makes it impossible to undef the parameter, since undefing leads to the default value being used.
As per [zabbix's](https://www.zabbix.com/documentation/5.0/en/manual/appendix/config/zabbix_agentd) documentation this parameter is no mandatory, so undef as default value should be okay.

#### This Pull Request (PR) fixes the following issues
#812 
