### PR TITLE
Add Zabbix 6.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ Take a look at the [REFERENCE.md](https://github.com/voxpupuli/puppet-zabbix/blo
 
 ## Limitations
 
-This module supports Zabbix 4.0, 5.0, 5.2 and 5.4. The upstream supported versions are documented [here](https://www.zabbix.com/de/life_cycle_and_release_policy)
+This module supports Zabbix 4.0, 5.0, 5.2, 5.4 and 6.0. The upstream supported versions are documented [here](https://www.zabbix.com/de/life_cycle_and_release_policy)
 Please have a look into the metadata.json for all supported operating systems.
 
 This module is supported on both the community and the Enterprise version of Puppet.

--- a/lib/puppet/provider/zabbix_template/ruby.rb
+++ b/lib/puppet/provider/zabbix_template/ruby.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:zabbix_template).provide(:ruby, parent: Puppet::Provider::Zab
           updateExisting: true
         },
         # templateDashboards was renamed to templateScreen on Zabbix >= 5.2
-        (@resource[:zabbix_version] =~ %r{5\.[24]} ? :templateDashboards : :templateScreens) => {
+        (@resource[:zabbix_version] =~ %r{5\.[24]|6\.0} ? :templateDashboards : :templateScreens) => {
           createMissing: true,
           deleteMissing: (@resource[:delete_missing_templatescreens].nil? ? false : @resource[:delete_missing_templatescreens]),
           updateExisting: true

--- a/lib/puppet/type/zabbix_template_host.rb
+++ b/lib/puppet/type/zabbix_template_host.rb
@@ -2,7 +2,7 @@
 
 Puppet::Type.newtype(:zabbix_template_host) do
   @doc = <<-DOC
-    Link or Unlink template to host.
+    Link or Unlink template to host. Only for Zabbix < 6.0!
 	  Example.
 	  Name should be in the format of "template_name@hostname"
 

--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -24,7 +24,7 @@ class zabbix::database::mysql (
   assert_private()
 
   if ($database_schema_path == false) or ($database_schema_path == '') {
-    if versioncmp($zabbix_version, '5.4') == 0 {
+    if versioncmp($zabbix_version, '5.4') >= 0 {
       $schema_path = '/usr/share/doc/zabbix-sql-scripts/mysql/'
     } else {
       $schema_path = '/usr/share/doc/zabbix-*-mysql*'
@@ -42,10 +42,16 @@ class zabbix::database::mysql (
 
   case $zabbix_type {
     'proxy': {
-      $zabbix_proxy_create_sql = "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < schema.sql && touch /etc/zabbix/.schema.done"
+      $zabbix_proxy_create_sql = versioncmp($zabbix_version, '6.0') >= 0 ? {
+        true  => "cd ${schema_path} && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < proxy.sql && touch /etc/zabbix/.schema.done",
+        false => "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < schema.sql && touch /etc/zabbix/.schema.done"
+      }
     }
     default: {
-      $zabbix_server_create_sql = "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < create.sql && touch /etc/zabbix/.schema.done"
+      $zabbix_server_create_sql = versioncmp($zabbix_version, '6.0') >= 0 ? {
+        true  => "cd ${schema_path} && if [ -f server.sql.gz ]; then gunzip -f server.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < server.sql && touch /etc/zabbix/.schema.done",
+        false => "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < create.sql && touch /etc/zabbix/.schema.done"
+      }
       $zabbix_server_images_sql = 'touch /etc/zabbix/.images.done'
       $zabbix_server_data_sql   = 'touch /etc/zabbix/.data.done'
     }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -355,7 +355,7 @@ class zabbix::proxy (
   }
 
   if $manage_database {
-    if versioncmp($zabbix_version, '5.4') == 0 {
+    if versioncmp($zabbix_version, '5.4') >= 0 {
       package { 'zabbix-sql-scripts':
         ensure  => present,
         require => Class['zabbix::repo'],
@@ -364,7 +364,7 @@ class zabbix::proxy (
     }
 
     # Zabbix version 5.4 uses zabbix-sql-scripts for initializing the database.
-    if versioncmp($zabbix_version, '5.4') == 0 {
+    if versioncmp($zabbix_version, '5.4') >= 0 {
       $zabbix_database_require = [Package["zabbix-proxy-${db}"], Package['zabbix-sql-scripts']]
     } else {
       $zabbix_database_require = Package["zabbix-proxy-${db}"]

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -273,7 +273,7 @@ class zabbix::server (
   Optional[Stdlib::Absolutepath] $socketdir                                   = $zabbix::params::server_socketdir,
   Optional[Stdlib::HTTPUrl] $webserviceurl                                    = undef,
 ) inherits zabbix::params {
-  # zabbix server 5.2 and 5.4 is not supported on RHEL 7.
+  # zabbix server 5.2, 5.4 and 6.0 is not supported on RHEL 7.
   # https://www.zabbix.com/documentation/current/manual/installation/install_from_packages/rhel_centos
   if $facts['os']['family'] == 'RedHat' and versioncmp($zabbix_version, '5.2') >= 0 {
     if versioncmp($facts['os']['release']['major'], '7') == 0 {
@@ -295,7 +295,7 @@ class zabbix::server (
     }
   }
 
-  if versioncmp($zabbix_version, '5.4') == 0 {
+  if versioncmp($zabbix_version, '5.4') >= 0 {
     package { 'zabbix-sql-scripts':
       ensure  => present,
       require => Class['zabbix::repo'],
@@ -309,8 +309,8 @@ class zabbix::server (
     'postgresql' : {
       $db = 'pgsql'
 
-      # Zabbix version 5.4 uses zabbix-sql-scripts for initializing the database.
-      if versioncmp($zabbix_version, '5.4') == 0 {
+      # Zabbix version >= 5.4 uses zabbix-sql-scripts for initializing the database.
+      if versioncmp($zabbix_version, '5.4') >= 0 {
         $zabbix_database_require = [Package["zabbix-server-${db}"], Package['zabbix-sql-scripts']]
       } else {
         $zabbix_database_require = Package["zabbix-server-${db}"]
@@ -335,8 +335,8 @@ class zabbix::server (
     'mysql' : {
       $db = 'mysql'
 
-      # Zabbix version 5.4 uses zabbix-sql-scripts for initializing the database.
-      if versioncmp($zabbix_version, '5.4') == 0 {
+      # Zabbix version >= 5.4 uses zabbix-sql-scripts for initializing the database.
+      if versioncmp($zabbix_version, '5.4') >= 0 {
         $zabbix_database_require = [Package["zabbix-server-${db}"], Package['zabbix-sql-scripts']]
       } else {
         $zabbix_database_require = Package["zabbix-server-${db}"]

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -195,7 +195,7 @@ class zabbix::web (
       '4.0': {
         $zabbixapi_version = '4.2.0'
       }
-      /^5\.[024]/: {
+      /^[56]\.[024]/: {
         $zabbixapi_version = '5.0.0-alpha1'
       }
       default: {

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -8,7 +8,7 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{(ubuntu-16.
     # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
     # Application API was removed in Zabbix 5.4
-    next if zabbix_version == '5.4'
+    next if zabbix_version >= '5.4'
     # No Zabbix 5.2 packages on Debian 11
     next if zabbix_version == '5.2' && default[:platform] == 'debian-11-amd64'
 

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -6,9 +6,8 @@ require 'serverspec_type_zabbixapi'
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 and 5.4 server packages are not available for RHEL 7
-    next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
-    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
+    # >= 5.2 server packages are not available for RHEL 7
+    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
     # No Zabbix 5.2 packages on Debian 11
     next if zabbix_version == '5.2' && default[:platform] == 'debian-11-amd64'
 

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -5,9 +5,8 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 and 5.4 server packages are not available for RHEL 7
-    next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
-    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
+    # >= 5.2 server packages are not available for RHEL 7
+    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
     # No Zabbix 5.2 packages on Debian 11
     next if zabbix_version == '5.2' && default[:platform] == 'debian-11-amd64'
 

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -6,9 +6,8 @@ require 'serverspec_type_zabbixapi'
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_proxy type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 and 5.4 server packages are not available for RHEL 7
-    next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
-    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
+    # >= 5.2 server packages are not available for RHEL 7
+    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
     # No Zabbix 5.2 packages on Debian 11
     next if zabbix_version == '5.2' && default[:platform] == 'debian-11-amd64'
 

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -5,9 +5,10 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_template_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 and 5.4 server packages are not available for RHEL 7
-    next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
-    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
+    # Zabbix 6.0 removed the ability to attach templates directly to hosts.
+    next if zabbix_version == '6.0'
+    # >= 5.2 server packages are not available for RHEL 7
+    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
     # No Zabbix 5.2 packages on Debian 11
     next if zabbix_version == '5.2' && default[:platform] == 'debian-11-amd64'
 

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -5,9 +5,8 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_template type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9)-amd64} do
   supported_versions.each do |zabbix_version|
-    # 5.2 and 5.4 server packages are not available for RHEL 7
-    next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'
-    next if zabbix_version == '5.4' && default[:platform] == 'el-7-x86_64'
+    # >= 5.2 server packages are not available for RHEL 7
+    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
     # No Zabbix 5.2 packages on Debian 11
     next if zabbix_version == '5.2' && default[:platform] == 'debian-11-amd64'
 

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -23,19 +23,26 @@ describe 'zabbix::database::postgresql' do
         path = case facts[:os]['name']
                when 'CentOS', 'RedHat', 'OracleLinux', 'VirtuozzoLinux'
                  # Path on RedHat
-                 if zabbix_version == '5.4'
+                 if Puppet::Util::Package.versioncmp(zabbix_version, '5.4') >= 0
                    '/usr/share/doc/zabbix-sql-scripts/postgresql/'
                  else
                    "/usr/share/doc/zabbix-*-pgsql-#{zabbix_version}*/"
                  end
                else
                  # Path on Debian
-                 if zabbix_version == '5.4'
+                 if Puppet::Util::Package.versioncmp(zabbix_version, '5.4') >= 0
                    '/usr/share/doc/zabbix-sql-scripts/postgresql/'
                  else
                    '/usr/share/doc/zabbix-*-pgsql'
                  end
                end
+
+        sql_server = case zabbix_version
+                     when '6.0'
+                       'server.sql'
+                     else
+                       'create.sql'
+                     end
 
         describe "when zabbix_type is server and version is #{zabbix_version}" do
           let :params do
@@ -52,7 +59,7 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f create.sql && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
           it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
           it { is_expected.to contain_file('/root/.pgpass') }
@@ -73,7 +80,7 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f create.sql && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
           it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
           it { is_expected.to contain_file('/root/.pgpass') }
@@ -95,7 +102,12 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+
+          if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
+            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+          else
+            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+          end
           it { is_expected.to contain_class('zabbix::params') }
         end
 
@@ -113,7 +125,13 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+
+          if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
+            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+          else
+            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+          end
+
           it { is_expected.to contain_class('zabbix::params') }
         end
       end

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -84,7 +84,7 @@ describe 'zabbix::web' do
           packages = if facts[:osfamily] == 'RedHat'
                        if facts[:operatingsystemmajrelease].to_i == 7 &&
                           !%w[VirtuozzoLinux OracleLinux Scientific].include?(facts[:os]['name']) &&
-                          zabbix_version =~ %r{5\.[024]}
+                          Puppet::Util::Package.versioncmp(zabbix_version, '5.0') >= 0
                          %w[zabbix-web-pgsql-scl zabbix-web]
                        else
                          %w[zabbix-web-pgsql zabbix-web]

--- a/spec/support/acceptance/prepare_host.rb
+++ b/spec/support/acceptance/prepare_host.rb
@@ -22,6 +22,7 @@ def prepare_host
   /opt/puppetlabs/bin/puppet resource package zabbix-server-pgsql ensure=purged
   /opt/puppetlabs/bin/puppet resource package zabbix-web-pgsql ensure=purged
   /opt/puppetlabs/bin/puppet resource package zabbix-frontend-php ensure=purged
+  /opt/puppetlabs/bin/puppet resource package zabbix-sql-scripts ensure=purged
   /opt/puppetlabs/puppet/bin/gem uninstall zabbixapi -a
   rm -f /etc/zabbix/.*done
   if id postgres > /dev/null 2>&1; then
@@ -38,6 +39,7 @@ def prepare_host
   /opt/puppetlabs/bin/puppet resource package zabbix-web-pgsql ensure=purged
   /opt/puppetlabs/bin/puppet resource package zabbix-web-pgsql-scl ensure=purged
   /opt/puppetlabs/bin/puppet resource package zabbix-frontend-php ensure=purged
+  /opt/puppetlabs/bin/puppet resource package zabbix-sql-scripts ensure=purged
   /opt/puppetlabs/puppet/bin/gem uninstall zabbixapi -a
   rm -f /etc/zabbix/.*done
   if id postgres > /dev/null 2>&1; then

--- a/spec/support/acceptance/supported_versions.rb
+++ b/spec/support/acceptance/supported_versions.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 def supported_versions
-  %w[4.0 5.0 5.2 5.4]
+  %w[4.0 5.0 5.2 5.4 6.0]
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Adds support for Zabbix 6.0 LTS release.

Things that may need to be added to this PR before merging:
* Ability to migrate database while updating from an non 6.x version. `/usr/share/doc/zabbix-sql-scripts/history_pk_prepare.sql` needs to be executed against the database. Haven't found a way to tackle this. Maybe we just need to add a note on the release for people to be aware?
* Zabbix 6.0 removed the ability to be able to attach Templates directly to host via the API. This automatically renders the `zabbix_template_host` unsable on Zabbix 6.0
The only way to attach Templates is via attaching them to Host Groups, so possibly a new provider is needed

#### This Pull Request (PR) fixes the following issues
Closes #814 
