### PR TITLE
Adding additional parameters for FPM configuration.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -197,6 +197,8 @@
 # @param saml_sp_key The location of the SAML Service Provider Key file.
 # @param saml_sp_cert The location of the SAML Service Provider Certificate.
 # @param saml_idp_cert The location of the SAML Identity Provider Certificate.
+# @param fpm_max_requests The number of requests each child process should execute before respawning.
+# @param fpm_max_spare_servers The desired maximum number of idle server processes.
 # @param saml_settings A hash of additional SAML SSO settings.
 # @example Single host setup:
 #   class { 'zabbix':
@@ -341,7 +343,8 @@ class zabbix (
   Optional[Stdlib::Absolutepath] $saml_sp_key                                 = $zabbix::params::saml_sp_key,
   Optional[Stdlib::Absolutepath] $saml_sp_cert                                = $zabbix::params::saml_sp_cert,
   Optional[Stdlib::Absolutepath] $saml_idp_cert                               = $zabbix::params::saml_idp_cert,
-  Optional[Integer[1, 1000]] $fpm_max_requests                                = $zabbix::params::fpm_max_requests,
+  Optional[Integer[1, 10000]] $fpm_max_requests                               = $zabbix::params::fpm_max_requests,
+  Optional[Integer[1, 1000]] $fpm_max_spare_servers                           = $zabbix::params::fpm_max_spare_servers,
   Hash[String[1], Variant[ScalarData, Hash]] $saml_settings                   = $zabbix::params::saml_settings,
 ) inherits zabbix::params {
   class { 'zabbix::web':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -341,6 +341,7 @@ class zabbix (
   Optional[Stdlib::Absolutepath] $saml_sp_key                                 = $zabbix::params::saml_sp_key,
   Optional[Stdlib::Absolutepath] $saml_sp_cert                                = $zabbix::params::saml_sp_cert,
   Optional[Stdlib::Absolutepath] $saml_idp_cert                               = $zabbix::params::saml_idp_cert,
+  Optional[Integer[1, 1000]] $fpm_max_requests                                = $zabbix::params::fpm_max_requests,
   Hash[String[1], Variant[ScalarData, Hash]] $saml_settings                   = $zabbix::params::saml_settings,
 ) inherits zabbix::params {
   class { 'zabbix::web':
@@ -388,6 +389,8 @@ class zabbix (
     saml_sp_cert                             => $saml_sp_cert,
     saml_idp_cert                            => $saml_idp_cert,
     saml_settings                            => $saml_settings,
+    fpm_max_requests                         => $fpm_max_requests,
+    fpm_max_spare_servers                    => $fpm_max_spare_servers,
     manage_selinux                           => $manage_selinux,
     require                                  => Class['zabbix::server'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -189,6 +189,7 @@ class zabbix::params {
   $saml_sp_cert                             = undef
   $saml_idp_cert                            = undef
   $saml_settings                            = {}
+  $fpm_max_spare_servers                    = 35
 
   # Zabbix-server
   $server_alertscriptspath                  = '/etc/zabbix/alertscripts'

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -139,6 +139,8 @@ class zabbix::web (
   Optional[Stdlib::Absolutepath] $saml_sp_key                         = $zabbix::params::saml_sp_key,
   Optional[Stdlib::Absolutepath] $saml_sp_cert                        = $zabbix::params::saml_sp_cert,
   Optional[Stdlib::Absolutepath] $saml_idp_cert                       = $zabbix::params::saml_idp_cert,
+  Optional[Integer[1, 1000]] $fpm_max_requests                        = $zabbix::params::fpm_max_requests,
+  Optional[Integer[1, 100]] $fpm_max_spare_servers                    = $zabbix::params::fpm_max_spare_servers,
   Hash[String[1], Variant[ScalarData, Hash]] $saml_settings           = $zabbix::params::saml_settings,
   $puppetgem                                                          = $zabbix::params::puppetgem,
   Boolean $manage_selinux                                             = $zabbix::params::manage_selinux,

--- a/templates/web/php-fpm.d.zabbix.conf.epp
+++ b/templates/web/php-fpm.d.zabbix.conf.epp
@@ -12,6 +12,12 @@ pm.max_children = 50
 pm.start_servers = 5
 pm.min_spare_servers = 5
 pm.max_spare_servers = 35
+<% if $zabbix::web::fpm_max_requests { %>
+pm.max_requests = <%= $zabbix::web::fpm_max_requests %>
+<% } %>
+<% if $zabbix::web::fpm_max_spare_servers { %>
+pm.max_spare_servers = <%= $zabbix::web::fpm_max_spare_servers %>
+<% } %>
 
 php_value[session.save_handler] = files
 php_value[session.save_path]    = /var<%= $zabbix::web::fpm_scl_prefix %>/lib/php/session/

--- a/templates/web/php-fpm.d.zabbix.conf.epp
+++ b/templates/web/php-fpm.d.zabbix.conf.epp
@@ -11,12 +11,9 @@ pm = dynamic
 pm.max_children = 50
 pm.start_servers = 5
 pm.min_spare_servers = 5
-pm.max_spare_servers = 35
+pm.max_spare_servers = <%= $zabbix::web::fpm_max_spare_servers %>
 <% if $zabbix::web::fpm_max_requests { %>
 pm.max_requests = <%= $zabbix::web::fpm_max_requests %>
-<% } %>
-<% if $zabbix::web::fpm_max_spare_servers { %>
-pm.max_spare_servers = <%= $zabbix::web::fpm_max_spare_servers %>
 <% } %>
 
 php_value[session.save_handler] = files


### PR DESCRIPTION
#### Pull Request (PR) description

This PR adds support for the 2 FPM configurations mentioned [here](https://www.zabbix.com/forum/zabbix-troubleshooting-and-problems/402946-zabbix-5-0-high-memory-utilization-php-fpm) that appear to resolve issues with FPM memory usage on RHEL/CentOS hosts.

#### This Pull Request (PR) fixes the following issues

No issues related to this PR