### PR TITLE
Escape string inside update_pgpass command

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -65,9 +65,9 @@ class zabbix::database::postgresql (
   }
 
   exec { 'update_pgpass':
-    command => "echo ${database_host}:5432:${database_name}:${database_user}:${database_password} >> /root/.pgpass",
+    command => "echo ${database_host}:5432:${database_name}:${database_user}:${shell_escape($database_password)} >> /root/.pgpass",
     path    => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-    unless  => "grep \"${database_host}:5432:${database_name}:${database_user}:${database_password}\" /root/.pgpass",
+    unless  => "grep ${database_host}:5432:${database_name}:${database_user}:${shell_escape($database_password)} /root/.pgpass",
     require => File['/root/.pgpass'],
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description

The `update_pgpass` resource may fail when using strong `${database_password}` that contain special characters such as `&` because the echoed string is not escaped. This Pull request adds ~~double quotes~~ `shell_escape()` (as suggested by @smortex).

#### This Pull Request (PR) fixes the following issues

- Fixes #830
