### PR TITLE
Drop EoL Ubuntu 16.04

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -151,7 +151,7 @@ class zabbix::web (
   # zabbix frontend 5.x is not supported, among others, on stretch and xenial.
   # https://www.zabbix.com/documentation/current/manual/installation/frontend/frontend_on_debian
   if $facts['os']['name'] in ['ubuntu', 'debian'] and versioncmp($zabbix_version, '5') >= 0 {
-    if versioncmp($facts['os']['release']['major'], '16.04') == 0 or versioncmp($facts['os']['release']['major'], '9') == 0 {
+    if versioncmp($facts['os']['release']['major'], '9') == 0 {
       fail("${facts['os']['family']} ${$facts['os']['release']['major']} is not supported for zabbix::web")
     }
   }
@@ -227,29 +227,7 @@ class zabbix::web (
   case $facts['os']['name'] {
     'ubuntu', 'debian': {
       $zabbix_web_package = 'zabbix-frontend-php'
-
-      # Check OS release for proper prefix
-      case $facts['os']['name'] {
-        'Ubuntu': {
-          if versioncmp($facts['os']['release']['major'], '16.04') >= 0 {
-            $php_db_package = "php-${db}"
-          }
-          else {
-            $php_db_package = "php5-${db}"
-          }
-        }
-        'Debian': {
-          if versioncmp($facts['os']['release']['major'], '9') >= 0 {
-            $php_db_package = "php-${db}"
-          }
-          else {
-            $php_db_package = "php5-${db}"
-          }
-        }
-        default: {
-          $php_db_package = "php5-${db}"
-        }
-      }
+      $php_db_package = "php-${db}"
 
       package { $php_db_package:
         ensure => $zabbix_package_state,

--- a/metadata.json
+++ b/metadata.json
@@ -107,7 +107,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04",
         "20.04"
       ]

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_application type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9|archlinux)} do
+describe 'zabbix_application type', unless: default[:platform] =~ %r{(debian-9|archlinux)} do
   supported_versions.each do |zabbix_version|
     # 5.2 and 5.4 server packages are not available for RHEL 7
     next if zabbix_version == '5.2' && default[:platform] == 'el-7-x86_64'

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
 # rubocop:disable RSpec/LetBeforeExamples
-describe 'zabbix_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9|archlinux)} do
+describe 'zabbix_host type', unless: default[:platform] =~ %r{(debian-9|archlinux)} do
   supported_versions.each do |zabbix_version|
     # >= 5.2 server packages are not available for RHEL 7
     next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9|archlinux)} do
+describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{(debian-9|archlinux)} do
   supported_versions.each do |zabbix_version|
     # >= 5.2 server packages are not available for RHEL 7
     next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
 # rubocop:disable RSpec/LetBeforeExamples
-describe 'zabbix_proxy type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9|archlinux)} do
+describe 'zabbix_proxy type', unless: default[:platform] =~ %r{(debian-9|archlinux)} do
   supported_versions.each do |zabbix_version|
     # >= 5.2 server packages are not available for RHEL 7
     next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_template_host type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9|archlinux)} do
+describe 'zabbix_template_host type', unless: default[:platform] =~ %r{(debian-9|archlinux)} do
   supported_versions.each do |zabbix_version|
     # Zabbix 6.0 removed the ability to attach templates directly to hosts.
     next if zabbix_version == '6.0'

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_template type', unless: default[:platform] =~ %r{(ubuntu-16.04|debian-9|archlinux)} do
+describe 'zabbix_template type', unless: default[:platform] =~ %r{(debian-9|archlinux)} do
   supported_versions.each do |zabbix_version|
     # >= 5.2 server packages are not available for RHEL 7
     next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -52,28 +52,6 @@ describe 'zabbix::repo' do
 
             it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/5.0/debian/') }
           end
-        when '16.04'
-          context 'on Ubuntu 14.04 and Zabbix 5.0' do
-            let :params do
-              {
-                zabbix_version: '5.0',
-                manage_repo: true
-              }
-            end
-
-            it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/5.0/ubuntu/') }
-          end
-
-          context 'on Ubuntu 16.04 and Zabbix 4.0' do
-            let :params do
-              {
-                zabbix_version: '4.0',
-                manage_repo: true
-              }
-            end
-
-            it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/4.0/ubuntu/') }
-          end
         end
       when 'RedHat'
 

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -20,7 +20,6 @@ describe 'zabbix::web' do
       next if facts[:os]['name'] == 'Archlinux'
       next if facts[:os]['name'] == 'Gentoo'
       next if facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'] == '9'
-      next if facts[:os]['name'] == 'Ubuntu' && facts[:os]['release']['major'] == '16.04'
       # There are no zabbix 5.2 packages for Debian 11
       next if facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'] == '11' && zabbix_version == '5.2'
 
@@ -64,22 +63,7 @@ describe 'zabbix::web' do
             super().merge(zabbix_version: zabbix_version)
           end
 
-          pgsqlpackage = case facts[:operatingsystem]
-                         when 'Ubuntu'
-                           if facts[:operatingsystemmajrelease] >= '16.04'
-                             'php-pgsql'
-                           else
-                             'php5-pgsql'
-                           end
-                         when 'Debian'
-                           if facts[:operatingsystemmajrelease].to_i >= 9
-                             'php-pgsql'
-                           else
-                             'php5-pgsql'
-                           end
-                         else
-                           'php5-pgsql'
-                         end
+          pgsqlpackage = 'php-pgsql'
 
           packages = if facts[:osfamily] == 'RedHat'
                        if facts[:operatingsystemmajrelease].to_i == 7 &&
@@ -104,22 +88,7 @@ describe 'zabbix::web' do
             super().merge(database_type: 'mysql')
           end
 
-          mysqlpackage = case facts[:operatingsystem]
-                         when 'Ubuntu'
-                           if facts[:operatingsystemmajrelease] >= '16.04'
-                             'php-mysql'
-                           else
-                             'php5-mysql'
-                           end
-                         when 'Debian'
-                           if facts[:operatingsystemmajrelease].to_i >= 9
-                             'php-mysql'
-                           else
-                             'php5-mysql'
-                           end
-                         else
-                           'php5-mysql'
-                         end
+          mysqlpackage = 'php-mysql'
 
           packages = facts[:osfamily] == 'RedHat' ? %w[zabbix-web-mysql zabbix-web] : ['zabbix-frontend-php', mysqlpackage]
           packages.each do |package|

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -13,7 +13,7 @@ def baseline_os_hash
       },
       {
         'operatingsystem' => 'Ubuntu',
-        'operatingsystemrelease' => %w[16.04 18.04 20.04]
+        'operatingsystemrelease' => %w[18.04 20.04]
       },
       {
         'operatingsystem' => 'Archlinux',


### PR DESCRIPTION

#### Pull Request (PR) description
Ubuntu 16.04 has been EoL since 30/04/21 

#### This Pull Request (PR) fixes the following issues
