### PR TITLE
Add repo for Ubuntu on aarch64

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -120,6 +120,11 @@ class zabbix::repo (
         } else {
           if ($facts['os']['distro']['id'] == 'Raspbian') {
             $operatingsystem = 'raspbian'
+          } elsif ($facts['os']['architecture'] == 'aarch64' and downcase($facts['os']['name']) == 'ubuntu') {
+            $operatingsystem = 'ubuntu-arm64'
+            if versioncmp($zabbix_version, '5.0') < 0 {
+              fail('Only packages for zabbix version 5.0 and newer are available for arm64!')
+            }
           } else {
             $operatingsystem = downcase($facts['os']['name'])
           }

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -53,6 +53,33 @@ describe 'zabbix::repo' do
             it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/5.0/debian/') }
           end
         end
+
+        if facts[:os]['distro']['id'] == 'Ubuntu'
+          case facts[:os]['architecture']
+          when 'amd64'
+            context 'on Ubuntu with architecture amd64' do
+              let :params do
+                {
+                  zabbix_version: '6.2',
+                  manage_repo: true
+                }
+              end
+
+              it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/6.2/ubuntu/') }
+            end
+          when 'aarch64'
+            context 'on Ubuntu with architecture aarch64' do
+              let :params do
+                {
+                  zabbix_version: '6.2',
+                  manage_repo: true
+                }
+              end
+
+              it { is_expected.to contain_apt__source('zabbix').with_location('http://repo.zabbix.com/zabbix/6.2/ubuntu-arm64/') }
+            end
+          end
+        end
       when 'RedHat'
 
         it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
Zabbix now provides Ubuntu Focal deb packages for the arm64 architecture:
https://support.zabbix.com/browse/ZBXNEXT-5982

They can be found under a different URL than "usual", for example:
https://repo.zabbix.com/zabbix/5.2/ubuntu-arm64/

so the repo.pp manifest has to be adapted to refelct this.

Be careful: Right now, Zabbix only provides aarch64 packages for version 5.0 and higher.