### PR TITLE
Drop support for Puppet 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,86 +7,12 @@ name: CI
 on: pull_request
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  setup_matrix:
-    name: 'Setup Test Matrix'
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    outputs:
-      puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
-      github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-      - name: Run static validations
-        run: bundle exec rake validate lint check
-      - name: Run rake rubocop
-        run: bundle exec rake rubocop
-      - name: Setup Test Matrix
-        id: get-outputs
-        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround CentOS,Ubuntu
-
-  unit:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
-    name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake parallel_spec
-
-  acceptance:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    env:
-      LANG: en_US
-      LC_ALL: en_US.UTF-8
-      BUNDLE_WITHOUT: development:test:release
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
-    name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake beaker
-        env:
-          BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
-          BEAKER_setfile: ${{ matrix.setfile.value }}
-
-  tests:
-    needs:
-      - unit
-      - acceptance
-    runs-on: ubuntu-latest
-    name: Test suite
-    steps:
-      - run: echo Test suite completed
+  puppet:
+    name: Puppet
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
+    with:
+      pidfile_workaround: 'CentOS,Ubuntu'

--- a/.msync.yml
+++ b/.msync.yml
@@ -2,4 +2,4 @@
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
-modulesync_config_version: '5.2.0'
+modulesync_config_version: '5.3.0'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,7 @@
 ---
-inherit_from: .rubocop_todo.yml
-
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
+inherit_from: .rubocop_todo.yml
 inherit_gem:
   voxpupuli-test: rubocop.yml

--- a/.sync.yml
+++ b/.sync.yml
@@ -9,8 +9,6 @@ spec/spec_helper.rb:
   spec_overrides:
     - "require 'support/acceptance/supported_versions'"
     - "require 'spec_helper_methods'"
-spec/spec_helper_acceptance.rb:
-  unmanaged: false
 .github/workflows/ci.yml:
   pidfile_workaround: CentOS,Ubuntu
 .puppet-lint.rc:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
-  gem 'voxpupuli-test', '~> 5.0',   :require => false
+  gem 'voxpupuli-test', '~> 5.4',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 1.0',  :require => false

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -16,12 +16,6 @@ describe 'zabbix::agent' do
 
   on_supported_os(baseline_os_hash).each do |os, facts|
     context "on #{os}" do
-      systemd_fact = case facts[:osfamily]
-                     when 'Archlinux', 'Fedora', 'Gentoo'
-                       { systemd: true }
-                     else
-                       { systemd: false }
-                     end
       config_path = case facts[:operatingsystem]
                     when 'Fedora'
                       '/etc/zabbix_agentd.conf'
@@ -45,9 +39,7 @@ describe 'zabbix::agent' do
                     end
       zabbix_version = '5.0'
 
-      let :facts do
-        facts.merge(systemd_fact)
-      end
+      let(:facts) { facts }
 
       case facts[:osfamily]
       when 'Gentoo'

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -213,7 +213,7 @@ describe 'zabbix::agent' do
       context 'it creates a startup script' do
         if facts[:kernel] == 'Linux'
           case facts[:osfamily]
-          when 'Archlinux', 'Fedora', 'Gentoo'
+          when 'Archlinux', 'Debian', 'Gentoo', 'RedHat'
             it { is_expected.to contain_file("/etc/init.d/#{service_name}").with_ensure('absent') }
             it { is_expected.to contain_file("/etc/systemd/system/#{service_name}.service").with_ensure('file') }
           when 'windows'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -147,7 +147,7 @@ describe 'zabbix::server' do
 
       context 'it creates a startup script' do
         case facts[:osfamily]
-        when 'Archlinux', 'Fedora', 'Gentoo'
+        when 'Archlinux', 'Debian', 'Gentoo', 'RedHat'
           it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('absent') }
           it { is_expected.to contain_file('/etc/systemd/system/zabbix-server.service').with_ensure('file') }
         else

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -13,15 +13,7 @@ describe 'zabbix::server' do
     next if facts[:os]['name'] == 'windows'
 
     context "on #{os}" do
-      systemd_fact = case facts[:osfamily]
-                     when 'Archlinux', 'Fedora', 'Gentoo'
-                       { systemd: true }
-                     else
-                       { systemd: false }
-                     end
-      let :facts do
-        facts.merge(systemd_fact)
-      end
+      let(:facts) { facts }
 
       zabbix_version = '5.0'
 

--- a/spec/defines/userparameters_spec.rb
+++ b/spec/defines/userparameters_spec.rb
@@ -7,15 +7,7 @@ describe 'zabbix::userparameters', type: :define do
     next if facts[:os]['name'] == 'windows'
 
     context "on #{os}" do
-      let :facts do
-        systemd_fact = case facts[:os]['family']
-                       when 'Archlinux', 'Fedora', 'Gentoo'
-                         { systemd: true }
-                       else
-                         { systemd: false }
-                       end
-        facts.merge(systemd_fact)
-      end
+      let(:facts) { facts }
       let(:title) { 'mysqld' }
       let(:pre_condition) { 'class { "zabbix::agent": include_dir => "/etc/zabbix/zabbix_agentd.d" }' }
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,6 +1,0 @@
-# Needed for os.distro.codebase fact on ubuntu 16/18 on puppet 6
-if $facts['os']['name'] == 'Ubuntu' and versioncmp($facts['puppetversion'], '7.0.0') < 0 {
-  package{'lsb-release':
-    ensure => present,
-  }
-}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 
 require 'voxpupuli/test/spec_helper'
 
+add_mocked_facts!
+
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
   facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
   facts&.each do |name, value|

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,9 +6,7 @@ configure_beaker do
   # In Puppet 7 the locale ends up being C.UTF-8 if it isn't passed.
   # This locale doesn't exist in EL7 and won't be supported either.
   # At least PostgreSQL runs into this.
-  if host['hypervisor'] == 'docker' && host['platform'] == 'el-7-x86_64'
-    ENV['LANG'] = 'en_US.UTF-8'
-  end
+  ENV['LANG'] = 'en_US.UTF-8' if host['hypervisor'] == 'docker' && host['platform'] == 'el-7-x86_64'
 end
 
 Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
-# Managed by modulesync - DO NOT EDIT
-# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
-
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-configure_beaker
+configure_beaker do
+  # In Puppet 7 the locale ends up being C.UTF-8 if it isn't passed.
+  # This locale doesn't exist in EL7 and won't be supported either.
+  # At least PostgreSQL runs into this.
+  if host['hypervisor'] == 'docker' && host['platform'] == 'el-7-x86_64'
+    ENV['LANG'] = 'en_US.UTF-8'
+  end
+end
 
 Dir['./spec/support/acceptance/**/*.rb'].sort.each { |f| require f }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,7 +2,7 @@
 
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-configure_beaker do
+configure_beaker do |host|
   # In Puppet 7 the locale ends up being C.UTF-8 if it isn't passed.
   # This locale doesn't exist in EL7 and won't be supported either.
   # At least PostgreSQL runs into this.

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -18,9 +18,10 @@ def baseline_os_hash
       {
         'operatingsystem' => 'Archlinux',
       },
-      {
-        'operatingsystem' => 'Gentoo',
-      },
+      # TODO: Support and tests for Gentoo need to be fixed
+      # {
+      #   'operatingsystem' => 'Gentoo',
+      # },
       {
         'operatingsystem' => 'windows',
         'operatingsystemrelease' => ['2012', '2012 R2', '2016']


### PR DESCRIPTION
This module install gems using the `puppet_gem` provider in the gempath of the version of Ruby bundled with Puppet.  Puppet 6 bundle Ruby 2.5 which has reached EoL on 2022-04-05, and the gems the module needs depend on gems that do not offer support for this version of Ruby anymore.
    
This break CI and the situation has no reason to improve in the future, so stop advertising support for Puppet 6.

This PR also include:
* #834 