### PR TITLE
Add charset and collate parameters for zabbix::proxy

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2505,6 +2505,8 @@ The following parameters are available in the `zabbix::proxy` class:
 * [`database_password`](#database_password)
 * [`database_socket`](#database_socket)
 * [`database_port`](#database_port)
+* [`database_charset`](#database_collate)
+* [`database_collate`](#database_collate)
 * [`database_tlsconnect`](#database_tlsconnect)
 * [`database_tlscafile`](#database_tlscafile)
 * [`database_tlscertfile`](#database_tlscertfile)
@@ -2873,6 +2875,22 @@ Data type: `Any`
 Database port when not using local socket. Ignored for sqlite.
 
 Default value: `$zabbix::params::proxy_database_port`
+
+##### <a name="database_charset"></a>`database_charset`
+
+Data type: `Any`
+
+The default charset of the database.
+
+Default value: `$zabbix::params::server_database_charset`
+
+##### <a name="database_collate"></a>`database_collate`
+
+Data type: `Any`
+
+The default collation of the database.
+
+Default value: `$zabbix::params::server_database_collate`
 
 ##### <a name="database_tlsconnect"></a>`database_tlsconnect`
 

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -43,6 +43,8 @@
 # @param database_password Database password. ignored for sqlite.
 # @param database_socket Path to mysql socket.
 # @param database_port Database port when not using local socket. Ignored for sqlite.
+# @param database_charset The default charset of the database.
+# @param database_collate The default collation of the database.
 # @param database_tlsconnect
 #   Available options:
 #   * required - connect using TLS
@@ -220,6 +222,8 @@ class zabbix::proxy (
   $database_password                                                          = $zabbix::params::proxy_database_password,
   $database_socket                                                            = $zabbix::params::proxy_database_socket,
   $database_port                                                              = $zabbix::params::proxy_database_port,
+  $database_charset                                                           = $zabbix::params::server_database_charset,
+  $database_collate                                                           = $zabbix::params::server_database_collate,
   Optional[Enum['required', 'verify_ca', 'verify_full']] $database_tlsconnect = $zabbix::params::proxy_database_tlsconnect,
   Optional[Stdlib::Absolutepath] $database_tlscafile                          = $zabbix::params::proxy_database_tlscafile,
   Optional[Stdlib::Absolutepath] $database_tlscertfile                        = $zabbix::params::proxy_database_tlscertfile,
@@ -487,6 +491,8 @@ class zabbix::proxy (
       database_user     => $database_user,
       database_password => $database_password,
       database_host     => $database_host,
+      database_charset  => $database_charset,
+      database_collate  => $database_collate,
       zabbix_proxy      => $zabbix_proxy,
       zabbix_proxy_ip   => $zabbix_proxy_ip,
       before            => $before_database,


### PR DESCRIPTION
#### Pull Request (PR) description
Add `database_charset` and `database_collate` parameters for `zabbix::proxy` class.

#### This Pull Request (PR) fixes the following issues
Fixes #832 
