### PR TITLE
On RHEL systems do not try to install the centos-release-scl package as its not present and fails

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -81,8 +81,8 @@ class zabbix::repo (
             priority => '1',
           }
         }
-
-        if ($facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
+        
+        if ($facts['os']['name'] != 'RedHat' $facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
           package { 'zabbix-required-scl-repo':
             ensure => 'latest',
             name   => 'centos-release-scl',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -82,7 +82,7 @@ class zabbix::repo (
           }
         }
         
-        if ($facts['os']['name'] != 'RedHat' $facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
+        if ($facts['os']['name'] != 'RedHat' and $facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
           package { 'zabbix-required-scl-repo':
             ensure => 'latest',
             name   => 'centos-release-scl',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -81,7 +81,7 @@ class zabbix::repo (
             priority => '1',
           }
         }
-        
+
         if ($facts['os']['name'] != 'RedHat' and $facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
           package { 'zabbix-required-scl-repo':
             ensure => 'latest',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -82,7 +82,7 @@ class zabbix::repo (
           }
         }
 
-        if ($facts['os']['name'] != 'RedHat' and $facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
+        if ($facts['os']['name'] != 'RedHat' and $facts['os']['name'] != 'OracleLinux' and $facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
           package { 'zabbix-required-scl-repo':
             ensure => 'latest',
             name   => 'centos-release-scl',


### PR DESCRIPTION
#### Pull Request (PR) description

On RHEL systems do not try to install the centos-release-scl package as its not present and fails it

I chose to specifically chose to exclude Red Hat rather than to only trigger when CentOS is detected, i am unclear if the scl release will install on other variants like Rocky or AlmaLinux or not - and figured it was safer to only deal with the specific use case - otherwise this could be changed if required

#### This Pull Request (PR) fixes the following issues

Fixes #823 

