### PR TITLE
Certificate authentication in zabbix_host resource

### DIFF
--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         selectInterfaces: %w[interfaceid type main ip port useip details],
         selectGroups: ['name'],
         selectMacros: %w[macro value],
-        output: %w[host proxy_hostid]
+        output: %w[host proxy_hostid tls_accept tls_connect tls_issuer tls_subject]
       }
     )
 
@@ -38,7 +38,11 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         macros: h['macros'].map { |macro| { macro['macro'] => macro['value'] } },
         proxy: proxy_select,
         interfacetype: interface['type'].to_i,
-        interfacedetails: interface['details']
+        interfacedetails: interface['details'],
+        tls_accept: h['tls_accept'].to_i,
+        tls_connect: h['tls_connect'].to_i,
+        tls_issuer: h['tls_issuer'].to_s,
+        tls_subject: h['tls_subject'].to_s
       )
     end
   end
@@ -60,6 +64,9 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
 
     proxy_hostid = @resource[:proxy].nil? || @resource[:proxy].empty? ? nil : zbx.proxies.get_id(host: @resource[:proxy])
 
+    tls_accept = @resource[:tls_accept].nil? ? 1 : @resource[:tls_accept]
+    tls_connect = @resource[:tls_connect].nil? ? 1 : @resource[:tls_connect]
+
     # Now we create the host
     zbx.hosts.create(
       host: @resource[:hostname],
@@ -76,7 +83,11 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         }
       ],
       templates: templates,
-      groups: groups
+      groups: groups,
+      tls_connect: tls_connect,
+      tls_accept: tls_accept,
+      tls_issuer: @resource[:tls_issuer].nil? ? '' : @resource[:tls_issuer],
+      tls_subject: @resource[:tls_subject].nil? ? '' : @resource[:tls_subject]
     )
   end
 
@@ -222,6 +233,39 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     zbx.hosts.create_or_update(
       host: @resource[:hostname],
       proxy_hostid: zbx.proxies.get_id(host: string)
+    )
+  end
+
+  def tls_connect=(int)
+    @property_hash[:tls_connect] = int
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      tls_connect: @property_hash[:tls_connect].nil? ? 1 : @property_hash[:tls_connect]
+    )
+  end
+
+  def tls_accept=(int)
+    @property_hash[:tls_accept] = int
+
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      tls_accept: @property_hash[:tls_accept].nil? ? 1 : @property_hash[:tls_accept]
+    )
+  end
+
+  def tls_issuer=(string)
+    @property_hash[:tls_issuer] = string
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      tls_issuer: @property_hash[:tls_issuer].nil? ? '' : @property_hash[:tls_issuer]
+    )
+  end
+
+  def tls_subject=(string)
+    @property_hash[:tls_subject] = string
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      tls_subject: @property_hash[:tls_subject].nil? ? '' : @property_hash[:tls_subject]
     )
   end
 end

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -27,6 +27,19 @@ Puppet::Type.newtype(:zabbix_host) do
     end
   end
 
+  def munge_encryption(value)
+    case value
+    when 1, 'unencrypted', :unencrypted
+      1
+    when 2, 'psk', :psk
+      2
+    when 4, 'cert', :cert
+      4
+    else
+      raise(Puppet::Error, 'munge_encryption only takes unencrypted, psk or cert')
+    end
+  end
+
   newparam(:hostname, namevar: true) do
     desc 'FQDN of the machine.'
   end
@@ -121,6 +134,36 @@ Puppet::Type.newtype(:zabbix_host) do
 
   newproperty(:proxy) do
     desc 'Whether it is monitored by an proxy or not.'
+  end
+
+  newproperty(:tls_connect) do
+    desc 'How the server connect to the client (unencrypted, psk or cert)'
+    def insync?(is)
+      is.to_i == should.to_i
+    end
+
+    munge do |value|
+      @resource.munge_encryption(value)
+    end
+  end
+
+  newproperty(:tls_accept) do
+    desc 'How the client connect to the server (unencrypted, psk or cert)'
+    def insync?(is)
+      is.to_i == should.to_i
+    end
+
+    munge do |value|
+      @resource.munge_encryption(value)
+    end
+  end
+
+  newproperty(:tls_issuer) do
+    desc 'Certificate issuer.'
+  end
+
+  newproperty(:tls_subject) do
+    desc 'Certificate subject.'
   end
 
   autorequire(:file) { '/etc/zabbix/api.conf' }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -79,6 +79,8 @@
 # @param tlsaccept What incoming connections to accept from Zabbix server. Used for a passive proxy, ignored on an active proxy.
 # @param tlscafile Full pathname of a file containing the top-level CA(s) certificates for peer certificate verification.
 # @param tlscertfile Full pathname of a file containing the proxy certificate or certificate chain.
+# @param tlscertissuer Issuer of the certificate that is allowed to talk with the serve
+# @param tlscertsubject Subject of the certificate that is allowed to talk with the server
 # @param tlsconnect How the proxy should connect to Zabbix server. Used for an active proxy, ignored on a passive proxy.
 # @param tlscrlfile Full pathname of a file containing revoked certificates.
 # @param tlskeyfile Full pathname of a file containing the proxy private key.
@@ -192,16 +194,18 @@ class zabbix::agent (
   $userparameter                                       = $zabbix::params::agent_userparameter,
   Optional[String[1]] $loadmodulepath                  = $zabbix::params::agent_loadmodulepath,
   $loadmodule                                          = $zabbix::params::agent_loadmodule,
-  $tlsaccept                                           = $zabbix::params::agent_tlsaccept,
+  Optional[Enum['unencrypted','psk','cert']] $tlsaccept = $zabbix::params::agent_tlsaccept,
   $tlscafile                                           = $zabbix::params::agent_tlscafile,
   $tlscertfile                                         = $zabbix::params::agent_tlscertfile,
+  Optional[String[1]] $tlscertissuer                   = undef,
+  Optional[String[1]] $tlscertsubject                  = undef,
   Optional[String[1]] $tlscipherall                    = $zabbix::params::agent_tlscipherall,
   Optional[String[1]] $tlscipherall13                  = $zabbix::params::agent_tlscipherall13,
   Optional[String[1]] $tlsciphercert                   = $zabbix::params::agent_tlsciphercert,
   Optional[String[1]] $tlsciphercert13                 = $zabbix::params::agent_tlsciphercert13,
   Optional[String[1]] $tlscipherpsk                    = $zabbix::params::agent_tlscipherpsk,
   Optional[String[1]] $tlscipherpsk13                  = $zabbix::params::agent_tlscipherpsk13,
-  $tlsconnect                                          = $zabbix::params::agent_tlsconnect,
+  Optional[Enum['unencrypted','psk','cert']] $tlsconnect = $zabbix::params::agent_tlsconnect,
   $tlscrlfile                                          = $zabbix::params::agent_tlscrlfile,
   $tlskeyfile                                          = $zabbix::params::agent_tlskeyfile,
   $tlspskfile                                          = $zabbix::params::agent_tlspskfile,
@@ -273,6 +277,10 @@ class zabbix::agent (
       interfacetype    => $zbx_interface_type,
       interfacedetails => $zbx_interface_details,
       proxy            => $use_proxy,
+      tls_accept       => $tlsaccept,
+      tls_connect      => $tlsconnect,
+      tls_issuer       => $tlscertissuer,
+      tls_subject      => $tlscertsubject,
     }
   }
 

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -11,6 +11,10 @@
 # @param proxy Whether it is monitored by an proxy or not.
 # @param interfacetype Internally used identifier for the host interface.
 # @param interfacedetails Hash with interface details for SNMP when interface type is 2.
+# @param tls_connect How the server must connect to the agent
+# @param tls_accept How the agent can connect to the server
+# @param tls_issuer Issuer of the certificate that is allowed to talk with the serve
+# @param tls_subject Subject of the certificate that is allowed to talk with the server
 class zabbix::resources::agent (
   $hostname                           = undef,
   $ipaddress                          = undef,
@@ -24,6 +28,10 @@ class zabbix::resources::agent (
   $proxy                              = undef,
   $interfacetype                      = 1,
   Variant[Array, Hash] $interfacedetails = [],
+  Optional[Enum['unencrypted','psk','cert']] $tls_connect = undef,
+  Optional[Enum['unencrypted','psk','cert']] $tls_accept  = undef,
+  Optional[String[1]] $tls_issuer                         = undef,
+  Optional[String[1]] $tls_subject                        = undef,
 ) {
   if $group and $groups {
     fail("Got group and groups. This isn't support! Please use groups only.")
@@ -47,5 +55,9 @@ class zabbix::resources::agent (
     proxy            => $proxy,
     interfacetype    => $interfacetype,
     interfacedetails => $interfacedetails,
+    tls_connect      => $tls_connect,
+    tls_accept       => $tls_accept,
+    tls_issuer       => $tls_issuer,
+    tls_subject      => $tls_subject,
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
inspired from #700

I need to authenticate with certificate in my infrastructure, this PR allow to push the configuration to the zabbix server via «storeconfigs»

As stated in #700, there is an issue with setting the PSK through the API as PSK values are write only since zabbix 5.4.  So I didn’t bother to dig deeper on this part, as I don’t require it in my infrastructure.

#### This Pull Request (PR) fixes the following issues

