### PR TITLE
use provided database port in pgpass

### DIFF
--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -18,7 +18,7 @@ class zabbix::database::postgresql (
   $database_user                                      = '',
   $database_password                                  = '',
   $database_host                                      = '',
-  Optional[Stdlib::Port::Unprivileged] $database_port = undef,
+  Stdlib::Port::Unprivileged $database_port           = 5432,
   $database_path                                      = $zabbix::params::database_path,
 ) inherits zabbix::params {
   assert_private()
@@ -45,35 +45,27 @@ class zabbix::database::postgresql (
     $schema_path = $database_schema_path
   }
 
-  if $database_port != undef {
-    $port = "-p ${database_port} "
-  } else {
-    $port = ''
-  }
-
   case $zabbix_type {
     'proxy': {
       $zabbix_proxy_create_sql = versioncmp($zabbix_version, '6.0') >= 0 ? {
-        true  => "cd ${schema_path} && psql -h '${database_host}' -U '${database_user}' ${port}-d '${database_name}' -f proxy.sql && touch /etc/zabbix/.schema.done",
-        false => "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' ${port}-d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
+        true  => "cd ${schema_path} && psql -h '${database_host}' -U '${database_user}' -p ${database_port} -d '${database_name}' -f proxy.sql && touch /etc/zabbix/.schema.done",
+        false => "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -p ${database_port} -d '${database_name}' -f schema.sql && touch /etc/zabbix/.schema.done"
       }
     }
     default: {
       $zabbix_server_create_sql = versioncmp($zabbix_version, '6.0') >= 0 ? {
-        true  => "cd ${schema_path} && if [ -f server.sql.gz ]; then gunzip -f server.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' ${port}-d '${database_name}' -f server.sql && touch /etc/zabbix/.schema.done",
-        false => "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' ${port}-d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
+        true  => "cd ${schema_path} && if [ -f server.sql.gz ]; then gunzip -f server.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -p ${database_port} -d '${database_name}' -f server.sql && touch /etc/zabbix/.schema.done",
+        false => "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -p ${database_port} -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
       }
       $zabbix_server_images_sql = 'touch /etc/zabbix/.images.done'
       $zabbix_server_data_sql   = 'touch /etc/zabbix/.data.done'
     }
   }
 
-  $db_port = pick($database_port, '5432')
-
   exec { 'update_pgpass':
-    command => "echo ${database_host}:${db_port}:${database_name}:${database_user}:${database_password} >> /root/.pgpass",
+    command => "echo ${database_host}:${database_port}:${database_name}:${database_user}:${database_password} >> /root/.pgpass",
     path    => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-    unless  => "grep \"${database_host}:${db_port}:${database_name}:${database_user}:${database_password}\" /root/.pgpass",
+    unless  => "grep \"${database_host}:${database_port}:${database_name}:${database_user}:${database_password}\" /root/.pgpass",
     require => File['/root/.pgpass'],
   }
 

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -68,10 +68,12 @@ class zabbix::database::postgresql (
     }
   }
 
+  $db_port = pick($database_port, '5432')
+
   exec { 'update_pgpass':
-    command => "echo ${database_host}:5432:${database_name}:${database_user}:${database_password} >> /root/.pgpass",
+    command => "echo ${database_host}:${db_port}:${database_name}:${database_user}:${database_password} >> /root/.pgpass",
     path    => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-    unless  => "grep \"${database_host}:5432:${database_name}:${database_user}:${database_password}\" /root/.pgpass",
+    unless  => "grep \"${database_host}:${db_port}:${database_name}:${database_user}:${database_password}\" /root/.pgpass",
     require => File['/root/.pgpass'],
   }
 

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -91,6 +91,28 @@ describe 'zabbix::database::postgresql' do
           it { is_expected.to contain_class('zabbix::params') }
         end
 
+        describe "when zabbix_type is server and version is #{zabbix_version} and custom port is defined" do
+          let :params do
+            {
+              database_name: 'zabbix-server',
+              database_user: 'zabbix-server',
+              database_password: 'zabbix-server',
+              database_host: 'node01.example.com',
+              database_port: 6432,
+              zabbix_type: 'server',
+              zabbix_version: zabbix_version
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
+          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 6432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
+          it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
+          it { is_expected.to contain_file('/root/.pgpass') }
+          it { is_expected.to contain_class('zabbix::params') }
+        end
+
         describe "when zabbix_type is proxy and version is #{zabbix_version}" do
           let :params do
             {

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -84,7 +84,7 @@ describe 'zabbix::database::postgresql' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
+          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
           it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
           it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
           it { is_expected.to contain_file('/root/.pgpass') }
@@ -153,9 +153,9 @@ describe 'zabbix::database::postgresql' do
           it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
 
           if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
           else
-            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
           end
 
           it { is_expected.to contain_class('zabbix::params') }


### PR DESCRIPTION
#### Pull Request (PR) description
When configuring a postgresql database that is not running on port 5432, the `.pgpass` is not correctly configured.

Then, the `exec { 'zabbix_server_create.sql':}` does not succeed as the server could not connect to the database.