### PR TITLE
Configure DirectoryIndex by default

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -306,6 +306,7 @@ class zabbix::web (
   # Is set to true, it will create the apache vhost.
   if $manage_vhost {
     include apache
+    include apache::mod::dir
     if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') >= 0 and versioncmp($zabbix_version, '5') >= 0 {
       if versioncmp($facts['os']['release']['major'], '7') == 0 {
         $fpm_service = 'rh-php72-php-fpm'


### PR DESCRIPTION
#### Pull Request (PR) description
Make sure the DirectoryIndex is configured when apache 'default_mods` are disabled:
```puppet
  class { 'apache':
    default_mods  => false,
  }

  class { 'zabbix' :
    [...]
  }
```

Feel free to correct me if you think it should not be in this module, but instead only in my own `profile`.

#### This Pull Request (PR) fixes the following issues
Fixes #853 
