### PR TITLE
Add/rename Linux SNMP templates for Zabbix 6.0+

### DIFF
--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -29,8 +29,12 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
                         ['Template OS Linux SNMPv2']
                       when '5.0'
                         ['Template OS Linux SNMP']
-                      else
+                      when '5.2'
                         ['Linux SNMP']
+                      when '5.4'
+                        ['Linux SNMP']
+                      else
+                        ['Linux by SNMP']
                       end
 
       pp1 = <<-EOS

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -29,9 +29,7 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
                         ['Template OS Linux SNMPv2']
                       when '5.0'
                         ['Template OS Linux SNMP']
-                      when '5.2'
-                        ['Linux SNMP']
-                      when '5.4'
+                      when '5.2', '5.4'
                         ['Linux SNMP']
                       else
                         ['Linux by SNMP']


### PR DESCRIPTION
#### Pull Request (PR) description
 As mentionned in #851, the SNMP templates has been renamed upstream, this is an attempt to fix the tests

#### This Pull Request (PR) fixes the following issues
