### PR TITLE
Add option to restrict API access to specific hosts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@
 # @param ldap_reqcert Specifies what checks to perform on a server certificate
 # @param zabbix_api_user Name of the user which the api should connect to. Default: Admin
 # @param zabbix_api_pass Password of the user which connects to the api. Default: zabbix
+# @param zabbix_api_access Which host has access to the api. Default: no restriction
 # @param listenport Listen port for the zabbix-server. Default: 10051
 # @param sourceip Source ip address for outgoing connections.
 # @param logfile Name of log file.
@@ -250,6 +251,7 @@ class zabbix (
   Optional[Enum['never', 'allow', 'try', 'demand', 'hard']] $ldap_reqcert     = $zabbix::params::ldap_reqcert,
   $zabbix_api_user                                                            = $zabbix::params::server_api_user,
   $zabbix_api_pass                                                            = $zabbix::params::server_api_pass,
+  Optional[Array[Stdlib::Fqdn]] $zabbix_api_access                            = $zabbix::params::server_api_acces,
   $listenport                                                                 = $zabbix::params::server_listenport,
   $sourceip                                                                   = $zabbix::params::server_sourceip,
   Enum['console', 'file', 'system'] $logtype                                  = $zabbix::params::server_logtype,
@@ -364,6 +366,7 @@ class zabbix (
     apache_listenport_ssl                    => $apache_listenport_ssl,
     zabbix_api_user                          => $zabbix_api_user,
     zabbix_api_pass                          => $zabbix_api_pass,
+    zabbix_api_access                        => $zabbix_api_access,
     database_host                            => $database_host,
     database_name                            => $database_name,
     database_schema                          => $database_schema,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -251,7 +251,7 @@ class zabbix (
   Optional[Enum['never', 'allow', 'try', 'demand', 'hard']] $ldap_reqcert     = $zabbix::params::ldap_reqcert,
   $zabbix_api_user                                                            = $zabbix::params::server_api_user,
   $zabbix_api_pass                                                            = $zabbix::params::server_api_pass,
-  Optional[Array[Stdlib::Fqdn]] $zabbix_api_access                            = $zabbix::params::server_api_acces,
+  Optional[Array[Stdlib::Host,1]] $zabbix_api_access                          = $zabbix::params::server_api_access,
   $listenport                                                                 = $zabbix::params::server_listenport,
   $sourceip                                                                   = $zabbix::params::server_sourceip,
   Enum['console', 'file', 'system'] $logtype                                  = $zabbix::params::server_logtype,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -184,6 +184,7 @@ class zabbix::params {
   $ldap_reqcert                             = undef
   $server_api_pass                          = 'zabbix'
   $server_api_user                          = 'Admin'
+  $server_api_access                        = undef
   $server_database_double_ieee754           = false
   $saml_sp_key                              = undef
   $saml_sp_cert                             = undef

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -115,7 +115,7 @@ class zabbix::web (
   Variant[Array[Stdlib::Port], Stdlib::Port] $apache_listenport_ssl   = $zabbix::params::apache_listenport_ssl,
   $zabbix_api_user                                                    = $zabbix::params::server_api_user,
   $zabbix_api_pass                                                    = $zabbix::params::server_api_pass,
-  Optional[Array[Stdlib::Fqdn]] $zabbix_api_access                    = $zabbix::params::server_api_access,
+  Optional[Array[Stdlib::Host,1]] $zabbix_api_access                  = $zabbix::params::server_api_access,
   $database_host                                                      = $zabbix::params::server_database_host,
   $database_name                                                      = $zabbix::params::server_database_name,
   $database_schema                                                    = $zabbix::params::server_database_schema,

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -393,10 +393,6 @@ class zabbix::web (
       $apache_listen_port = $apache_listenport
     }
 
-    if versioncmp($apache::apache_version, '2.4') < 0 {
-      fail('Only apache >= 2.4 is supported')
-    }
-
     $location_api_access = $zabbix_api_access ? {
       undef   => 'all granted',
       default => $zabbix_api_access.map |$host| { "host ${host}" },

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -235,6 +235,20 @@ describe 'zabbix::web' do
           it { is_expected.to contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(%r{^\$SSO\['IDP_CERT'\] = '/etc/zabbix/web/idp.cert'}) }
           it { is_expected.to contain_file('/etc/zabbix/web/zabbix.conf.php').with_content(%r{^\$SSO\['SETTINGS'\] = \[ \n  "strict" => true,\n  "baseurl" => "http://example.com/sp/",\n  "security" => \[\n    "signatureAlgorithm" => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384",\n    "digestAlgorithm" => "http://www.w3.org/2001/04/xmldsig-more#sha384",\n    "singleLogoutService" => \[\n      "responseUrl" => ""\n    \]\n  \]\n\];}) }
         end
+
+        describe 'with restriction to api access' do
+          let :params do
+            super().merge(
+              zabbix_api_access: ['127.0.0.1']
+            )
+          end
+
+          it {
+            is_expected.to contain_concat__fragment('zabbix.example.com-directories').with(
+              content: %r{^\s+Require host 127\.0\.0\.1$}
+            )
+          }
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
By default, the api is open to everyone.  I would like to restrict it to only the zabbix server.

I’m not sure if it should be included in this module like I suggest, or if I should manage my own apache config by disabling this module apache management  `manage_vhost => false` in `web.pp`, but I think the changes are simple enough to include in this module


My suggestion in this PR allow to add restriction to the api like so:
```puppet
class { 'zabbix::web' :
  [...]
  zabbix_api_access => [$facts['networking']['fqdn']],
}
```

This creates this `location` entry in apache config (or equivalent in apache 2.2):
```apache
<Location "/api_jsonrpc.php" >
  Require host zabbix.example.com
</Location>
```

#### This Pull Request (PR) fixes the following issues

