### PR TITLE
Remove check for Apache 2.4

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -391,14 +391,9 @@ class zabbix::web (
       $apache_listen_port = $apache_listenport
     }
 
-    # Check which version of Apache we're using
-    if versioncmp($apache::apache_version, '2.4') >= 0 {
-      $directory_allow = { 'require' => 'all granted', }
-      $directory_deny = { 'require' => 'all denied', }
-    } else {
-      $directory_allow = { 'allow' => 'from all', 'order' => 'Allow,Deny', }
-      $directory_deny = { 'deny' => 'from all', 'order' => 'Deny,Allow', }
-    }
+    # Apache >= 2.4
+    $directory_allow = { 'require' => 'all granted', }
+    $directory_deny = { 'require' => 'all denied', }
 
     apache::vhost { $zabbix_url:
       docroot         => '/usr/share/zabbix',

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 9.0.0"
     },
     {
       "name": "puppetlabs/firewall",

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 9.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/firewall",


### PR DESCRIPTION
#### Pull Request (PR) description
Apache 9.0.0 release [drops](https://github.com/puppetlabs/puppetlabs-apache/pull/2329) 2.2 support. Since Zabbix has a dependency on Apache, it makes sense to remove the comparison between >= `2.4` and `2.2`, including setting the minimum dependency version for Apache to 9.0.0.

The Zabbix module breaks if you run Apache version higher than `9.0.0`, due to not being able to verify the fact.