### PR TITLE
Provide correct gpgkey for RHEL family, version > 8.

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -34,8 +34,13 @@ class zabbix::repo (
     }
     case $facts['os']['family'] {
       'RedHat': {
-        $gpgkey_zabbix = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591'
-        $gpgkey_nonsupported = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-79EA5ED4'
+        if versioncmp(fact('os.release.major'), '9') >= 0 {
+          $gpgkey_zabbix = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD'
+          $gpgkey_nonsupported = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD'
+        } else {
+          $gpgkey_zabbix = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-A14FE591'
+          $gpgkey_nonsupported = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-79EA5ED4'
+        }
 
         $_repo_location = $repo_location ? {
           undef   => "https://repo.zabbix.com/zabbix/${zabbix_version}/rhel/${majorrelease}/\$basearch/",

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -112,6 +112,35 @@ describe 'zabbix::repo' do
 
             it { is_expected.to contain_package('zabbix-required-scl-repo').with_ensure('latest').with_name('centos-release-scl') }
           end
+        when '9'
+
+          context 'on RedHat 9 and Zabbix 5.0' do
+            let :params do
+              {
+                zabbix_version: '5.0',
+                manage_repo: true
+              }
+            end
+
+            it { is_expected.to contain_yumrepo('zabbix').with_baseurl('https://repo.zabbix.com/zabbix/5.0/rhel/9/$basearch/') }
+            it { is_expected.to contain_yumrepo('zabbix').with_gpgkey('https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD') }
+            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_baseurl('https://repo.zabbix.com/non-supported/rhel/9/$basearch/') }
+            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_gpgkey('https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD') }
+          end
+
+          context 'on RedHat 9 and Zabbix 6.0' do
+            let :params do
+              {
+                zabbix_version: '6.0',
+                manage_repo: true
+              }
+            end
+
+            it { is_expected.to contain_yumrepo('zabbix').with_baseurl('https://repo.zabbix.com/zabbix/6.0/rhel/9/$basearch/') }
+            it { is_expected.to contain_yumrepo('zabbix').with_gpgkey('https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD') }
+            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_baseurl('https://repo.zabbix.com/non-supported/rhel/9/$basearch/') }
+            it { is_expected.to contain_yumrepo('zabbix-nonsupported').with_gpgkey('https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD') }
+          end
         end
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description
This change provides the correct gpgkey for RHEL family operating systems newer than version 8.

The new gpgkey works for both the "zabbix" and the "zabbix_nonsupported" repos.

This was successfully tested on RHEL 9.

#### This Pull Request (PR) fixes the following issues
Fixes #858 
