### PR TITLE
Add support for FreeBSD only for Zabbix Agent

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,21 @@ class zabbix::params {
       $zabbix_package_provider  = undef
       $agent_loadmodulepath     = '/usr/lib/modules'
     }
+    'FreeBSD': {
+      $manage_repo              = false
+      $manage_choco             = false
+      $zabbix_package_agent     = 'zabbix6-agent'
+      $agent_configfile_path    = '/usr/local/etc/zabbix6/zabbix_agentd.conf'
+      $agent_config_owner       = 'zabbix'
+      $agent_zabbix_user        = 'zabbix'
+      $agent_config_group       = 'zabbix'
+      $agent_pidfile            = '/var/run/zabbix/zabbix_agentd.pid'
+      $agent_servicename        = 'zabbix_agentd'
+      $agent_include            = '/usr/local/etc/zabbix6/zabbix_agentd.d'
+      $server_zabbix_user       = 'zabbix'
+      $zabbix_package_provider  = undef
+      $agent_loadmodulepath     = '/usr/local/lib/zabbix/modules'
+    }
     'Gentoo': {
       $server_fpinglocation     = '/usr/sbin/fping'
       $server_fping6location    = '/usr/sbin/fping6'
@@ -135,6 +150,7 @@ class zabbix::params {
 
   $manage_startup_script = downcase($facts['kernel']) ? {
     'windows' => false,
+    'FreeBSD' => false,
     default   => true,
   }
 

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -76,6 +76,6 @@ define zabbix::startup (
       notify   => Service[$name],
     }
   } else {
-    fail('We currently only support Debian, Redhat, AIX and Windows osfamily as non-systemd')
+    fail('We currently only support Debian, FreeBSD, Redhat, AIX and Windows osfamily as non-systemd')
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -164,6 +164,12 @@
       "operatingsystemrelease": [
         "7"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "13"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add support for FreeBSD only for Zabbix Agent.

Tested on FreeBSD 13.1 with puppet 7.23