### PR TITLE
Add Zabbix parameter StatsAllowedIP  for Server and Proxy and remove ServerPort for proxy in >6.0

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -129,6 +129,7 @@
 # @param fpinglocation Location of fping.
 # @param fping6location Location of fping6.
 # @param sshkeylocation Location of public and private keys for ssh checks and actions.
+# @param statsallowedip list of allowed ipadresses that can access the internal stats of zabbix proxy over network
 # @param sslcalocation_dir Location of certificate authority (CA) files for SSL server certificate verification.
 # @param sslcertlocation_dir Location of SSL client certificate files for client authentication.
 # @param sslkeylocation_dir Location of SSL private key files for client authentication.
@@ -288,7 +289,7 @@ class zabbix::proxy (
   $fpinglocation                                                              = $zabbix::params::proxy_fpinglocation,
   $fping6location                                                             = $zabbix::params::proxy_fping6location,
   $sshkeylocation                                                             = $zabbix::params::proxy_sshkeylocation,
-  $statsallowedip                                                             = $zabbix::params::proxy_statsallowedip,
+  Optional[String[1]] $statsallowedip                                         = $zabbix::params::proxy_statsallowedip,
   $logslowqueries                                                             = $zabbix::params::proxy_logslowqueries,
   $tmpdir                                                                     = $zabbix::params::proxy_tmpdir,
   $allowroot                                                                  = $zabbix::params::proxy_allowroot,

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -288,6 +288,7 @@ class zabbix::proxy (
   $fpinglocation                                                              = $zabbix::params::proxy_fpinglocation,
   $fping6location                                                             = $zabbix::params::proxy_fping6location,
   $sshkeylocation                                                             = $zabbix::params::proxy_sshkeylocation,
+  $statsallowedip                                                             = $zabbix::params::proxy_statsallowedip,
   $logslowqueries                                                             = $zabbix::params::proxy_logslowqueries,
   $tmpdir                                                                     = $zabbix::params::proxy_tmpdir,
   $allowroot                                                                  = $zabbix::params::proxy_allowroot,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -130,6 +130,7 @@
 # @param proxydatafrequency How often zabbix server requests history data from a zabbix proxy in seconds.
 # @param allowroot Allow the server to run as 'root'.
 # @param include_dir You may include individual files or all files in a directory in the configuration file.
+# @param statsallowedip list of allowed ipadresses that can access the internal stats of zabbix server over network
 # @param loadmodulepath Full path to location of server modules.
 # @param loadmodule Module to load at server startup.
 # @param sslcertlocation_dir Location of SSL client certificate files for client authentication.
@@ -266,7 +267,7 @@ class zabbix::server (
   $loadmodule                                                                 = $zabbix::params::server_loadmodule,
   $sslcertlocation_dir                                                        = $zabbix::params::server_sslcertlocation,
   $sslkeylocation_dir                                                         = $zabbix::params::server_sslkeylocation,
-  $statsallowedip                                                             = $zabbix::params::server_statsallowedip,
+  Optional[String[1]] $statsallowedip                                         = $zabbix::params::server_statsallowedip,
 
   Boolean $manage_selinux                                                     = $zabbix::params::manage_selinux,
   String $additional_service_params                                           = $zabbix::params::additional_service_params,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -266,6 +266,8 @@ class zabbix::server (
   $loadmodule                                                                 = $zabbix::params::server_loadmodule,
   $sslcertlocation_dir                                                        = $zabbix::params::server_sslcertlocation,
   $sslkeylocation_dir                                                         = $zabbix::params::server_sslkeylocation,
+  $statsallowedip                                                             = $zabbix::params::server_statsallowedip,
+
   Boolean $manage_selinux                                                     = $zabbix::params::manage_selinux,
   String $additional_service_params                                           = $zabbix::params::additional_service_params,
   Optional[String[1]] $zabbix_user                                            = $zabbix::params::server_zabbix_user,

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -17,11 +17,13 @@ ProxyMode=<%= @mode %>
 #
 Server=<%= @zabbix_server_host %>
 
+<% if @zabbix_version.to_f < 6.0 %>
 ### Option: ServerPort
 #	Port of Zabbix trapper on Zabbix server.
 #	For a proxy in the passive mode this parameter will be ignored.
 #
 ServerPort=<%= @zabbix_server_port %>
+<% end %>
 
 ### Option: Hostname
 #	Unique, case sensitive Proxy name. Make sure the Proxy name is known to the server!

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -448,6 +448,20 @@ LoadModulePath=<%= @loadmodulepath %>
 #
 <% if @loadmodule %>LoadModule=<%= @loadmodule %><% end %>
 
+### Option: StatsAllowedIP
+#	List of comma delimited IP addresses, optionally in CIDR notation, or DNS names of external Zabbix instances.
+#	Stats request will be accepted only from the addresses listed here. If this parameter is not set no stats requests
+#	will be accepted.
+#	If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally
+#	and '::/0' will allow any IPv4 or IPv6 address.
+#	'0.0.0.0/0' can be used to allow any IPv4 address.
+#	Example: StatsAllowedIP=127.0.0.1,192.168.1.0/24,::1,2001:db8::/32,zabbix.example.com
+#
+# Mandatory: no
+# Default:
+# StatsAllowedIP=
+<% if @statsallowedip %>StatsAllowedIP=<%= @statsallowedip %><% end %>
+
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSConnect

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -438,6 +438,20 @@ SSLKeyLocation=<%= @sslkeylocation_dir %>
 #
 <% if @sslcalocation_dir %>SSLCALocation=<%= @sslcalocation_dir %><% end %>
 
+### Option: StatsAllowedIP
+#	List of comma delimited IP addresses, optionally in CIDR notation, or DNS names of external Zabbix instances.
+#	Stats request will be accepted only from the addresses listed here. If this parameter is not set no stats requests
+#	will be accepted.
+#	If IPv6 support is enabled then '127.0.0.1', '::127.0.0.1', '::ffff:127.0.0.1' are treated equally
+#	and '::/0' will allow any IPv4 or IPv6 address.
+#	'0.0.0.0/0' can be used to allow any IPv4 address.
+#	Example: StatsAllowedIP=127.0.0.1,192.168.1.0/24,::1,2001:db8::/32,zabbix.example.com
+#
+# Mandatory: no
+# Default:
+# StatsAllowedIP=
+<% if @statsallowedip %>StatsAllowedIP=<%= @statsallowedip %><% end %>
+
 ####### LOADABLE MODULES #######
 
 ### Option: LoadModulePath


### PR DESCRIPTION
#### Pull Request (PR) description
This adds the optional parameter StatsAllowedIP to zabbix server and proxy.
The paramter has been supported since v4.2

#### This Pull Request (PR) fixes the following issues
n/a
