### PR TITLE
Restarting agent if it get's upgraded

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -347,9 +347,11 @@ class zabbix::agent (
 
   # Controlling the 'zabbix-agent' service
   service { $servicename:
-    ensure  => $service_ensure,
-    enable  => $service_enable,
-    require => $service_require,
+    ensure    => $service_ensure,
+    enable    => $service_enable,
+    require   => $service_require,
+    subscribe => Package[$zabbix_package_agent],
+
   }
 
   # Override the service provider on AIX


### PR DESCRIPTION
#### Pull Request (PR) description
I recently upgraded all agents to the latest 6.4 version of zabbix, and stumbled into Zabbix having issues eg getting old agents not compatible with new items from 6.4. I figured out that the upgrade of the agent-package did upgrade the agent, but it did not restart them, which left the old agent running. This had  me to restart all agents manually. This fix will restart the agent if it get's upgraded.