### PR TITLE
getting latest puppet-agent in place of the old 4.4.5 for Windows

### DIFF
--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -60,7 +60,7 @@ describe 'zabbix::agent' do
         if facts[:kernel] == 'windows'
           it do
             is_expected.to contain_package(package_name).with(
-              ensure: '4.4.5',
+              ensure: 'latest',
               provider: 'chocolatey',
               tag: 'zabbix'
             )


### PR DESCRIPTION
#### Pull Request (PR) description
Updating to latest instead of 4.4.5