### PR TITLE
metadata: increase max version of puppetlabs firewall module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.7.0 < 4.0.0"
+      "version_requirement": ">= 1.7.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Increases max version of Puppetlabs firewall module to < 6.0.0.

5.0.0 was released which adds support for Puppet 8 and drops support for Puppet 6 which this module already does not support. 

#### This Pull Request (PR) fixes the following issues

N/A
