### PR TITLE
Add support for ODBC pollers in Zabbix >= 6.0

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -146,6 +146,7 @@ The following parameters are available in the `zabbix` class:
 * [`startpollers`](#-zabbix--startpollers)
 * [`startpreprocessors`](#-zabbix--startpreprocessors)
 * [`startipmipollers`](#-zabbix--startipmipollers)
+* [`startodbcpollers`](#-zabbix--startodbcpollers)
 * [`startpollersunreachable`](#-zabbix--startpollersunreachable)
 * [`starttrappers`](#-zabbix--starttrappers)
 * [`startpingers`](#-zabbix--startpingers)
@@ -739,6 +740,14 @@ Data type: `Any`
 Number of pre-forked instances of ipmi pollers.
 
 Default value: `$zabbix::params::server_startipmipollers`
+
+##### <a name="-zabbix--startodbcpollers"></a>`startodbcpollers`
+
+Data type: `Integer[0, 1000]`
+
+Number of pre-forked instances of ODBC pollers.
+
+Default value: `$zabbix::params::server_startodbcpollers`
 
 ##### <a name="-zabbix--startpollersunreachable"></a>`startpollersunreachable`
 
@@ -2548,6 +2557,7 @@ The following parameters are available in the `zabbix::proxy` class:
 * [`startpollers`](#-zabbix--proxy--startpollers)
 * [`startpreprocessors`](#-zabbix--proxy--startpreprocessors)
 * [`startipmipollers`](#-zabbix--proxy--startipmipollers)
+* [`startodbcpollers`](#-zabbix--proxy--startodbcpollers)
 * [`startpollersunreachable`](#-zabbix--proxy--startpollersunreachable)
 * [`starttrappers`](#-zabbix--proxy--starttrappers)
 * [`startpingers`](#-zabbix--proxy--startpingers)
@@ -3033,6 +3043,14 @@ Data type: `Any`
 Number of pre-forked instances of ipmi pollers.
 
 Default value: `$zabbix::params::proxy_startipmipollers`
+
+##### <a name="-zabbix--proxy--startodbcpollers"></a>`startodbcpollers`
+
+Data type: `Integer[0, 1000]`
+
+Number of pre-forked instances of ODBC pollers.
+
+Default value: `$zabbix::params::proxy_startodbcpollers`
 
 ##### <a name="-zabbix--proxy--startpollersunreachable"></a>`startpollersunreachable`
 
@@ -3947,6 +3965,7 @@ The following parameters are available in the `zabbix::server` class:
 * [`startpollers`](#-zabbix--server--startpollers)
 * [`startpreprocessors`](#-zabbix--server--startpreprocessors)
 * [`startipmipollers`](#-zabbix--server--startipmipollers)
+* [`startodbcpollers`](#-zabbix--server--startodbcpollers)
 * [`startpollersunreachable`](#-zabbix--server--startpollersunreachable)
 * [`starttrappers`](#-zabbix--server--starttrappers)
 * [`startpingers`](#-zabbix--server--startpingers)
@@ -4329,6 +4348,14 @@ Data type: `Any`
 Number of pre-forked instances of ipmi pollers.
 
 Default value: `$zabbix::params::server_startipmipollers`
+
+##### <a name="-zabbix--server--startodbcpollers"></a>`startodbcpollers`
+
+Data type: `Integer[0, 1000]`
+
+Number of pre-forked instances of ODBC pollers.
+
+Default value: `$zabbix::params::server_startodbcpollers`
 
 ##### <a name="-zabbix--server--startpollersunreachable"></a>`startpollersunreachable`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,6 +105,7 @@
 # @param startpollers Number of pre-forked instances of pollers.
 # @param startpreprocessors Number of pre-forked instances of preprocessing workers
 # @param startipmipollers Number of pre-forked instances of ipmi pollers.
+# @param startodbcpollers Number of pre-forked instances of ODBC pollers.
 # @param startpollersunreachable Number of pre-forked instances of pollers for unreachable hosts (including ipmi).
 # @param starttrappers Number of pre-forked instances of trappers.
 # @param startpingers Number of pre-forked instances of icmp pingers.
@@ -274,6 +275,7 @@ class zabbix (
   Optional[Stdlib::Absolutepath] $database_tlscafile                          = $zabbix::params::server_database_tlscafile,
   $startpollers                                                               = $zabbix::params::server_startpollers,
   $startipmipollers                                                           = $zabbix::params::server_startipmipollers,
+  Integer[0, 1000] $startodbcpollers                                          = $zabbix::params::server_startodbcpollers,
   $startpollersunreachable                                                    = $zabbix::params::server_startpollersunreachable,
   Integer[1, 1000] $startpreprocessors                                        = $zabbix::params::server_startpreprocessors,
   $starttrappers                                                              = $zabbix::params::server_starttrappers,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -253,6 +253,7 @@ class zabbix::params {
   $server_startipmipollers                  = '0'
   $server_startjavapollers                  = '5'
   $server_startlldprocessors                = 2
+  $server_startodbcpollers                  = 1
   $server_startpingers                      = '1'
   $server_startpollers                      = '5'
   $server_startpollersunreachable           = '1'
@@ -422,6 +423,7 @@ class zabbix::params {
   $proxy_startipmipollers                   = '0'
   $proxy_startjavapollers                   = '5'
   $proxy_startpingers                       = '1'
+  $proxy_startodbcpollers                   = 1
   $proxy_startpollers                       = '5'
   $proxy_startpollersunreachable            = '1'
   $proxy_startpreprocessors                 = 3

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -63,6 +63,7 @@
 # @param startpollers Number of pre-forked instances of pollers.
 # @param startpreprocessors Number of pre-forked instances of preprocessing workers
 # @param startipmipollers Number of pre-forked instances of ipmi pollers.
+# @param startodbcpollers Number of pre-forked instances of ODBC pollers.
 # @param startpollersunreachable Number of pre-forked instances of pollers for unreachable hosts (including ipmi).
 # @param starttrappers Number of pre-forked instances of trappers.
 # @param startpingers Number of pre-forked instances of icmp pingers.
@@ -237,6 +238,7 @@ class zabbix::proxy (
   $datasenderfrequency                                                        = $zabbix::params::proxy_datasenderfrequency,
   $startpollers                                                               = $zabbix::params::proxy_startpollers,
   $startipmipollers                                                           = $zabbix::params::proxy_startipmipollers,
+  Integer[0, 1000] $startodbcpollers                                          = $zabbix::params::proxy_startodbcpollers,
   $startpollersunreachable                                                    = $zabbix::params::proxy_startpollersunreachable,
   Integer[1, 1000] $startpreprocessors                                        = $zabbix::params::proxy_startpreprocessors,
   $starttrappers                                                              = $zabbix::params::proxy_starttrappers,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,6 +50,7 @@
 # @param startpollers Number of pre-forked instances of pollers.
 # @param startpreprocessors Number of pre-forked instances of preprocessing workers
 # @param startipmipollers Number of pre-forked instances of ipmi pollers.
+# @param startodbcpollers Number of pre-forked instances of ODBC pollers.
 # @param startpollersunreachable Number of pre-forked instances of pollers for unreachable hosts (including ipmi).
 # @param starttrappers Number of pre-forked instances of trappers.
 # @param startpingers Number of pre-forked instances of icmp pingers.
@@ -202,6 +203,7 @@ class zabbix::server (
   Optional[String[1]] $database_tlscipher13                                   = $zabbix::params::server_database_tlscipher13,
   $startpollers                                                               = $zabbix::params::server_startpollers,
   $startipmipollers                                                           = $zabbix::params::server_startipmipollers,
+  Integer[0, 1000] $startodbcpollers                                          = $zabbix::params::server_startodbcpollers,
   $startpollersunreachable                                                    = $zabbix::params::server_startpollersunreachable,
   Integer[1, 1000] $startpreprocessors                                        = $zabbix::params::server_startpreprocessors,
   $starttrappers                                                              = $zabbix::params::server_starttrappers,

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -366,11 +366,26 @@ describe 'zabbix::proxy' do
           let :params do
             {
               socketdir: '/var/run/zabbix',
+              startodbcpollers: 1,
               zabbix_version: '5.0'
             }
           end
 
           it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^SocketDir=/var/run/zabbix} }
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').without_content %r{^StartODBCPollers=1$} }
+        end
+
+        context 'with zabbix_proxy.conf and version 6.0' do
+          let :params do
+            {
+              socketdir: '/var/run/zabbix',
+              startodbcpollers: 1,
+              zabbix_version: '6.0'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^SocketDir=/var/run/zabbix} }
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^StartODBCPollers=1$} }
         end
 
         context 'with zabbix_proxy.conf and logtype declared' do

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -367,11 +367,13 @@ describe 'zabbix::server' do
         let :params do
           {
             socketdir: '/var/run/zabbix',
+            startodbcpollers: 1,
             zabbix_version: '5.0'
           }
         end
 
         it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_content %r{^SocketDir=/var/run/zabbix} }
+        it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').without_content %r{^StartODBCPollers=1} }
       end
 
       context 'with zabbix_server.conf and logtype declared' do

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -356,6 +356,17 @@ UnavailableDelay=<%= @unavaliabledelay %>
 #
 UnreachableDelay=<%= @unreachabedelay %>
 
+<% if @zabbix_version.to_f >= 6.0 %>
+## Option: StartODBCPollers
+#       Number of pre-forked ODBC poller instances.
+#
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartODBCPollers=1
+StartODBCPollers=<%= @startodbcpollers %>
+<% end %>
+
 ### Option: ExternalScripts
 #	Full path to location of external scripts.
 #	Default depends on compilation options.

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -133,6 +133,17 @@ StartIPMIPollers=<%= @startipmipollers %>
 #
 StartPollersUnreachable=<%= @startpollersunreachable %>
 
+<% if @zabbix_version.to_f >= 6.0 %>
+## Option: StartODBCPollers
+#       Number of pre-forked ODBC poller instances.
+#
+# Mandatory: no
+# Range: 0-1000
+# Default:
+# StartODBCPollers=1
+StartODBCPollers=<%= @startodbcpollers %>
+<% end %>
+
 ### Option: StartTrappers
 #	Number of pre-forked instances of trappers.
 #	Trappers accept incoming connections from Zabbix sender, active agents and active proxies.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This PR adds support for the `StartODBCPollers` configuration parameter, that was introduced in Zabbix 6.0.

#### This Pull Request (PR) fixes the following issues

This parameter was already discussed in https://github.com/voxpupuli/puppet-zabbix/issues/814#issuecomment-1042347988, but a PR was never submitted, AFAICT.