### PR TITLE
manifests/proxy.pp: avoid undefined variable for Puppet 8 compat

### DIFF
--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -317,6 +317,8 @@ class zabbix::proxy (
     } else {
       $listen_ip = undef
     }
+  } else {
+    $listen_ip = undef
   }
 
   # So if manage_resources is set to true, we can send some data


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
If we don't specify the `$listenip` parameter for the zabbix proxy class its value is, by default, `undef`, which in turn causes the variable `$listen_ip` to be undefined:

https://github.com/voxpupuli/puppet-zabbix/blob/58b7688015b4b0e1a3332a3892eea8fe4a186b2a/manifests/proxy.pp#L310-L323

and here `$listen_ip` is used without being ever defined:

https://github.com/voxpupuli/puppet-zabbix/blob/58b7688015b4b0e1a3332a3892eea8fe4a186b2a/manifests/proxy.pp#L336-L343

Puppet 8 seems to be more strict than puppet 7 and errors out with the following message:

```shell
Error: Unknown variable: 'listen_ip'
```

This is how i'm using the proxy class

```ruby
class { 'zabbix::proxy':
  zabbix_version       => $version,
  zabbix_package_state => 'installed',
  manage_resources     => true,
  mode                 =>  1,
  zabbix_server_host   => $server_address,
  database_type        => 'postgresql',
}
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Without this change i can't use this module to configure the proxy on a Linux node with puppet-agent v7.26.0 connected to a puppet-server v8.2.3:

```shell
root@lazp-pupprx-01:~# puppet agent -t 
Info: Using environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Unknown variable: 'listen_ip'. (file: /etc/puppetlabs/code/environments/production/modules/zabbix/manifests/proxy.pp, line: 342, column: 22) on node lazp-pupprx-01
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
root@lazp-pupprx-01:~# 
```