### PR TITLE
Clean up PostgreSQL DB creation logic

### DIFF
--- a/manifests/database/mysql.pp
+++ b/manifests/database/mysql.pp
@@ -52,8 +52,6 @@ class zabbix::database::mysql (
         true  => "cd ${schema_path} && if [ -f server.sql.gz ]; then gunzip -f server.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < server.sql && touch /etc/zabbix/.schema.done",
         false => "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && mysql -h '${database_host}' -u '${database_user}' -p'${database_password}' ${port}-D '${database_name}' < create.sql && touch /etc/zabbix/.schema.done"
       }
-      $zabbix_server_images_sql = 'touch /etc/zabbix/.images.done'
-      $zabbix_server_data_sql   = 'touch /etc/zabbix/.data.done'
     }
   }
 
@@ -72,18 +70,6 @@ class zabbix::database::mysql (
         command  => $zabbix_server_create_sql,
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.schema.done',
-        provider => 'shell',
-      }
-      -> exec { 'zabbix_server_images.sql':
-        command  => $zabbix_server_images_sql,
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.images.done',
-        provider => 'shell',
-      }
-      -> exec { 'zabbix_server_data.sql':
-        command  => $zabbix_server_data_sql,
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.data.done',
         provider => 'shell',
       }
     }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -47,13 +47,13 @@ class zabbix::database::postgresql (
     'proxy': {
       $zabbix_create_sql = versioncmp($zabbix_version, '6.0') >= 0 ? {
         true  => "cd ${schema_path} && psql -f proxy.sql && touch /etc/zabbix/.schema.done",
-        false => "cd ${schema_path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -f schema.sql && touch ${done_file}"
+        false => "cd ${schema_path} && if [ -f schema.sql.gz ]; then zcat schema.sql.gz | psql ; else psql -f schema.sql; fi && touch ${done_file}",
       }
     }
     default: {
       $zabbix_create_sql = versioncmp($zabbix_version, '6.0') >= 0 ? {
-        true  => "cd ${schema_path} && if [ -f server.sql.gz ]; then gunzip -f server.sql.gz ; fi && psql -f server.sql && touch ${done_file}",
-        false => "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -f create.sql && touch ${done_file}"
+        true  => "cd ${schema_path} && if [ -f server.sql.gz ]; then zcat server.sql.gz | psql ; else psql -f server.sql; fi && touch ${done_file}",
+        false => "cd ${schema_path} && if [ -f create.sql.gz ]; then zcat create.sql.gz | psql ; else psql -f create.sql; fi && touch ${done_file}"
       }
     }
   }

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -23,22 +23,14 @@ class zabbix::database::postgresql (
 ) inherits zabbix::params {
   assert_private()
 
-  if ($database_schema_path == false) or ($database_schema_path == '') {
-    if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' {
-      if versioncmp($zabbix_version, '6.0') >= 0 {
-        $schema_path = '/usr/share/zabbix-sql-scripts/postgresql/'
-      } else {
-        $schema_path = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/"
-      }
-    } else {
-      if versioncmp($zabbix_version, '6.0') >= 0 {
-        $schema_path = '/usr/share/zabbix-sql-scripts/postgresql/'
-      } else {
-        $schema_path = '/usr/share/doc/zabbix-*-pgsql'
-      }
-    }
-  } else {
+  if $database_schema_path != false and $database_schema_path != '' {
     $schema_path = $database_schema_path
+  } elsif versioncmp($zabbix_version, '6.0') >= 0 {
+    $schema_path = '/usr/share/zabbix-sql-scripts/postgresql/'
+  } elsif $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' {
+    $schema_path = "/usr/share/doc/zabbix-*-pgsql-${zabbix_version}*/"
+  } else {
+    $schema_path = '/usr/share/doc/zabbix-*-pgsql'
   }
 
   $done_file = '/etc/zabbix/.schema.done'

--- a/manifests/database/postgresql.pp
+++ b/manifests/database/postgresql.pp
@@ -53,8 +53,6 @@ class zabbix::database::postgresql (
         true  => "cd ${schema_path} && if [ -f server.sql.gz ]; then gunzip -f server.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -p ${database_port} -d '${database_name}' -f server.sql && touch /etc/zabbix/.schema.done",
         false => "cd ${schema_path} && if [ -f create.sql.gz ]; then gunzip -f create.sql.gz ; fi && psql -h '${database_host}' -U '${database_user}' -p ${database_port} -d '${database_name}' -f create.sql && touch /etc/zabbix/.schema.done"
       }
-      $zabbix_server_images_sql = 'touch /etc/zabbix/.images.done'
-      $zabbix_server_data_sql   = 'touch /etc/zabbix/.data.done'
     }
   }
 
@@ -87,20 +85,6 @@ class zabbix::database::postgresql (
         command  => $zabbix_server_create_sql,
         path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
         unless   => 'test -f /etc/zabbix/.schema.done',
-        provider => 'shell',
-        require  => Exec['update_pgpass'],
-      }
-      -> exec { 'zabbix_server_images.sql':
-        command  => $zabbix_server_images_sql,
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.images.done',
-        provider => 'shell',
-        require  => Exec['update_pgpass'],
-      }
-      -> exec { 'zabbix_server_data.sql':
-        command  => $zabbix_server_data_sql,
-        path     => "/bin:/usr/bin:/usr/local/sbin:/usr/local/bin:${database_path}",
-        unless   => 'test -f /etc/zabbix/.data.done',
         provider => 'shell',
         require  => Exec['update_pgpass'],
       }

--- a/spec/classes/database_mysql_spec.rb
+++ b/spec/classes/database_mysql_spec.rb
@@ -54,8 +54,6 @@ describe 'zabbix::database::mysql' do
             it { is_expected.to contain_class('zabbix::database::mysql') }
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && mysql -h 'rspec.puppet.com' -u 'zabbix-server' -p'zabbix-server' -P 3306 -D 'zabbix-server' < #{sql_server} && touch /etc/zabbix/.schema.done") }
-            it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
-            it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
           end
 
           describe 'and no database_port is defined' do
@@ -74,8 +72,6 @@ describe 'zabbix::database::mysql' do
             it { is_expected.to contain_class('zabbix::database::mysql') }
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && mysql -h 'rspec.puppet.com' -u 'zabbix-server' -p'zabbix-server' -D 'zabbix-server' < #{sql_server} && touch /etc/zabbix/.schema.done") }
-            it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
-            it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
           end
         end
 

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -25,6 +25,12 @@ describe 'zabbix::database::postgresql' do
         }
       end
 
+      let :expected_environment do
+        [
+          'PGHOST=node01.example.com',
+        ]
+      end
+
       supported_versions.each do |zabbix_version|
         path = if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '7'
                  # Path on EL7
@@ -59,20 +65,24 @@ describe 'zabbix::database::postgresql' do
                 zabbix_type: 'server'
               )
             end
+            let(:expected_environment) do
+              super() + [
+                'PGPORT=5432',
+                'PGUSER=zabbix-server',
+                'PGPASSWORD=zabbix-server',
+                'PGDATABASE=zabbix-server',
+              ]
+            end
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-            it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
-            it { is_expected.to contain_file('/root/.pgpass') }
+            it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -f #{sql_server} && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             it { is_expected.to contain_class('zabbix::params') }
 
             describe 'with custom port is defined' do
               let(:params) { super().merge(database_port: 6432) }
 
               it { is_expected.to compile.with_all_deps }
-              it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 6432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
-              it { is_expected.to contain_file('/root/.pgpass') }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_environment(expected_environment.map { |v| v.start_with?('PGPORT=') ? 'PGPORT=6432' : v }) }
               it { is_expected.to contain_class('zabbix::params') }
             end
           end
@@ -86,14 +96,21 @@ describe 'zabbix::database::postgresql' do
                 zabbix_type: 'proxy'
               )
             end
+            let(:expected_environment) do
+              super() + [
+                'PGPORT=5432',
+                'PGUSER=zabbix-proxy',
+                'PGPASSWORD=zabbix-proxy',
+                'PGDATABASE=zabbix-proxy',
+              ]
+            end
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
 
             if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -f schema.sql && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             else
-              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && psql -f proxy.sql && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             end
             it { is_expected.to contain_class('zabbix::params') }
 
@@ -101,14 +118,7 @@ describe 'zabbix::database::postgresql' do
               let(:params) { super().merge(database_port: 6432) }
 
               it { is_expected.to compile.with_all_deps }
-              it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-
-              if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-                it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
-              else
-                it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
-              end
-
+              it { is_expected.to contain_exec('zabbix_create.sql').with_environment(expected_environment.map { |v| v.start_with?('PGPORT=') ? 'PGPORT=6432' : v }) }
               it { is_expected.to contain_class('zabbix::params') }
             end
           end

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -75,7 +75,7 @@ describe 'zabbix::database::postgresql' do
             end
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -f #{sql_server} && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
+            it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then zcat #{sql_server}.gz | psql ; else psql -f #{sql_server}; fi && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             it { is_expected.to contain_class('zabbix::params') }
 
             describe 'with custom port is defined' do
@@ -108,7 +108,7 @@ describe 'zabbix::database::postgresql' do
             it { is_expected.to compile.with_all_deps }
 
             if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -f schema.sql && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then zcat schema.sql.gz | psql ; else psql -f schema.sql; fi && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             else
               it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && psql -f proxy.sql && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             end

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -62,7 +62,7 @@ describe 'zabbix::database::postgresql' do
 
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-            it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
+            it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
             it { is_expected.to contain_file('/root/.pgpass') }
             it { is_expected.to contain_class('zabbix::params') }
 
@@ -71,7 +71,7 @@ describe 'zabbix::database::postgresql' do
 
               it { is_expected.to compile.with_all_deps }
               it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-              it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 6432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 6432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
               it { is_expected.to contain_file('/root/.pgpass') }
               it { is_expected.to contain_class('zabbix::params') }
             end
@@ -91,9 +91,9 @@ describe 'zabbix::database::postgresql' do
             it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
 
             if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-              it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
             else
-              it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
             end
             it { is_expected.to contain_class('zabbix::params') }
 
@@ -104,9 +104,9 @@ describe 'zabbix::database::postgresql' do
               it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
 
               if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-                it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+                it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
               else
-                it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+                it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
               end
 
               it { is_expected.to contain_class('zabbix::params') }

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -19,6 +19,12 @@ describe 'zabbix::database::postgresql' do
         facts
       end
 
+      let :params do
+        {
+          database_host: 'node01.example.com',
+        }
+      end
+
       supported_versions.each do |zabbix_version|
         path = if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '7'
                  # Path on EL7
@@ -41,117 +47,75 @@ describe 'zabbix::database::postgresql' do
                        'create.sql'
                      end
 
-        describe "when zabbix_type is server and version is #{zabbix_version}" do
-          let :params do
-            {
-              database_name: 'zabbix-server',
-              database_user: 'zabbix-server',
-              database_password: 'zabbix-server',
-              database_host: 'node01.example.com',
-              database_port: 5432,
-              zabbix_type: 'server',
-              zabbix_version: zabbix_version
-            }
+        describe "when version is #{zabbix_version}" do
+          let(:params) { super().merge(zabbix_version: zabbix_version) }
+
+          describe 'when zabbix_type is server' do
+            let(:params) do
+              super().merge(
+                database_name: 'zabbix-server',
+                database_user: 'zabbix-server',
+                database_password: 'zabbix-server',
+                zabbix_type: 'server'
+              )
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
+            it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
+            it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
+            it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
+            it { is_expected.to contain_file('/root/.pgpass') }
+            it { is_expected.to contain_class('zabbix::params') }
+
+            describe 'with custom port is defined' do
+              let(:params) { super().merge(database_port: 6432) }
+
+              it { is_expected.to compile.with_all_deps }
+              it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
+              it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 6432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
+              it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
+              it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
+              it { is_expected.to contain_file('/root/.pgpass') }
+              it { is_expected.to contain_class('zabbix::params') }
+            end
           end
 
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
-          it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
-          it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
-          it { is_expected.to contain_file('/root/.pgpass') }
-          it { is_expected.to contain_class('zabbix::params') }
-        end
+          describe 'when zabbix_type is proxy' do
+            let :params do
+              super().merge(
+                database_name: 'zabbix-proxy',
+                database_user: 'zabbix-proxy',
+                database_password: 'zabbix-proxy',
+                zabbix_type: 'proxy'
+              )
+            end
 
-        describe "when zabbix_type is server and version is #{zabbix_version} and no port is defined" do
-          let :params do
-            {
-              database_name: 'zabbix-server',
-              database_user: 'zabbix-server',
-              database_password: 'zabbix-server',
-              database_host: 'node01.example.com',
-              zabbix_type: 'server',
-              zabbix_version: zabbix_version
-            }
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
+
+            if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
+              it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+            else
+              it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+            end
+            it { is_expected.to contain_class('zabbix::params') }
+
+            describe 'with a custom port' do
+              let(:params) { super().merge(database_port: 6432) }
+
+              it { is_expected.to compile.with_all_deps }
+              it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
+
+              if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
+                it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
+              else
+                it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 6432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
+              end
+
+              it { is_expected.to contain_class('zabbix::params') }
+            end
           end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
-          it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
-          it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
-          it { is_expected.to contain_file('/root/.pgpass') }
-          it { is_expected.to contain_class('zabbix::params') }
-        end
-
-        describe "when zabbix_type is server and version is #{zabbix_version} and custom port is defined" do
-          let :params do
-            {
-              database_name: 'zabbix-server',
-              database_user: 'zabbix-server',
-              database_password: 'zabbix-server',
-              database_host: 'node01.example.com',
-              database_port: 6432,
-              zabbix_type: 'server',
-              zabbix_version: zabbix_version
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
-          it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 6432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
-          it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
-          it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
-          it { is_expected.to contain_file('/root/.pgpass') }
-          it { is_expected.to contain_class('zabbix::params') }
-        end
-
-        describe "when zabbix_type is proxy and version is #{zabbix_version}" do
-          let :params do
-            {
-              database_name: 'zabbix-proxy',
-              database_user: 'zabbix-proxy',
-              database_password: 'zabbix-proxy',
-              database_host: 'node01.example.com',
-              database_port: 5432,
-              zabbix_type: 'proxy',
-              zabbix_version: zabbix_version
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-
-          if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
-          else
-            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
-          end
-          it { is_expected.to contain_class('zabbix::params') }
-        end
-
-        describe "when zabbix_type is proxy and version is #{zabbix_version} and no port is defined" do
-          let :params do
-            {
-              database_name: 'zabbix-proxy',
-              database_user: 'zabbix-proxy',
-              database_password: 'zabbix-proxy',
-              database_host: 'node01.example.com',
-              zabbix_type: 'proxy',
-              zabbix_version: zabbix_version
-            }
-          end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-proxy:zabbix-proxy:zabbix-proxy >> /root/.pgpass') }
-
-          if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
-            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then gunzip -f schema.sql.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f schema.sql && touch /etc/zabbix/.schema.done") }
-          else
-            it { is_expected.to contain_exec('zabbix_proxy_create.sql').with_command("cd #{path} && psql -h 'node01.example.com' -U 'zabbix-proxy' -p 5432 -d 'zabbix-proxy' -f proxy.sql && touch /etc/zabbix/.schema.done") }
-          end
-
-          it { is_expected.to contain_class('zabbix::params') }
         end
       end
     end

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -63,8 +63,6 @@ describe 'zabbix::database::postgresql' do
             it { is_expected.to compile.with_all_deps }
             it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:5432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
             it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 5432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
-            it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
-            it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
             it { is_expected.to contain_file('/root/.pgpass') }
             it { is_expected.to contain_class('zabbix::params') }
 
@@ -74,8 +72,6 @@ describe 'zabbix::database::postgresql' do
               it { is_expected.to compile.with_all_deps }
               it { is_expected.to contain_exec('update_pgpass').with_command('echo node01.example.com:6432:zabbix-server:zabbix-server:zabbix-server >> /root/.pgpass') }
               it { is_expected.to contain_exec('zabbix_server_create.sql').with_command("cd #{path} && if [ -f #{sql_server}.gz ]; then gunzip -f #{sql_server}.gz ; fi && psql -h 'node01.example.com' -U 'zabbix-server' -p 6432 -d 'zabbix-server' -f #{sql_server} && touch /etc/zabbix/.schema.done") }
-              it { is_expected.to contain_exec('zabbix_server_images.sql').with_command('touch /etc/zabbix/.images.done') }
-              it { is_expected.to contain_exec('zabbix_server_data.sql').with_command('touch /etc/zabbix/.data.done') }
               it { is_expected.to contain_file('/root/.pgpass') }
               it { is_expected.to contain_class('zabbix::params') }
             end

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -7,10 +7,6 @@ describe 'zabbix::database::postgresql' do
     'rspec.puppet.com'
   end
 
-  let :pre_condition do
-    'include postgresql::server'
-  end
-
   on_supported_os(baseline_os_hash).each do |os, facts|
     next if facts[:os]['name'] == 'windows'
 

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -110,7 +110,7 @@ describe 'zabbix::database::postgresql' do
             if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') < 0
               it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f schema.sql.gz ]; then zcat schema.sql.gz | psql ; else psql -f schema.sql; fi && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             else
-              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && psql -f proxy.sql && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
+              it { is_expected.to contain_exec('zabbix_create.sql').with_command("cd #{path} && if [ -f proxy.sql.gz ]; then zcat proxy.sql.gz | psql ; else psql -f proxy.sql; fi && touch /etc/zabbix/.schema.done").with_environment(expected_environment) }
             end
             it { is_expected.to contain_class('zabbix::params') }
 

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -38,7 +38,7 @@ describe 'zabbix::proxy' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('zabbix::params') }
         it { is_expected.to contain_exec('update_pgpass') }
-        it { is_expected.to contain_exec('zabbix_proxy_create.sql') }
+        it { is_expected.to contain_exec('zabbix_create.sql') }
         it { is_expected.to contain_file('/root/.pgpass') }
         it { is_expected.to contain_postgresql__server__pg_hba_rule('Allow zabbix-proxy to access database') }
 

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -37,9 +37,7 @@ describe 'zabbix::proxy' do
         it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf.d').with_require('File[/etc/zabbix/zabbix_proxy.conf]') }
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('zabbix::params') }
-        it { is_expected.to contain_exec('update_pgpass') }
         it { is_expected.to contain_exec('zabbix_create.sql') }
-        it { is_expected.to contain_file('/root/.pgpass') }
         it { is_expected.to contain_postgresql__server__pg_hba_rule('Allow zabbix-proxy to access database') }
 
         describe 'when manage_repo is true and zabbix version is unset' do

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -80,8 +80,6 @@ describe 'zabbix::server' do
         it { is_expected.to contain_package('zabbix-server-pgsql').with_ensure('present') }
         it { is_expected.to contain_package('zabbix-server-pgsql').with_name('zabbix-server-pgsql') }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_require('Package[zabbix-server-pgsql]') }
-        it { is_expected.to contain_exec('update_pgpass') }
-        it { is_expected.to contain_file('/root/.pgpass') }
       end
 
       describe 'with database_type as mysql' do

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -95,8 +95,6 @@ describe 'zabbix::server' do
         it { is_expected.to contain_package('zabbix-server-mysql').with_name('zabbix-server-mysql') }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_server.conf').with_require('Package[zabbix-server-mysql]') }
         it { is_expected.to contain_exec('zabbix_server_create.sql') }
-        it { is_expected.to contain_exec('zabbix_server_data.sql') }
-        it { is_expected.to contain_exec('zabbix_server_images.sql') }
       end
 
       # Include directory should be available.


### PR DESCRIPTION
This started with the goal of getting rid of /root/.pgpass and instead use environment variables, but it escalated. See individual commits for details.