### PR TITLE
Better Hiera compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,6 @@ node 'zabbix.example.com' {
   }
   include apache::mod::php
 
-  class { 'postgresql::server': }
-
   class { 'zabbix':
     zabbix_url    => 'zabbix.example.com',
   }
@@ -215,8 +213,6 @@ Like the zabbix-server, the zabbix-proxy can also be used in 2 ways:
 The following is an example for using the PostgreSQL as database:
 ```ruby
 node 'proxy.example.com' {
-  class { 'postgresql::server': }
-
   class { 'zabbix::database':
     database_type => 'postgresql',
   }

--- a/README.md
+++ b/README.md
@@ -152,8 +152,6 @@ node 'zabbix.example.com' {
   }
   include apache::mod::php
 
-  class { 'mysql::server': }
-
   class { 'zabbix':
     zabbix_url    => 'zabbix.example.com',
     database_type => 'mysql',
@@ -227,8 +225,6 @@ node 'proxy.example.com' {
 When you want to make use of an MySQL database as backend:
 ```ruby
 node 'proxy.example.com' {
-  class { 'mysql::server': }
-
   class { 'zabbix::database':
     database_type => 'mysql',
   }

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ node 'zabbix.example.com' {
   class { 'apache':
     mpm_module => 'prefork',
   }
-  include apache::mod::php
 
   class { 'zabbix':
     zabbix_url    => 'zabbix.example.com',
@@ -150,7 +149,6 @@ node 'zabbix.example.com' {
   class { 'apache':
     mpm_module => 'prefork',
   }
-  include apache::mod::php
 
   class { 'zabbix':
     zabbix_url    => 'zabbix.example.com',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4936,7 +4936,6 @@ node 'wdpuppet02.dj-wasabi.local' {
   class { 'apache':
       mpm_module => 'prefork',
   }
-  class { 'apache::mod::php': }
   class { 'zabbix::web':
     zabbix_url    => 'zabbix.dj-wasabi.nl',
     zabbix_server => 'wdpuppet03.dj-wasabi.local',

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -146,6 +146,7 @@ class zabbix::database (
       }
       'mysql': {
         # This is the MySQL part.
+        include mysql::server
 
         # First we check what kind of zabbix component it is. We have to use clear names
         # as it may be confusing when you need to fill in the zabbix-proxy name into the

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -94,12 +94,13 @@ class zabbix::database (
     case $database_type {
       'postgresql': {
         # This is the PostgreSQL part.
+
+        include postgresql::server
         # Create the postgres database.
         postgresql::server::db { $database_name:
           user       => $database_user,
           owner      => $database_user,
           password   => postgresql::postgresql_password($database_user, $database_password),
-          require    => Class['postgresql::server'],
           tablespace => $database_tablespace,
         }
 

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -82,7 +82,6 @@
 #     class { 'apache':
 #         mpm_module => 'prefork',
 #     }
-#     class { 'apache::mod::php': }
 #     class { 'zabbix::web':
 #       zabbix_url    => 'zabbix.dj-wasabi.nl',
 #       zabbix_server => 'wdpuppet03.dj-wasabi.local',
@@ -343,6 +342,8 @@ class zabbix::web (
       }
     }
     else {
+      include apache::mod::php
+
       $apache_vhost_custom_fragment = "
         php_value max_execution_time ${apache_php_max_execution_time}
         php_value memory_limit ${apache_php_memory_limit}

--- a/spec/acceptance/hieradata/common.yaml
+++ b/spec/acceptance/hieradata/common.yaml
@@ -1,0 +1,7 @@
+---
+apache::mpm_module: 'prefork'
+
+postgresql::globals::encoding: 'UTF-8'
+postgresql::globals::locale: 'en_US.UTF-8'
+postgresql::globals::manage_package_repo: true
+postgresql::globals::version: '13'

--- a/spec/acceptance/hieradata/os/RedHat/8.yaml
+++ b/spec/acceptance/hieradata/os/RedHat/8.yaml
@@ -1,0 +1,3 @@
+---
+postgresql::globals::manage_dnf_module: true
+postgresql::globals::manage_package_repo: false

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -23,7 +23,6 @@ describe 'zabbix::server class', unless: default[:platform] =~ %r{archlinux} do
           manage_dnf_module => $facts['os']['release']['major'] == '8',
           version => '13',
         }
-        -> class { 'postgresql::server': }
         -> class { 'zabbix::database': }
         -> class { 'zabbix::server': }
       EOS
@@ -73,7 +72,6 @@ describe 'zabbix::server class', unless: default[:platform] =~ %r{archlinux} do
             manage_dnf_module => $facts['os']['release']['major'] == '8',
             version => '13',
           }
-          -> class { 'postgresql::server': }
           -> class { 'zabbix::database': }
           -> class { 'zabbix::server':
             zabbix_version => "#{zabbix_version}"

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -16,14 +16,7 @@ describe 'zabbix::server class', unless: default[:platform] =~ %r{archlinux} do
 
       # this will actually deploy apache + postgres + zabbix-server + zabbix-web
       pp = <<-EOS
-        class { 'postgresql::globals':
-          encoding => 'UTF-8',
-          locale   => 'en_US.UTF-8',
-          manage_package_repo => $facts['os']['release']['major'] != '8',
-          manage_dnf_module => $facts['os']['release']['major'] == '8',
-          version => '13',
-        }
-        -> class { 'zabbix::database': }
+        class { 'zabbix::database': }
         -> class { 'zabbix::server': }
       EOS
 
@@ -65,14 +58,7 @@ describe 'zabbix::server class', unless: default[:platform] =~ %r{archlinux} do
 
         # this will actually deploy apache + postgres + zabbix-server + zabbix-web
         pp = <<-EOS
-          class { 'postgresql::globals':
-            encoding => 'UTF-8',
-            locale   => 'en_US.UTF-8',
-            manage_package_repo => $facts['os']['release']['major'] != '8',
-            manage_dnf_module => $facts['os']['release']['major'] == '8',
-            version => '13',
-          }
-          -> class { 'zabbix::database': }
+          class { 'zabbix::database': }
           -> class { 'zabbix::server':
             zabbix_version => "#{zabbix_version}"
           }

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -33,7 +33,6 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{archlinux} 
           manage_dnf_module => $facts['os']['release']['major'] == '8',
           version => '13',
         }
-        -> class { 'postgresql::server': }
 
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
@@ -42,7 +41,7 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{archlinux} 
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => [ Class['postgresql::server'], Class['apache'], ],
+          require          => Class['apache'],
         }
 
       EOS

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -24,9 +24,6 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{archlinux} 
         class { 'apache':
             mpm_module => 'prefork',
         }
-        if $facts['os']['family'] != 'RedHat' {
-          include apache::mod::php
-        }
         class { 'postgresql::globals':
           locale   => 'en_US.UTF-8',
           manage_package_repo => $facts['os']['release']['major'] != '8',

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -21,16 +21,6 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{archlinux} 
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests
       pp1 = <<-EOS
-        class { 'apache':
-            mpm_module => 'prefork',
-        }
-        class { 'postgresql::globals':
-          locale   => 'en_US.UTF-8',
-          manage_package_repo => $facts['os']['release']['major'] != '8',
-          manage_dnf_module => $facts['os']['release']['major'] == '8',
-          version => '13',
-        }
-
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
           zabbix_url       => 'localhost',
@@ -38,7 +28,6 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{archlinux} 
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => Class['apache'],
         }
 
       EOS

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -30,16 +30,6 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
                       end
 
       pp1 = <<-EOS
-        class { 'apache':
-            mpm_module => 'prefork',
-        }
-        class { 'postgresql::globals':
-          locale   => 'en_US.UTF-8',
-          manage_package_repo => $facts['os']['release']['major'] != '8',
-          manage_dnf_module => $facts['os']['release']['major'] == '8',
-          version => '13',
-        }
-
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
           zabbix_url       => 'localhost',
@@ -47,7 +37,6 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => Class['apache'],
         }
       EOS
 

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -42,7 +42,6 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
           manage_dnf_module => $facts['os']['release']['major'] == '8',
           version => '13',
         }
-        -> class { 'postgresql::server': }
 
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
@@ -51,7 +50,7 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => [ Class['postgresql::server'], Class['apache'], ],
+          require          => Class['apache'],
         }
       EOS
 

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -33,9 +33,6 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
         class { 'apache':
             mpm_module => 'prefork',
         }
-        if $facts['os']['family'] != 'RedHat' {
-          include apache::mod::php
-        }
         class { 'postgresql::globals':
           locale   => 'en_US.UTF-8',
           manage_package_repo => $facts['os']['release']['major'] != '8',

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -17,9 +17,6 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{archlinux} do
         class { 'apache':
             mpm_module => 'prefork',
         }
-        if $facts['os']['family'] != 'RedHat' {
-          include apache::mod::php
-        }
         class { 'postgresql::globals':
           locale   => 'en_US.UTF-8',
           manage_package_repo => $facts['os']['release']['major'] != '8',

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -26,7 +26,6 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{archlinux} do
           manage_dnf_module => $facts['os']['release']['major'] == '8',
           version => '13',
         }
-        -> class { 'postgresql::server': }
 
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
@@ -35,7 +34,7 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{archlinux} do
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => [ Class['postgresql::server'], Class['apache'], ],
+          require          => Class['apache'],
         }
       EOS
 

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -14,16 +14,6 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{archlinux} do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests
       pp1 = <<-EOS
-        class { 'apache':
-            mpm_module => 'prefork',
-        }
-        class { 'postgresql::globals':
-          locale   => 'en_US.UTF-8',
-          manage_package_repo => $facts['os']['release']['major'] != '8',
-          manage_dnf_module => $facts['os']['release']['major'] == '8',
-          version => '13',
-        }
-
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
           zabbix_url       => 'localhost',
@@ -31,7 +21,6 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{archlinux} do
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => Class['apache'],
         }
       EOS
 

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -27,7 +27,6 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{archlinux} do
         manage_dnf_module => $facts['os']['release']['major'] == '8',
         version => '13',
       }
-      -> class { 'postgresql::server': }
 
       class { 'zabbix':
         zabbix_version   => "#{zabbix_version}",
@@ -36,7 +35,7 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{archlinux} do
         zabbix_api_pass  => 'zabbix',
         apache_use_ssl   => false,
         manage_resources => true,
-        require          => [ Class['postgresql::server'], Class['apache'], ],
+        require          => Class['apache'],
       }
       EOS
 

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -15,16 +15,6 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{archlinux} do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests
       pp1 = <<-EOS
-      class { 'apache':
-        mpm_module => 'prefork',
-      }
-      class { 'postgresql::globals':
-        locale   => 'en_US.UTF-8',
-        manage_package_repo => $facts['os']['release']['major'] != '8',
-        manage_dnf_module => $facts['os']['release']['major'] == '8',
-        version => '13',
-      }
-
       class { 'zabbix':
         zabbix_version   => "#{zabbix_version}",
         zabbix_url       => 'localhost',
@@ -32,7 +22,6 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{archlinux} do
         zabbix_api_pass  => 'zabbix',
         apache_use_ssl   => false,
         manage_resources => true,
-        require          => Class['apache'],
       }
       EOS
 

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -18,9 +18,6 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{archlinux} do
       class { 'apache':
         mpm_module => 'prefork',
       }
-      if $facts['os']['family'] != 'RedHat' {
-        include apache::mod::php
-      }
       class { 'postgresql::globals':
         locale   => 'en_US.UTF-8',
         manage_package_repo => $facts['os']['release']['major'] != '8',

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -23,16 +23,6 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests
       pp1 = <<-EOS
-        class { 'apache':
-          mpm_module => 'prefork',
-        }
-        class { 'postgresql::globals':
-          locale   => 'en_US.UTF-8',
-          manage_package_repo => $facts['os']['release']['major'] != '8',
-          manage_dnf_module => $facts['os']['release']['major'] == '8',
-          version => '13',
-        }
-
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
           zabbix_url       => 'localhost',
@@ -40,7 +30,6 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => Class['apache'],
         }
       EOS
 

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -26,9 +26,6 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux
         class { 'apache':
           mpm_module => 'prefork',
         }
-        if $facts['os']['family'] != 'RedHat' {
-          include apache::mod::php
-        }
         class { 'postgresql::globals':
           locale   => 'en_US.UTF-8',
           manage_package_repo => $facts['os']['release']['major'] != '8',

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -35,7 +35,6 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux
           manage_dnf_module => $facts['os']['release']['major'] == '8',
           version => '13',
         }
-        -> class { 'postgresql::server': }
 
         class { 'zabbix':
           zabbix_version   => "#{zabbix_version}",
@@ -44,7 +43,7 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux
           zabbix_api_pass  => 'zabbix',
           apache_use_ssl   => false,
           manage_resources => true,
-          require          => [ Class['postgresql::server'], Class['apache'], ],
+          require          => Class['apache'],
         }
       EOS
 

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -26,7 +26,6 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{archlinux} do
             manage_dnf_module => $facts['os']['release']['major'] == '8',
             version => '13',
           }
-          -> class { 'postgresql::server': }
 
           class { 'zabbix':
             zabbix_version   => "#{zabbix_version}",
@@ -35,7 +34,7 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{archlinux} do
             zabbix_api_pass  => 'zabbix',
             apache_use_ssl   => false,
             manage_resources => true,
-            require          => [ Class['postgresql::server'], Class['apache'], ],
+            require          => Class['apache'],
           }
       EOS
 

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -14,16 +14,6 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{archlinux} do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests
       pp1 = <<-EOS
-          class { 'apache':
-              mpm_module => 'prefork',
-          }
-          class { 'postgresql::globals':
-            locale   => 'en_US.UTF-8',
-            manage_package_repo => $facts['os']['release']['major'] != '8',
-            manage_dnf_module => $facts['os']['release']['major'] == '8',
-            version => '13',
-          }
-
           class { 'zabbix':
             zabbix_version   => "#{zabbix_version}",
             zabbix_url       => 'localhost',
@@ -31,7 +21,6 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{archlinux} do
             zabbix_api_pass  => 'zabbix',
             apache_use_ssl   => false,
             manage_resources => true,
-            require          => Class['apache'],
           }
       EOS
 

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -17,9 +17,6 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{archlinux} do
           class { 'apache':
               mpm_module => 'prefork',
           }
-          if $facts['os']['family'] != 'RedHat' {
-            include apache::mod::php
-          }
           class { 'postgresql::globals':
             locale   => 'en_US.UTF-8',
             manage_package_repo => $facts['os']['release']['major'] != '8',

--- a/spec/classes/database_mysql_spec.rb
+++ b/spec/classes/database_mysql_spec.rb
@@ -7,10 +7,6 @@ describe 'zabbix::database::mysql' do
     'rspec.puppet.com'
   end
 
-  let :pre_condition do
-    "include 'mysql::server'"
-  end
-
   on_supported_os(baseline_os_hash).each do |os, facts|
     next if facts[:os]['name'] == 'windows'
 

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -17,7 +17,6 @@ describe 'zabbix::database' do
 
       let :pre_condition do
         <<-EOS
-          include 'postgresql::server'
           if $facts['os']['family'] == 'Gentoo' {
             # We don't need the package to be installed as its the same for the server.
             class { 'mysql::client':

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -23,7 +23,6 @@ describe 'zabbix::database' do
               package_manage => false,
             }
           }
-          include 'mysql::server'
         EOS
       end
 

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -28,8 +28,7 @@ describe 'zabbix::proxy' do
         end
       else
         let :pre_condition do
-          "include 'postgresql::server'
-           include 'mysql::server'"
+          "include 'mysql::server'"
         end
         let :params do
           {

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -27,9 +27,6 @@ describe 'zabbix::proxy' do
           it { is_expected.not_to compile }
         end
       else
-        let :pre_condition do
-          "include 'mysql::server'"
-        end
         let :params do
           {
             zabbix_server_host: '192.168.1.1',
@@ -130,10 +127,6 @@ describe 'zabbix::proxy' do
               database_type: 'mysql',
               manage_database: true
             }
-          end
-
-          let(:pre_condition) do
-            "include 'mysql::server'"
           end
 
           it { is_expected.to contain_class('zabbix::database::mysql').with_zabbix_type('proxy') }

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -14,6 +14,16 @@ describe 'zabbix::web' do
     }
   end
 
+  let :pre_condition do
+    <<~PUPPET
+      if $facts['os']['family'] != 'RedHat' {
+        class { 'apache':
+          mpm_module => 'prefork',
+        }
+      }
+    PUPPET
+  end
+
   on_supported_os(baseline_os_hash).each do |os, facts|
     supported_versions.each do |zabbix_version|
       next if facts[:os]['name'] == 'windows'


### PR DESCRIPTION
This does the required includes for `apache` and `postgresql::server` if needed. It then uses this together with beaker-hiera (which voxpupuli-acceptance already automatically sets up for us) to reduce duplication in acceptance tests.