### PR TITLE
remove old version comparison guards for Zabbix pre 5.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -466,10 +466,7 @@ class zabbix::params {
   $proxy_zabbix_server_host                 = undef
   $proxy_zabbix_server_port                 = '10051'
   $proxy_zbx_templates                      = ['Template App Zabbix Proxy']
-  $proxy_socketdir                          = versioncmp($zabbix_version, '5.0') ? {
-    -1      => undef,
-    default => '/var/run/zabbix',
-  }
+  $proxy_socketdir                          = '/var/run/zabbix'
 
   # Java Gateway specific params
   $javagateway_listenip                     = '0.0.0.0'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -87,7 +87,7 @@ class zabbix::repo (
           }
         }
 
-        if ($facts['os']['release']['major'] == '7' and versioncmp($zabbix_version, '5.0') >= 0) {
+        if ($facts['os']['release']['major'] == '7') {
           case $facts['os']['name'] {
             'CentOS': {
               $scl_package_name = 'centos-release-scl'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -50,7 +50,7 @@ describe 'zabbix::web' do
           it { is_expected.to contain_package('zabbix-required-scl-repo') }                if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '7'
           it { is_expected.to contain_service('rh-php72-php-fpm') }                        if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '7'
           it { is_expected.to contain_file('/etc/opt/rh/rh-php72/php-fpm.d/zabbix.conf') } if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '7'
-          it { is_expected.to contain_file('/etc/zabbix/zabbix.conf.php') }                if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '7' && Puppet::Util::Package.versioncmp(zabbix_version, '5.0') >= 0
+          it { is_expected.to contain_file('/etc/zabbix/zabbix.conf.php') }                if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '7'
           it { is_expected.to contain_service('php-fpm') }                                 if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] >= '8'
           it { is_expected.to contain_file('/etc/php-fpm.d/zabbix.conf') }                 if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] >= '8'
         end
@@ -91,8 +91,7 @@ describe 'zabbix::web' do
 
           packages = if facts[:os]['family'] == 'RedHat'
                        if facts[:os]['release']['major'].to_i == 7 &&
-                          !%w[VirtuozzoLinux OracleLinux Scientific].include?(facts[:os]['name']) &&
-                          Puppet::Util::Package.versioncmp(zabbix_version, '5.0') >= 0
+                          !%w[VirtuozzoLinux OracleLinux Scientific].include?(facts[:os]['name'])
                          %w[zabbix-web-pgsql-scl zabbix-web]
                        else
                          %w[zabbix-web-pgsql zabbix-web]

--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -48,7 +48,6 @@ DebugLevel=<%= @debuglevel %>
 #
 <% if @sourceip %>SourceIP=<%= @sourceip %><% end %>
 
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: AllowKey
 #       Allow execution of item keys matching pattern.
 #       Multiple keys matching rules may be defined in combination with DenyKey.
@@ -72,16 +71,6 @@ DebugLevel=<%= @debuglevel %>
 # Mandatory: no
 # Default:
 <% if @denykey %>DenyKey=<%= @denykey -%><% end %>
-<% end %>
-
-<% if @zabbix_version.to_f < 5.0 %>
-### Option: EnableRemoteCommands
-#	Whether remote commands from Zabbix server are allowed.
-#	0 - not allowed
-#	1 - allowed
-#
-EnableRemoteCommands=<%= @enableremotecommands %>
-<% end %>
 
 ### Option: LogRemoteCommands
 #	Enable logging of executed shell commands as warnings.
@@ -375,7 +364,6 @@ LoadModulePath=<%= @loadmodulepath %>
 # TLSPSKFile=
 <% if @tlspskfile %>TLSPSKFile=<%= @tlspskfile %><% end %>
 
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: TLSCipherCert13
 #       Cipher string for OpenSSL 1.1.1 or newer in TLS 1.3.
 #       Override the default ciphersuite selection criteria for certificate-based encryption.
@@ -439,5 +427,3 @@ LoadModulePath=<%= @loadmodulepath %>
 # Mandatory: no
 # Default:
 <% if @tlscipherall %>TLSCipherAll=<%= @tlscipherall %><% end %>
-
-<% end %>

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -85,7 +85,6 @@ DebugLevel=<%= @debuglevel %>
 #
 PidFile=<%= @pidfile %>
 
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: SocketDir
 #       IPC socket directory.
 #               Directory to store IPC sockets used by internal Zabbix services.
@@ -94,7 +93,6 @@ PidFile=<%= @pidfile %>
 # Default:
 
 <% if @socketdir %>SocketDir=<%= @socketdir %><% end %>
-<% end %>
 
 ### Option: DBHost
 #	Database host name.
@@ -516,7 +514,6 @@ LoadModulePath=<%= @loadmodulepath %>
 <% if @tlspskfile %>TLSPSKFile=<%= @tlspskfile %><% end %>
 
 ####### For advanced users - TLS ciphersuite selection criteria #######
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: DBTLSConnect
 #       Setting this option enforces to use TLS connection to database.
 #       required    - connect using TLS
@@ -572,9 +569,7 @@ LoadModulePath=<%= @loadmodulepath %>
 # Mandatory no
 # Default:
 <% if @database_tlscipher13 %>DBTLSCipher13=<%= @database_tlscipher13 %><% end %>
-<% end %>
 
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: TLSCipherCert13
 #       Cipher string for OpenSSL 1.1.1 or newer in TLS 1.3.
 #       Override the default ciphersuite selection criteria for certificate-based encryption.
@@ -644,7 +639,6 @@ LoadModulePath=<%= @loadmodulepath %>
 # Default:
 # TLSCipherAll13=
 <% if @tlscipherall %>TLSCipherAll=<%= @tlscipherall %><% end %>
-<% end %>
 
 <% if @zabbix_version.to_f >= 5.2 %>
 ### Option: VaultToken

--- a/templates/zabbix_server.conf.erb
+++ b/templates/zabbix_server.conf.erb
@@ -384,7 +384,6 @@ ProxyConfigFrequency=<%= @proxyconfigfrequency %>
 #
 ProxyDataFrequency=<%= @proxydatafrequency %>
 
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: StartLLDProcessors
 #       Number of pre-forked instances of low level discovery processors.
 #
@@ -393,7 +392,6 @@ ProxyDataFrequency=<%= @proxydatafrequency %>
 # Default:
 # StartLLDProcessors=2
 <% if @startlldprocessors %>StartLLDProcessors=<%= @startlldprocessors -%><% end %>
-<% end %>
 
 ### Option: AllowRoot
 #   Allow the server to run as 'root'. If disabled and the server is started by 'root', the server
@@ -490,7 +488,6 @@ LoadModulePath=<%= @loadmodulepath %>
 <% if @tlskeyfile %>TLSKeyFile=<%= @tlskeyfile %><% end %>
 
 ####### For advanced users - TLS ciphersuite selection criteria #######
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: DBTLSConnect
 #       Setting this option enforces to use TLS connection to database.
 #       required    - connect using TLS
@@ -546,9 +543,7 @@ LoadModulePath=<%= @loadmodulepath %>
 # Mandatory no
 # Default:
 <% if @database_tlscipher13 %>DBTLSCipher13=<%= @database_tlscipher13 %><% end %>
-<% end %>
 
-<% if @zabbix_version.to_f >= 5.0 %>
 ### Option: TLSCipherCert13
 #       Cipher string for OpenSSL 1.1.1 or newer in TLS 1.3.
 #       Override the default ciphersuite selection criteria for certificate-based encryption.
@@ -618,7 +613,6 @@ LoadModulePath=<%= @loadmodulepath %>
 # Default:
 # TLSCipherAll13=
 <% if @tlscipherall %>TLSCipherAll=<%= @tlscipherall %><% end %>
-<% end %>
 
 <% if @zabbix_version.to_f >= 5.2 %>
 ### Option: VaultToken


### PR DESCRIPTION
we don't support 4.x anymore, so anything that's checking for versions before 5.0 can be safely removed

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
