### PR TITLE
Remove deprecated zabbix_host.group, zabbix::agent::zbx_group, zabbix::resources::agent::group parameters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1348,7 +1348,6 @@ The following parameters are available in the `zabbix::agent` class:
 * [`manage_resources`](#-zabbix--agent--manage_resources)
 * [`monitored_by_proxy`](#-zabbix--agent--monitored_by_proxy)
 * [`agent_use_ip`](#-zabbix--agent--agent_use_ip)
-* [`zbx_group`](#-zabbix--agent--zbx_group)
 * [`zbx_groups`](#-zabbix--agent--zbx_groups)
 * [`zbx_group_create`](#-zabbix--agent--zbx_group_create)
 * [`zbx_templates`](#-zabbix--agent--zbx_templates)
@@ -1515,14 +1514,6 @@ When true, when creating hosts via the zabbix-api, it will configure that
 connection should me made via ip, not fqdn.
 
 Default value: `$zabbix::params::agent_use_ip`
-
-##### <a name="-zabbix--agent--zbx_group"></a>`zbx_group`
-
-Data type: `Any`
-
-*Deprecated* (see zbx_groups) Name of the hostgroup where this host needs to be added.
-
-Default value: `$zabbix::params::agent_zbx_group`
 
 ##### <a name="-zabbix--agent--zbx_groups"></a>`zbx_groups`
 
@@ -3607,7 +3598,6 @@ The following parameters are available in the `zabbix::resources::agent` class:
 * [`ipaddress`](#-zabbix--resources--agent--ipaddress)
 * [`use_ip`](#-zabbix--resources--agent--use_ip)
 * [`port`](#-zabbix--resources--agent--port)
-* [`group`](#-zabbix--resources--agent--group)
 * [`groups`](#-zabbix--resources--agent--groups)
 * [`group_create`](#-zabbix--resources--agent--group_create)
 * [`templates`](#-zabbix--resources--agent--templates)
@@ -3649,14 +3639,6 @@ Default value: `undef`
 Data type: `Any`
 
 The port that the zabbix agent is listening on.
-
-Default value: `undef`
-
-##### <a name="-zabbix--resources--agent--group"></a>`group`
-
-Data type: `Any`
-
-*Deprecated* (see groups parameter) Name of the hostgroup.
 
 Default value: `undef`
 
@@ -6013,10 +5995,6 @@ Valid values: `present`, `absent`
 The basic property that the resource should be in.
 
 Default value: `present`
-
-##### `group`
-
-Deprecated! Name of the hostgroup.
 
 ##### `groups`
 

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -9,16 +9,6 @@ Puppet::Type.newtype(:zabbix_host) do
     defaultto :present
   end
 
-  def initialize(*args)
-    super
-
-    # Migrate group to groups
-    return if self[:group].nil?
-
-    self[:groups] = self[:group]
-    delete(:group)
-  end
-
   def munge_boolean(value)
     case value
     when true, 'true', :true
@@ -96,14 +86,6 @@ Puppet::Type.newtype(:zabbix_host) do
     end
   end
 
-  newproperty(:group) do
-    desc 'Deprecated! Name of the hostgroup.'
-
-    validate do |_value|
-      Puppet.warning('Passing group to zabbix_host is deprecated and will be removed. Use groups instead.')
-    end
-  end
-
   newproperty(:groups, array_matching: :all) do
     desc 'An array of groups the host belongs to.'
     def insync?(is)
@@ -170,8 +152,4 @@ Puppet::Type.newtype(:zabbix_host) do
   end
 
   autorequire(:file) { '/etc/zabbix/api.conf' }
-
-  validate do
-    raise(_('The properties group and groups are mutually exclusive.')) if self[:group] && self[:groups]
-  end
 end

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -23,7 +23,6 @@
 # @param agent_use_ip
 #   When true, when creating hosts via the zabbix-api, it will configure that
 #   connection should me made via ip, not fqdn.
-# @param zbx_group *Deprecated* (see zbx_groups) Name of the hostgroup where this host needs to be added.
 # @param zbx_groups An array of hostgroups where this host needs to be added.
 # @param zbx_group_create Whether to create hostgroup if missing.
 # @param zbx_templates List of templates which will be added when host is configured.
@@ -148,7 +147,6 @@ class zabbix::agent (
   Boolean $manage_resources                            = $zabbix::params::manage_resources,
   $monitored_by_proxy                                  = $zabbix::params::monitored_by_proxy,
   $agent_use_ip                                        = $zabbix::params::agent_use_ip,
-  $zbx_group                                           = $zabbix::params::agent_zbx_group,
   Variant[String[1],Array[String[1]]] $zbx_groups      = $zabbix::params::agent_zbx_groups,
   $zbx_group_create                                    = $zabbix::params::agent_zbx_group_create,
   $zbx_templates                                       = $zabbix::params::agent_zbx_templates,
@@ -236,22 +234,6 @@ class zabbix::agent (
   # is set to false, you'll get warnings like this:
   # "Warning: You cannot collect without storeconfigs being set"
   if $manage_resources {
-    # Migrate deprecated zbx_group parameter
-    if $zbx_group == $zabbix::params::agent_zbx_group and $zbx_groups == $zabbix::params::agent_zbx_groups {
-      $groups = $zabbix::params::agent_zbx_groups
-    } else {
-      if $zbx_group != $zabbix::params::agent_zbx_group and $zbx_groups != $zabbix::params::agent_zbx_groups {
-        fail("Seems like you have filled zbx_group and zbx_groups with custom values. This isn't support! Please use zbx_groups only.")
-      }
-
-      if $zbx_group != $zabbix::params::agent_zbx_group {
-        warning('Passing zbx_group to zabbix::agent is deprecated and will be removed. Use zbx_groups instead.')
-        $groups = Array($zbx_group)
-      } else {
-        $groups = $zbx_groups
-      }
-    }
-
     if $monitored_by_proxy != '' {
       $use_proxy = $monitored_by_proxy
     } else {
@@ -264,7 +246,7 @@ class zabbix::agent (
       ipaddress        => $listen_ip,
       use_ip           => $agent_use_ip,
       port             => $listenport,
-      groups           => [$groups].flatten(),
+      groups           => [$zbx_groups].flatten(),
       group_create     => $zbx_group_create,
       templates        => $zbx_templates,
       macros           => $zbx_macros,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -358,7 +358,6 @@ class zabbix::params {
   $agent_use_ip                             = true
   $agent_userparameter                      = undef
   $agent_zabbix_alias                       = undef
-  $agent_zbx_group                          = 'Linux servers'
   $agent_zbx_groups                         = ['Linux servers',]
   $agent_zbx_group_create                   = true
   $agent_zbx_templates                      = ['Template OS Linux', 'Template App SSH Service']

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -3,7 +3,6 @@
 # @param ipaddress The IP address of the machine running zabbix agent.
 # @param use_ip Use ipadress instead of dns to connect.
 # @param port The port that the zabbix agent is listening on.
-# @param group *Deprecated* (see groups parameter) Name of the hostgroup.
 # @param groups An array of groups the host belongs to.
 # @param group_create Whether to create hostgroup if missing.
 # @param templates List of templates which should be attached to this host.
@@ -20,7 +19,6 @@ class zabbix::resources::agent (
   $ipaddress                          = undef,
   $use_ip                             = undef,
   $port                               = undef,
-  $group                              = undef,
   Array[String[1]] $groups            = undef,
   $group_create                       = undef,
   $templates                          = undef,
@@ -33,22 +31,11 @@ class zabbix::resources::agent (
   Optional[String[1]] $tls_issuer                         = undef,
   Optional[String[1]] $tls_subject                        = undef,
 ) {
-  if $group and $groups {
-    fail("Got group and groups. This isn't support! Please use groups only.")
-  } else {
-    if $group {
-      warning('Passing group to zabbix::resources::agent is deprecated and will be removed. Use groups instead.')
-      $_groups = Array($group)
-    } else {
-      $_groups = $groups
-    }
-  }
-
   @@zabbix_host { $hostname:
     ipaddress        => $ipaddress,
     use_ip           => $use_ip,
     port             => $port,
-    groups           => $_groups,
+    groups           => $groups,
     group_create     => $group_create,
     templates        => $templates,
     macros           => $macros,

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -38,7 +38,7 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux
           ipaddress    => '127.0.0.1',
           use_ip       => true,
           port         => 10050,
-          group        => 'TestgroupOne',
+          groups       => ['TestgroupOne'],
           group_create => true,
           templates    => [ "#{template}", ],
         }

--- a/spec/types/zabbix_host_spec.rb
+++ b/spec/types/zabbix_host_spec.rb
@@ -9,7 +9,6 @@ describe 'zabbix_host' do
     it { is_expected.to be_valid_type.with_provider(:ruby) }
 
     it { is_expected.to be_valid_type.with_properties('ensure') }
-    it { is_expected.to be_valid_type.with_properties('group') }
     it { is_expected.to be_valid_type.with_properties('groups') }
     it { is_expected.to be_valid_type.with_properties('id') }
     it { is_expected.to be_valid_type.with_properties('interfaceid') }

--- a/spec/unit/puppet/type/zabbix_host_spec.rb
+++ b/spec/unit/puppet/type/zabbix_host_spec.rb
@@ -18,7 +18,6 @@ describe Puppet::Type.type(:zabbix_host) do
 
   describe 'when validating properties' do
     %i[
-      group
       groups
       id
       interfaceid
@@ -74,10 +73,6 @@ describe Puppet::Type.type(:zabbix_host) do
   describe 'properties' do
     describe 'ensure' do
       it_behaves_like 'generic ensurable', :present
-    end
-
-    describe 'group' do
-      it_behaves_like 'validated property', :group, nil, ['group1', 'Group One']
     end
 
     describe 'groups' do


### PR DESCRIPTION
These were deprecated since 7.0.0 via a4750d47cd21ed8b03722b36df0b05a3fb9ff482

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
