### PR TITLE
Bootstrap agent2 support (rebased)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 5. [Usage - Configuration options and additional functionality](#usage)
     * [zabbix-server](#usage-zabbix-server)
     * [zabbix-agent](#usage-zabbix-agent)
+    * [zabbix-agent2](#usage-zabbix-agent2)
     * [zabbix-proxy](#usage-zabbix-proxy)
     * [zabbix-javagateway](#usage-zabbix-javagateway)
     * [zabbix-sender](#usage-zabbix-sender)
@@ -198,6 +199,21 @@ class { 'zabbix::agent':
   zabbix_package_provider => 'windows',
   zabbix_package_source   => "${tmpdir}/zabbix_agent-windows-amd64-openssl.msi",
 }
+```
+
+### Usage zabbix-agent2
+
+To use Zabbix agent2 you need to define some parameters
+
+```ruby
+  class { 'zabbix::agent':
+    package_name          => 'zabbix-agent2',
+    agent_configfile_path => '/etc/zabbix/zabbix_agent2.d',
+    pidfile               => '/var/run/zabbix/zabbix_agentd2.pid',
+    servicename           => 'zabbix-agent2',
+    zabbix_package_agent  => 'zabbix-agent2',
+    binary_location       => '/usr/sbin/zabbix_agent2'
+  }
 ```
 
 ### Usage zabbix-proxy

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -81,6 +81,19 @@ class { 'zabbix':
 }
 ```
 
+##### Using Zabbix Agent 2
+
+```puppet
+class { 'zabbix::agent':
+  package_name          => 'zabbix-agent2',
+  agent_configfile_path => '/etc/zabbix/zabbix_agent2.d',
+  pidfile               => '/var/run/zabbix/zabbix_agentd2.pid',
+  servicename           => 'zabbix-agent2',
+  zabbix_package_agent  => 'zabbix-agent2',
+  binary_location       => '/usr/sbin/zabbix_agent2'
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `zabbix` class:
@@ -1418,6 +1431,7 @@ The following parameters are available in the `zabbix::agent` class:
 * [`userparameter`](#-zabbix--agent--userparameter)
 * [`loadmodulepath`](#-zabbix--agent--loadmodulepath)
 * [`loadmodule`](#-zabbix--agent--loadmodule)
+* [`binary_location`](#-zabbix--agent--binary_location)
 * [`manage_startup_script`](#-zabbix--agent--manage_startup_script)
 
 ##### <a name="-zabbix--agent--zabbix_version"></a>`zabbix_version`
@@ -2089,6 +2103,14 @@ Data type: `Any`
 Module to load at agent startup.
 
 Default value: `$zabbix::params::agent_loadmodule`
+
+##### <a name="-zabbix--agent--binary_location"></a>`binary_location`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Location of th binary file, this feature is available only for systemd startup script
+
+Default value: `$zabbix::params::agent_binary_location`
 
 ##### <a name="-zabbix--agent--manage_startup_script"></a>`manage_startup_script`
 
@@ -5637,6 +5659,7 @@ The following parameters are available in the `zabbix::startup` defined type:
 * [`service_type`](#-zabbix--startup--service_type)
 * [`manage_database`](#-zabbix--startup--manage_database)
 * [`service_name`](#-zabbix--startup--service_name)
+* [`binary_location`](#-zabbix--startup--binary_location)
 
 ##### <a name="-zabbix--startup--pidfile"></a>`pidfile`
 
@@ -5711,6 +5734,14 @@ Data type: `Optional[String]`
 Name of the service. Defaults to the resource name
 
 Default value: `$name`
+
+##### <a name="-zabbix--startup--binary_location"></a>`binary_location`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+This params is use for define a specific binary location. This is actually only available for zabbix agent and systemd
+
+Default value: `undef`
 
 ### <a name="zabbix--template"></a>`zabbix::template`
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -118,6 +118,7 @@
 # @param userparameter User-defined parameter to monitor.
 # @param loadmodulepath Full path to location of agent modules.
 # @param loadmodule Module to load at agent startup.
+# @param binary_location Location of th binary file, this feature is available only for systemd startup script
 # @param manage_startup_script
 #  If the init script should be managed by this module. Attention: This might
 #  cause problems with some config options of this module (e.g
@@ -218,7 +219,10 @@ class zabbix::agent (
   String $additional_service_params                    = $zabbix::params::additional_service_params,
   String $service_type                                 = $zabbix::params::service_type,
   Boolean $manage_startup_script                       = $zabbix::params::manage_startup_script,
+  Optional[Stdlib::Absolutepath] $binary_location      = $zabbix::params::agent_binary_location,
 ) inherits zabbix::params {
+  $agent2 = $zabbix_package_agent == 'zabbix-agent2'
+
   # Find if listenip is set. If not, we can set to specific ip or
   # to network name. If more than 1 interfaces are available, we
   # can find the ipaddress of this specific interface if listenip
@@ -305,6 +309,7 @@ class zabbix::agent (
       additional_service_params => $additional_service_params,
       service_type              => $service_type,
       service_name              => 'zabbix-agent',
+      binary_location           => $binary_location,
       require                   => Package[$zabbix_package_agent],
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -199,10 +199,12 @@
 # @param saml_sp_cert The location of the SAML Service Provider Certificate.
 # @param saml_idp_cert The location of the SAML Identity Provider Certificate.
 # @param saml_settings A hash of additional SAML SSO settings.
+#
 # @example Single host setup:
 #   class { 'zabbix':
 #     zabbix_url => 'zabbix.dj-wasabi.nl',
 #   }
+#
 #
 # @example This assumes that you want to use the postgresql database. If not and  you want to supply your own database crendentials:
 #   class { 'zabbix':
@@ -211,6 +213,17 @@
 #     database_user     => 'zabbix',
 #     database_password => 'ThisIsVeryDifficult.nl',
 #   }
+#
+# @example Using Zabbix Agent 2
+#   class { 'zabbix::agent':
+#     package_name          => 'zabbix-agent2',
+#     agent_configfile_path => '/etc/zabbix/zabbix_agent2.d',
+#     pidfile               => '/var/run/zabbix/zabbix_agentd2.pid',
+#     servicename           => 'zabbix-agent2',
+#     zabbix_package_agent  => 'zabbix-agent2',
+#     binary_location       => '/usr/sbin/zabbix_agent2'
+#   }
+#
 # @author Werner Dijkerman ikben@werner-dijkerman.nl
 class zabbix (
   $zabbix_url                                                                 = '',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -292,6 +292,10 @@ class zabbix::params {
   $server_socketdir                         = undef
 
   # Agent specific params
+  $agent_binary_location                    = $facts['kernel'] ? {
+    'Linux' => '/usr/sbin/zabbix_agentd',
+    default => undef,
+  }
   $agent_allowroot                          = '0'
   $agent_buffersend                         = '5'
   $agent_buffersize                         = '100'

--- a/manifests/startup.pp
+++ b/manifests/startup.pp
@@ -11,6 +11,7 @@
 # @param service_type Systemd service type
 # @param manage_database When true, it will configure the database and execute the sql scripts.
 # @param service_name Name of the service. Defaults to the resource name
+# @param binary_location This params is use for define a specific binary location. This is actually only available for zabbix agent and systemd
 # @example
 #   zabbix::startup { 'agent': }
 #
@@ -27,6 +28,7 @@ define zabbix::startup (
   String $service_type                                   = 'simple',
   Optional[Boolean] $manage_database                     = undef,
   Optional[String] $service_name                         = $name,
+  Optional[Stdlib::Absolutepath] $binary_location        = undef,
 ) {
   case $title.downcase {
     /agent/: {
@@ -41,8 +43,10 @@ define zabbix::startup (
       fail('we currently only support a title that contains agent or server')
     }
   }
-  # provided by camp2camp/systemd
   if $facts['systemd'] {
+    if $name =~ /^zabbix-agent2?$/ {
+      assert_type(Stdlib::Absolutepath, $binary_location)
+    }
     contain systemd
     systemd::unit_file { "${name}.service":
       content => template("zabbix/${service_name}-systemd.init.erb"),

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -445,6 +445,36 @@ describe 'zabbix::agent' do
           it { is_expected.to contain_systemd__unit_file('zabbix-agent.service') }
         end
       end
+
+      context 'when binary_location is define', if: facts[:kernel] == 'Linux' do
+        it do
+          is_expected.to contain_zabbix__startup(service_name).with(
+            binary_location: '/usr/sbin/zabbix_agentd'
+          )
+        end
+      end
+
+      context 'when zabbix_package_agent is zabbix-agent2' do
+        let :params do
+          {
+            zabbix_package_agent: 'zabbix-agent2', startagents: 1,
+            maxlinespersecond: 1, allowroot: 1, zabbix_user: 'root',
+            loadmodulepath: '/tmp', allowkey: 'system.run[*]',
+            denykey: 'system.run[*]', enableremotecommands: 1,
+            logremotecommands: 1
+          }
+        end
+
+        it { is_expected.to contain_package('zabbix-agent2') }
+
+        it do
+          is_expected.not_to contain_file(config_path).with_content(
+            %r{^(LogRemoteCommands|StartAgents|MaxLinesPerSecond
+                 |AllowRoot|User|LoadModulePath|AllowKey|DenyKey|
+                 EnableRemoteCommands|LogRemoteCommands)}
+          )
+        end
+      end
     end
   end
 end

--- a/spec/classes/database_spec.rb
+++ b/spec/classes/database_spec.rb
@@ -11,9 +11,7 @@ describe 'zabbix::database' do
     next if facts[:os]['name'] == 'windows'
 
     context "on #{os}" do
-      let :facts do
-        facts
-      end
+      let(:facts) { facts }
 
       let :pre_condition do
         <<-EOS

--- a/spec/defines/startup_spec.rb
+++ b/spec/defines/startup_spec.rb
@@ -65,7 +65,8 @@ describe 'zabbix::startup', type: :define do # rubocop:disable RSpec/MultipleDes
               {
                 agent_configfile_path: '/something',
                 pidfile: '/somethingelse',
-                additional_service_params: '--foreground'
+                additional_service_params: '--foreground',
+                binary_location: '/usr/sbin/zabbix_agentd'
               }
             end
 

--- a/templates/zabbix-agent-systemd.init.erb
+++ b/templates/zabbix-agent-systemd.init.erb
@@ -8,7 +8,7 @@ After=network.target
 Restart=on-failure
 <% if @pidfile %>PIDFile=<%= @pidfile %><% end %>
 KillMode=control-group
-ExecStart=/usr/sbin/zabbix_agentd <%= @additional_service_params %> -c <%= @agent_configfile_path %>
+ExecStart=<%= @binary_location %> <%= @additional_service_params %> -c <%= @agent_configfile_path %>
 <% if @zabbix_user %>User=<%= @zabbix_user %><% end %>
 RestartSec=10s
 

--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -48,6 +48,8 @@ DebugLevel=<%= @debuglevel %>
 #
 <% if @sourceip %>SourceIP=<%= @sourceip %><% end %>
 
+<% unless @agent2 %>
+<%  if @zabbix_version.to_f >= 5.0 %>
 ### Option: AllowKey
 #       Allow execution of item keys matching pattern.
 #       Multiple keys matching rules may be defined in combination with DenyKey.
@@ -57,7 +59,7 @@ DebugLevel=<%= @debuglevel %>
 #       If no AllowKey or DenyKey rules defined, all keys are allowed.
 #
 # Mandatory: no
-<% if @allowkey %>AllowKey=<%= @allowkey -%><% end %>
+<%    if @allowkey %>AllowKey=<%= @allowkey -%><% end %>
 
 ### Option: DenyKey
 #       Deny execution of items keys matching pattern.
@@ -70,7 +72,15 @@ DebugLevel=<%= @debuglevel %>
 #
 # Mandatory: no
 # Default:
-<% if @denykey %>DenyKey=<%= @denykey -%><% end %>
+<%    if @denykey %>DenyKey=<%= @denykey -%><% end %>
+<%  end %>
+
+### Option: EnableRemoteCommands
+#	Whether remote commands from Zabbix server are allowed.
+#	0 - not allowed
+#	1 - allowed
+#
+EnableRemoteCommands=<%= @enableremotecommands %>
 
 ### Option: LogRemoteCommands
 #	Enable logging of executed shell commands as warnings.
@@ -78,6 +88,7 @@ DebugLevel=<%= @debuglevel %>
 #	1 - enabled
 #
 LogRemoteCommands=<%= @logremotecommands %>
+<% end %>
 
 
 ##### Passive checks related
@@ -100,11 +111,13 @@ ListenPort=<%= @listenport %>
 #
 <% if @listen_ip %>ListenIP=<%= @listen_ip %><% end %>
 
+<% unless @agent2 %>
 ### Option: StartAgents
 #	Number of pre-forked instances of zabbix_agentd that process passive checks.
 #	If set to 0, disables passive checks and the agent will not listen on any TCP port.
 #
 StartAgents=<%= @startagents %>
+<% end %>
 
 ##### Active checks related
 
@@ -181,6 +194,7 @@ BufferSend=<%= @buffersend %>
 #
 BufferSize=<%= @buffersize %>
 
+<% unless @agent2 %>
 ### Option: MaxLinesPerSecond
 #	Maximum number of new lines the agent will send per second to Zabbix Server
 #	or Proxy processing 'log' and 'logrt' active checks.
@@ -188,6 +202,7 @@ BufferSize=<%= @buffersize %>
 #	provided in 'log' or 'logrt' item keys.
 #
 MaxLinesPerSecond=<%= @maxlinespersecond %>
+<% end %>
 
 ############ ADVANCED PARAMETERS #################
 
@@ -211,7 +226,7 @@ MaxLinesPerSecond=<%= @maxlinespersecond %>
 #
 Timeout=<%= @timeout %>
 
-<% if @kernel != 'windows' %>
+<% if @kernel != 'windows' and !@agent2 %>
 ### Option: AllowRoot
 #	Allow the agent to run as 'root'. If disabled and the agent is started by 'root', the agent
 #	will try to switch to the user specified by the User configuration option instead.
@@ -220,9 +235,7 @@ Timeout=<%= @timeout %>
 #	1 - allow
 #
 AllowRoot=<%= @allowroot %>
-<% end %>
 
-<% if @kernel != 'windows' %>
 ### Option: User
 #	Drop privileges to a specific, existing user on the system.
 #	Only has effect if run as 'root' and AllowRoot is disabled.
@@ -257,7 +270,7 @@ UnsafeUserParameters=<%= @unsafeuserparameters %>
 # 	Disabled. A configuration file should be placed on directory: <%= @include %>
 
 ####### LOADABLE MODULES #######
-<% if @kernel != 'windows' %>
+<% if @kernel != 'windows' and !@agent2 %>
 ### Option: LoadModulePath
 #	Full path to location of agent modules.
 #	Default depends on compilation options.


### PR DESCRIPTION
In this PR I try to continue the work of fe80 (and others) in [PR824](https://github.com/voxpupuli/puppet-zabbix/pull/824).

#### Pull Request (PR) description
This Pr bootstrap a support for zabbix-agent2

* Add param binary_location for specify zabbix agent binary (only for systemd)
* Remove some parameters in zabbix agent configuration if it's zabbix agent2 package
  * LogRemoteCommands
  * StartAgents
  * MaxLinesPerSecond
  * AllowRoot
  * User
  * LoadModulePath

It's possible to use agent2 with this configration:
```
      'agent_configfile_path' => '/etc/zabbix/zabbix_agent2.conf',
      'include_dir'           => '/etc/zabbix/zabbix_agent2.d',
      'pidfile'               => '/var/run/zabbix/zabbix_agentd2.pid',
      'servicename'           => 'zabbix-agent2',
      'zabbix_package_agent'  => 'zabbix-agent2',
      'binary_location'       => '/usr/sbin/zabbix_agent2',
```

I actually not test with windows kernel.

#### This Pull Request (PR) fixes the following issues
Fixes #692