### PR TITLE
Add Debian 12 OS support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -131,7 +131,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11"
+        "11",
+				"12"
       ]
     },
     {

--- a/spec/acceptance/agent_spec.rb
+++ b/spec/acceptance/agent_spec.rb
@@ -3,6 +3,9 @@
 require 'spec_helper_acceptance'
 
 supported_versions.each do |version|
+  # < 6.0 agent packages are not available for Debian 12
+  next if version < '6.0' && default[:platform] =~ %r{debian-12}
+
   describe "zabbix::agent class with zabbix_version #{version}" do
     it 'works idempotently with no errors' do
       pp = <<-EOS

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -45,6 +45,8 @@ describe 'zabbix::server class', unless: default[:platform] =~ %r{archlinux} do
     next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
     # <6.0 server packages are not available for ubuntu 22.04
     next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
+    # < 6.0 server packages are not available for Debian 12
+    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     context "deploys a zabbix #{zabbix_version} server" do
       # Using puppet_apply as a helper

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -11,6 +11,8 @@ describe 'zabbix_application type', unless: default[:platform] =~ %r{archlinux} 
     next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
     # <6.0 server packages are not available for ubuntu 22.04
     next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
+    # < 6.0 server packages are not available for Debian 12
+    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     template = case zabbix_version
                when '5.0'

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -12,6 +12,8 @@ describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
     next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
     # <6.0 server packages are not available for ubuntu 22.04
     next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
+    # < 6.0 server packages are not available for Debian 12
+    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     context "create zabbix_host resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -11,6 +11,8 @@ describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{archlinux} do
     next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
     # <6.0 server packages are not available for ubuntu 22.04
     next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
+    # < 6.0 server packages are not available for Debian 12
+    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     context "create zabbix_hostgroup resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -12,6 +12,8 @@ describe 'zabbix_proxy type', unless: default[:platform] =~ %r{archlinux} do
     next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
     # <6.0 server packages are not available for ubuntu 22.04
     next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
+    # < 6.0 server packages are not available for Debian 12
+    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     context "create zabbix_proxy resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -13,6 +13,8 @@ describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux
     next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
     # <6.0 server packages are not available for ubuntu 22.04
     next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
+    # < 6.0 server packages are not available for Debian 12
+    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     context "create zabbix_template_host resources with zabbix version #{zabbix_version}" do
       template = case zabbix_version

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -11,6 +11,8 @@ describe 'zabbix_template type', unless: default[:platform] =~ %r{archlinux} do
     next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
     # <6.0 server packages are not available for ubuntu 22.04
     next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
+    # < 6.0 server packages are not available for Debian 12
+    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     context "create zabbix_template resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -2,9 +2,11 @@ case $facts['os']['name'] {
   'Debian': {
     # On Debian it seems that make is searching for mkdir in /usr/bin/ but mkdir
     # does not exist. Symlink it from /bin/mkdir to make it work.
-    file { '/usr/bin/mkdir':
-      ensure => link,
-      target => '/bin/mkdir',
+    if $facts['os']['release']['major'] < '12' {
+      file { '/usr/bin/mkdir':
+        ensure => link,
+        target => '/bin/mkdir',
+      }
     }
   }
   'Ubuntu': {

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -9,7 +9,7 @@ def baseline_os_hash
       },
       {
         'operatingsystem' => 'Debian',
-        'operatingsystemrelease' => %w[11]
+        'operatingsystemrelease' => %w[11 12]
       },
       {
         'operatingsystem' => 'Ubuntu',


### PR DESCRIPTION
#### Pull Request (PR) description
add Debian 12 to metadata.json
skip acceptance on version 5.0 because not supported

#### This Pull Request (PR) fixes the following issues
Initial work to add Debian 12 support
