### PR TITLE
Centralize the logic which server/agent versions are supported

### DIFF
--- a/spec/acceptance/agent_spec.rb
+++ b/spec/acceptance/agent_spec.rb
@@ -2,10 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-supported_versions.each do |version|
-  # < 6.0 agent packages are not available for Debian 12
-  next if version < '6.0' && default[:platform] =~ %r{debian-12}
-
+supported_agent_versions(default[:platform]).each do |version|
   describe "zabbix::agent class with zabbix_version #{version}" do
     context 'With minimal parameter' do
       it 'works idempotently with no errors' do

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -38,16 +38,7 @@ describe 'zabbix::server class', unless: default[:platform] =~ %r{archlinux} do
     end
   end
 
-  supported_versions.each do |zabbix_version|
-    # >= 5.2 server packages are not available for RHEL 7
-    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
-    # < 6.0 server packages are not available for RHEL 9
-    next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
-    # <6.0 server packages are not available for ubuntu 22.04
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
-    # < 6.0 server packages are not available for Debian 12
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
-
+  supported_server_versions(default[:platform]).each do |zabbix_version|
     context "deploys a zabbix #{zabbix_version} server" do
       # Using puppet_apply as a helper
       it 'works idempotently with no errors' do

--- a/spec/acceptance/zabbix_application_spec.rb
+++ b/spec/acceptance/zabbix_application_spec.rb
@@ -3,16 +3,10 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_application type', unless: default[:platform] =~ %r{archlinux} do
-  supported_versions.each do |zabbix_version|
+describe 'zabbix_application type' do
+  supported_server_versions(default[:platform]).each do |zabbix_version|
     # Application API was removed in Zabbix 5.4
     next if zabbix_version >= '5.4'
-    # < 6.0 server packages are not available for RHEL 9
-    next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
-    # <6.0 server packages are not available for ubuntu 22.04
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
-    # < 6.0 server packages are not available for Debian 12
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     template = case zabbix_version
                when '5.0'

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -4,17 +4,8 @@ require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
 # rubocop:disable RSpec/LetBeforeExamples
-describe 'zabbix_host type', unless: default[:platform] =~ %r{archlinux} do
-  supported_versions.each do |zabbix_version|
-    # >= 5.2 server packages are not available for RHEL 7
-    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
-    # < 6.0 server packages are not available for RHEL 9
-    next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
-    # <6.0 server packages are not available for ubuntu 22.04
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
-    # < 6.0 server packages are not available for Debian 12
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
-
+describe 'zabbix_host type' do
+  supported_server_versions(default[:platform]).each do |zabbix_version|
     context "create zabbix_host resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -3,17 +3,8 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_hostgroup type', unless: default[:platform] =~ %r{archlinux} do
-  supported_versions.each do |zabbix_version|
-    # >= 5.2 server packages are not available for RHEL 7
-    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
-    # < 6.0 server packages are not available for RHEL 9
-    next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
-    # <6.0 server packages are not available for ubuntu 22.04
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
-    # < 6.0 server packages are not available for Debian 12
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
-
+describe 'zabbix_hostgroup type' do
+  supported_server_versions(default[:platform]).each do |zabbix_version|
     context "create zabbix_hostgroup resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -4,17 +4,8 @@ require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
 # rubocop:disable RSpec/LetBeforeExamples
-describe 'zabbix_proxy type', unless: default[:platform] =~ %r{archlinux} do
-  supported_versions.each do |zabbix_version|
-    # >= 5.2 server packages are not available for RHEL 7
-    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
-    # < 6.0 server packages are not available for RHEL 9
-    next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
-    # <6.0 server packages are not available for ubuntu 22.04
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
-    # < 6.0 server packages are not available for Debian 12
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
-
+describe 'zabbix_proxy type' do
+  supported_server_versions(default[:platform]).each do |zabbix_version|
     context "create zabbix_proxy resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -3,18 +3,10 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_template_host type', unless: default[:platform] =~ %r{archlinux} do
-  supported_versions.each do |zabbix_version|
+describe 'zabbix_template_host type' do
+  supported_server_versions(default[:platform]).each do |zabbix_version|
     # Zabbix 6.0 removed the ability to attach templates directly to hosts.
     next if zabbix_version == '6.0'
-    # >= 5.2 server packages are not available for RHEL 7
-    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
-    # < 6.0 server packages are not available for RHEL 9
-    next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
-    # <6.0 server packages are not available for ubuntu 22.04
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
-    # < 6.0 server packages are not available for Debian 12
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
 
     context "create zabbix_template_host resources with zabbix version #{zabbix_version}" do
       template = case zabbix_version

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -3,17 +3,8 @@
 require 'spec_helper_acceptance'
 require 'serverspec_type_zabbixapi'
 
-describe 'zabbix_template type', unless: default[:platform] =~ %r{archlinux} do
-  supported_versions.each do |zabbix_version|
-    # >= 5.2 server packages are not available for RHEL 7
-    next if zabbix_version >= '5.2' && default[:platform] == 'el-7-x86_64'
-    # < 6.0 server packages are not available for RHEL 9
-    next if zabbix_version < '6.0' && default[:platform] == 'el-9-x86_64'
-    # <6.0 server packages are not available for ubuntu 22.04
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{ubuntu-22}
-    # < 6.0 server packages are not available for Debian 12
-    next if zabbix_version < '6.0' && default[:platform] =~ %r{debian-12}
-
+describe 'zabbix_template type' do
+  supported_server_versions(default[:platform]).each do |zabbix_version|
     context "create zabbix_template resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/support/acceptance/supported_versions.rb
+++ b/spec/support/acceptance/supported_versions.rb
@@ -9,3 +9,17 @@ def supported_versions
   end
   supported_versions
 end
+
+def supported_agent_versions(platform)
+  supported_versions.reject do |version|
+    version < '6.0' && platform.start_with?('debian-12')
+  end
+end
+
+def supported_server_versions(platform)
+  supported_versions.reject do |version|
+    platform.start_with?('archlinux') ||
+      (version >= '5.2' && platform.start_with?('el-7')) ||
+      (version < '6.0' && platform.start_with?('el-9', 'ubuntu-22', 'debian-12'))
+  end
+end


### PR DESCRIPTION
Rather than duplicating the logic in every file, this introduces helpers.