### PR TITLE
Allow allowkey and denykey on agent2

### DIFF
--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -462,7 +462,7 @@ describe 'zabbix::agent' do
         it do
           is_expected.not_to contain_file(config_path).with_content(
             %r{^(LogRemoteCommands|StartAgents|MaxLinesPerSecond
-                 |AllowRoot|User|LoadModulePath|AllowKey|DenyKey|
+                 |AllowRoot|User|LoadModulePath|
                  EnableRemoteCommands|LogRemoteCommands)}
           )
         end

--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -48,7 +48,6 @@ DebugLevel=<%= @debuglevel %>
 #
 <% if @sourceip %>SourceIP=<%= @sourceip %><% end %>
 
-<% unless @agent2 %>
 <%  if @zabbix_version.to_f >= 5.0 %>
 ### Option: AllowKey
 #       Allow execution of item keys matching pattern.
@@ -74,6 +73,7 @@ DebugLevel=<%= @debuglevel %>
 # Default:
 <%    if @denykey %>DenyKey=<%= @denykey -%><% end %>
 <%  end %>
+<% unless @agent2 %>
 
 ### Option: EnableRemoteCommands
 #	Whether remote commands from Zabbix server are allowed.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Enable allowkey and denykey options for agent2 as they are still valid options

#### This Pull Request (PR) fixes the following issues
n/a
