### PR TITLE
Support multiple values in TLSAccept

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1860,7 +1860,7 @@ Default value: `$zabbix::params::agent_timeout`
 
 ##### <a name="-zabbix--agent--tlsaccept"></a>`tlsaccept`
 
-Data type: `Optional[Enum['unencrypted','psk','cert']]`
+Data type: `Optional[Variant[Array[Enum['unencrypted','psk','cert']],Enum['unencrypted','psk','cert']]]`
 
 What incoming connections to accept from Zabbix server. Used for a passive proxy, ignored on an active proxy.
 
@@ -3279,7 +3279,7 @@ Default value: `$zabbix::params::proxy_timeout`
 
 ##### <a name="-zabbix--proxy--tlsaccept"></a>`tlsaccept`
 
-Data type: `Any`
+Data type: `Optional[Variant[Array[Enum['unencrypted','psk','cert']],Enum['unencrypted','psk','cert']]]`
 
 What incoming connections to accept from Zabbix server. Used for a passive proxy, ignored on an active proxy.
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -203,7 +203,7 @@ class zabbix::agent (
   $userparameter                                       = $zabbix::params::agent_userparameter,
   Optional[String[1]] $loadmodulepath                  = $zabbix::params::agent_loadmodulepath,
   $loadmodule                                          = $zabbix::params::agent_loadmodule,
-  Optional[Enum['unencrypted','psk','cert']] $tlsaccept = $zabbix::params::agent_tlsaccept,
+  Optional[Variant[Array[Enum['unencrypted','psk','cert']],Enum['unencrypted','psk','cert']]] $tlsaccept = $zabbix::params::agent_tlsaccept,
   $tlscafile                                           = $zabbix::params::agent_tlscafile,
   $tlscertfile                                         = $zabbix::params::agent_tlscertfile,
   Optional[String[1]] $tlscertissuer                   = undef,

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -269,7 +269,7 @@ class zabbix::proxy (
   $historyindexcachesize                                                      = $zabbix::params::proxy_historyindexcachesize,
   $historytextcachesize                                                       = $zabbix::params::proxy_historytextcachesize,
   $timeout                                                                    = $zabbix::params::proxy_timeout,
-  $tlsaccept                                                                  = $zabbix::params::proxy_tlsaccept,
+  Optional[Variant[Array[Enum['unencrypted','psk','cert']],Enum['unencrypted','psk','cert']]] $tlsaccept = $zabbix::params::proxy_tlsaccept,
   $tlscafile                                                                  = $zabbix::params::proxy_tlscafile,
   $tlscertfile                                                                = $zabbix::params::proxy_tlscertfile,
   $tlsconnect                                                                 = $zabbix::params::proxy_tlsconnect,

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -352,6 +352,30 @@ describe 'zabbix::agent' do
         end
       end
 
+      context 'tlsaccept with one value array' do
+        if facts[:kernel] == 'Linux'
+          let :params do
+            {
+              tlsaccept: %w[cert]
+            }
+          end
+
+          it { is_expected.to contain_file(config_path).with_content %r{^TLSAccept=cert$} }
+        end
+      end
+
+      context 'tlsaccept with two value array' do
+        if facts[:kernel] == 'Linux'
+          let :params do
+            {
+              tlsaccept: %w[unencrypted cert]
+            }
+          end
+
+          it { is_expected.to contain_file(config_path).with_content %r{^TLSAccept=unencrypted,cert$} }
+        end
+      end
+
       context 'without ListenIP' do
         let :params do
           {

--- a/spec/classes/proxy_spec.rb
+++ b/spec/classes/proxy_spec.rb
@@ -415,6 +415,37 @@ describe 'zabbix::proxy' do
             it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^LogFileSize=10$} }
           end
         end
+
+        context 'tlsaccept with one string value' do
+          let :params do
+            {
+              tlsaccept: 'cert'
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TLSAccept=cert$} }
+        end
+
+        context 'tlsaccept with one value array' do
+          let :params do
+            {
+              tlsaccept: %w[cert]
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TLSAccept=cert$} }
+        end
+
+        context 'tlsaccept with two value array' do
+          let :params do
+            {
+              tlsaccept: %w[unencrypted cert]
+            }
+          end
+
+          it { is_expected.to contain_file('/etc/zabbix/zabbix_proxy.conf').with_content %r{^TLSAccept=unencrypted,cert$} }
+        end
+
       end
     end
   end

--- a/templates/zabbix_agentd.conf.erb
+++ b/templates/zabbix_agentd.conf.erb
@@ -310,7 +310,7 @@ LoadModulePath=<%= @loadmodulepath %>
 # Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
 # Default:
 # TLSAccept=unencrypted
-<% if @tlsaccept %>TLSAccept=<%= @tlsaccept %><% end %>
+<% if @tlsaccept %>TLSAccept=<%= [@tlsaccept].flatten.join(',') %><% end %>
 
 ### Option: TLSCAFile
 #	Full pathname of a file containing the top-level CA(s) certificates for

--- a/templates/zabbix_proxy.conf.erb
+++ b/templates/zabbix_proxy.conf.erb
@@ -511,7 +511,7 @@ LoadModulePath=<%= @loadmodulepath %>
 # Mandatory: yes, if TLS certificate or PSK parameters are defined (even for 'unencrypted' connection)
 # Default:
 # TLSAccept=unencrypted
-<% if @tlsaccept %>TLSAccept=<%= @tlsaccept %><% end %>
+<% if @tlsaccept %>TLSAccept=<%= [@tlsaccept].flatten.join(',') %><% end %>
 
 ### Option: TLSCAFile
 #	Full pathname of a file containing the top-level CA(s) certificates for


### PR DESCRIPTION

#### Pull Request (PR) description
Option TLSAccept in zabbix_agentd.conf accepts list of values separated with comma. But the module define tlsaccept as Enum of those three values. The string as comma separated list of values is not allowed anymore. Therefore the tlsaccept should be array of that enum and in the template the array should be joined with comma.

BTW: the same option TLSAccept is in zabbix_proxy.conf, but in the module the tlsaccept in proxy.pp is still simple string value.

Thank you.