### PR TITLE
Add zabbix 7.0 support in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
-      beaker_facter: 'zabbix_version:Zabbix:5.0,6.0'
+      beaker_facter: 'zabbix_version:Zabbix:5.0,6.0,7.0'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -31,7 +31,10 @@ class zabbix::repo (
     }
     case $facts['os']['family'] {
       'RedHat': {
-        if versioncmp(fact('os.release.major'), '9') >= 0 {
+        if (versioncmp(fact('os.release.major'), '7') >= 0 and $zabbix_version == '7.0') {
+          $gpgkey_zabbix = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-B5333005'
+          $gpgkey_nonsupported = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-B5333005'
+        } elsif versioncmp(fact('os.release.major'), '9') >= 0 {
           $gpgkey_zabbix = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD'
           $gpgkey_nonsupported = 'https://repo.zabbix.com/RPM-GPG-KEY-ZABBIX-08EFA7DD'
         } else {
@@ -139,6 +142,10 @@ class zabbix::repo (
           id     => 'A1848F5352D022B9471D83D0082AB56BA14FE591',
           source => 'https://repo.zabbix.com/zabbix-official-repo.key',
         }
+        apt::key { 'zabbix-4C3D6F2':
+          id     => '4C3D6F2CC75F5146754FC374D913219AB5333005',
+          source => 'https://repo.zabbix.com/zabbix-official-repo.key',
+        }
 
         # Debian 11 provides Zabbix 5.0 by default. This can cause problems for 4.0 versions
         $pinpriority = $facts['os']['release']['major'] ? {
@@ -153,6 +160,7 @@ class zabbix::repo (
           require  => [
             Apt_key['zabbix-FBABD5F'],
             Apt_key['zabbix-A1848F5'],
+            Apt_key['zabbix-4C3D6F2'],
           ],
         }
 

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -6,6 +6,9 @@ require 'serverspec_type_zabbixapi'
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_host type' do
   supported_server_versions(default[:platform]).each do |zabbix_version|
+    # Zabbix 7.0 removed the deprecated params 'user' in favor to 'username'
+    next if zabbix_version >= '7.0'
+
     context "create zabbix_host resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_hostgroup_spec.rb
+++ b/spec/acceptance/zabbix_hostgroup_spec.rb
@@ -5,6 +5,9 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_hostgroup type' do
   supported_server_versions(default[:platform]).each do |zabbix_version|
+    # Zabbix 7.0 removed the deprecated params 'user' in favor to 'username'
+    next if zabbix_version >= '7.0'
+
     context "create zabbix_hostgroup resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_proxy_spec.rb
+++ b/spec/acceptance/zabbix_proxy_spec.rb
@@ -6,6 +6,9 @@ require 'serverspec_type_zabbixapi'
 # rubocop:disable RSpec/LetBeforeExamples
 describe 'zabbix_proxy type' do
   supported_server_versions(default[:platform]).each do |zabbix_version|
+    # Zabbix 7.0 removed the deprecated params 'user' in favor to 'username'
+    next if zabbix_version >= '7.0'
+
     context "create zabbix_proxy resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/acceptance/zabbix_template_host_spec.rb
+++ b/spec/acceptance/zabbix_template_host_spec.rb
@@ -6,7 +6,7 @@ require 'serverspec_type_zabbixapi'
 describe 'zabbix_template_host type' do
   supported_server_versions(default[:platform]).each do |zabbix_version|
     # Zabbix 6.0 removed the ability to attach templates directly to hosts.
-    next if zabbix_version == '6.0'
+    next if zabbix_version >= '6.0'
 
     context "create zabbix_template_host resources with zabbix version #{zabbix_version}" do
       template = case zabbix_version

--- a/spec/acceptance/zabbix_template_spec.rb
+++ b/spec/acceptance/zabbix_template_spec.rb
@@ -5,6 +5,9 @@ require 'serverspec_type_zabbixapi'
 
 describe 'zabbix_template type' do
   supported_server_versions(default[:platform]).each do |zabbix_version|
+    # Zabbix 7.0 removed the deprecated params 'user' in favor to 'username'
+    next if zabbix_version >= '7.0'
+
     context "create zabbix_template resources with zabbix version #{zabbix_version}" do
       # This will deploy a running Zabbix setup (server, web, db) which we can
       # use for custom type tests

--- a/spec/classes/database_mysql_spec.rb
+++ b/spec/classes/database_mysql_spec.rb
@@ -29,8 +29,7 @@ describe 'zabbix::database::mysql' do
                  '/usr/share/doc/zabbix-*-mysql*'
                end
 
-        sql_server = case zabbix_version
-                     when '6.0'
+        sql_server = if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') >= 0
                        'server.sql'
                      else
                        'create.sql'

--- a/spec/classes/database_postgresql_spec.rb
+++ b/spec/classes/database_postgresql_spec.rb
@@ -42,8 +42,7 @@ describe 'zabbix::database::postgresql' do
                  '/usr/share/doc/zabbix-*-pgsql'
                end
 
-        sql_server = case zabbix_version
-                     when '6.0'
+        sql_server = if Puppet::Util::Package.versioncmp(zabbix_version, '6.0') >= 0
                        'server.sql'
                      else
                        'create.sql'

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -8,6 +8,9 @@ case $facts['os']['name'] {
         target => '/bin/mkdir',
       }
     }
+    package { 'gnupg':
+      ensure => present,
+    }
   }
   'Ubuntu': {
     # The Ubuntu 18.04+ docker image has a dpkg config that won't install docs, to keep used space low

--- a/spec/support/acceptance/supported_versions.rb
+++ b/spec/support/acceptance/supported_versions.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 def supported_versions
-  supported_versions = %w[5.0 6.0]
+  supported_versions = %w[5.0 6.0 7.0]
   # this is a hack so that we don't have to rewrite the existing acceptance tests
   if (beaker_zabbix_version = ENV.fetch('BEAKER_FACTER_zabbix_version', nil))
     supported_versions &= [beaker_zabbix_version]
@@ -20,6 +20,7 @@ def supported_server_versions(platform)
   supported_versions.reject do |version|
     platform.start_with?('archlinux') ||
       (version >= '5.2' && platform.start_with?('el-7')) ||
-      (version < '6.0' && platform.start_with?('el-9', 'ubuntu-22', 'debian-12'))
+      (version < '6.0' && platform.start_with?('el-9', 'ubuntu-22', 'debian-12')) ||
+      (version >= '7.0' && platform.start_with?('ubuntu-20', 'debian-11'))
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description
Add zabbix 7.0 to CI

#### This Pull Request (PR) fixes the following issues
Zabbix has released stable lts 7.0 not tested in CI

zabbixapi gem not support zabbix 7 so it fail if you use the resource managed by it https://github.com/voxpupuli/puppet-zabbix/blob/051f24c0ec94ff1a45e75e3ad58c42eb30b41fa1/manifests/zabbixapi.pp#L15