### PR TITLE
Change `manage_startup_script` default to false

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class zabbix::params {
       $server_zabbix_user       = 'zabbix'
       $zabbix_package_provider  = undef
       $agent_loadmodulepath     = '/usr/lib/modules'
+      $manage_startup_script    = false
     }
     'AIX': {
       $manage_repo              = false
@@ -32,6 +33,7 @@ class zabbix::params {
       $agent_config_group       = 'zabbix'
       $agent_pidfile            = '/var/run/zabbix/zabbix_agentd.pid'
       $agent_servicename        = 'zabbix-agent'
+      $manage_startup_script    = true
     }
     'Archlinux': {
       $server_fpinglocation     = '/usr/bin/fping'
@@ -51,6 +53,7 @@ class zabbix::params {
       $server_zabbix_user       = 'zabbix-server'
       $zabbix_package_provider  = undef
       $agent_loadmodulepath     = '/usr/lib/modules'
+      $manage_startup_script    = false
     }
     'FreeBSD': {
       $manage_repo              = false
@@ -66,6 +69,7 @@ class zabbix::params {
       $server_zabbix_user       = 'zabbix'
       $zabbix_package_provider  = undef
       $agent_loadmodulepath     = '/usr/local/lib/zabbix/modules'
+      $manage_startup_script    = false
     }
     'Gentoo': {
       $server_fpinglocation     = '/usr/sbin/fping'
@@ -85,6 +89,7 @@ class zabbix::params {
       $server_zabbix_user       = 'zabbix'
       $zabbix_package_provider  = undef
       $agent_loadmodulepath     = '/usr/lib/modules'
+      $manage_startup_script    = false
     }
     'windows': {
       $manage_repo             = false
@@ -99,6 +104,7 @@ class zabbix::params {
       $agent_servicename       = 'Zabbix Agent'
       $agent_include           = 'C:/ProgramData/zabbix/zabbix_agentd.d'
       $agent_loadmodulepath    = undef
+      $manage_startup_script   = false
     }
     default  : {
       $server_fpinglocation     = '/usr/sbin/fping'
@@ -118,6 +124,7 @@ class zabbix::params {
       $server_zabbix_user       = 'zabbix'
       $zabbix_package_provider  = undef
       $agent_loadmodulepath     = '/usr/lib/modules'
+      $manage_startup_script    = false
     }
   }
 
@@ -127,12 +134,6 @@ class zabbix::params {
     $zabbix_version = '5.0'
   } else {
     $zabbix_version = '6.0'
-  }
-
-  $manage_startup_script = downcase($facts['kernel']) ? {
-    'windows' => false,
-    'FreeBSD' => false,
-    default   => true,
   }
 
   $zabbix_package_state                     = 'present'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -25,7 +25,7 @@ describe 'zabbix::server' do
         it { is_expected.to contain_class('zabbix::repo') }
         it { is_expected.to contain_class('zabbix::params') }
         it { is_expected.to contain_service('zabbix-server').with_ensure('running') }
-        it { is_expected.to contain_zabbix__startup('zabbix-server') }
+        it { is_expected.not_to contain_zabbix__startup('zabbix-server') }
 
         it { is_expected.to contain_apt__source('zabbix') }      if facts[:os]['family'] == 'Debian'
         it { is_expected.to contain_apt__key('zabbix-A1848F5') } if facts[:os]['family'] == 'Debian'
@@ -159,26 +159,26 @@ describe 'zabbix::server' do
         it { is_expected.not_to contain_firewall('151 zabbix-server') }
       end
 
-      context 'it creates a startup script' do
-        case facts[:os]['family']
-        when 'Archlinux', 'Debian', 'Gentoo', 'RedHat'
-          it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('absent') }
-          it { is_expected.to contain_file('/etc/systemd/system/zabbix-server.service').with_ensure('file') }
-          it { is_expected.to contain_systemd__unit_file('zabbix-server.service') }
-        else
-          it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('file') }
-          it { is_expected.not_to contain_file('/etc/systemd/system/zabbix-server.service') }
-        end
-      end
-
-      context 'when declaring manage_startup_script is false' do
+      context 'when declaring manage_startup_script is true' do
         let :params do
           {
-            manage_startup_script: false
+            manage_startup_script: true
           }
         end
 
-        it { is_expected.not_to contain_zabbix__startup('zabbix-server') }
+        context 'it creates a startup script' do
+          case facts[:os]['family']
+          when 'Archlinux', 'Debian', 'Gentoo', 'RedHat'
+            it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('absent') }
+            it { is_expected.to contain_file('/etc/systemd/system/zabbix-server.service').with_ensure('file') }
+            it { is_expected.to contain_systemd__unit_file('zabbix-server.service') }
+          else
+            it { is_expected.to contain_file('/etc/init.d/zabbix-server').with_ensure('file') }
+            it { is_expected.not_to contain_file('/etc/systemd/system/zabbix-server.service') }
+          end
+        end
+
+        it { is_expected.to contain_zabbix__startup('zabbix-server') }
       end
 
       # If manage_service is true (default), it should create a service

--- a/spec/defines/userparameters_spec.rb
+++ b/spec/defines/userparameters_spec.rb
@@ -22,12 +22,12 @@ describe 'zabbix::userparameters', type: :define do
         it { is_expected.to contain_class('zabbix::params') }
         it { is_expected.to contain_class('zabbix::repo') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_file("/etc/init.d/#{service}") }
+        it { is_expected.not_to contain_file("/etc/init.d/#{service}") }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.conf') }
         it { is_expected.to contain_file('/etc/zabbix/zabbix_agentd.d') }
         it { is_expected.to contain_package(package) }
         it { is_expected.to contain_service(service) }
-        it { is_expected.to contain_zabbix__startup(service) }
+        it { is_expected.not_to contain_zabbix__startup(service) }
       end
 
       context 'with ensure => absent' do


### PR DESCRIPTION
#### Pull Request (PR) description
Set manage_startup_script to false on OS passing acceptance test because zabbix provide correct systemd unit

#### This Pull Request (PR) fixes the following issues
Fixes #960 
