### PR TITLE
Run acceptance tests on Ubuntu 20.04 M runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,4 @@ jobs:
     with:
       beaker_facter: 'zabbix_version:Zabbix:5.0,6.0,7.0'
       unit_runs_on: 'cern-self-hosted'
+      acceptance_runs_on: 'ubuntu-2004-m'

--- a/.sync.yml
+++ b/.sync.yml
@@ -15,3 +15,4 @@ spec/spec_helper.rb:
   with:
     beaker_facter: 'zabbix_version:Zabbix:5.0,6.0'
     unit_runs_on: 'cern-self-hosted'
+    acceptance_runs_on: 'ubuntu-2004-m'


### PR DESCRIPTION
Those runners contain 4 cores / 16G ram. The default S runners only have 2 cores.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
