### PR TITLE
repo.pp: use apt::keyring on distros where using keys stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg) is deprecated

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -118,39 +118,53 @@ class zabbix::repo (
           default => $repo_location,
         }
 
-        $_gpgkey_zabbix = $repo_gpg_key_location ? {
-          undef   => 'https://repo.zabbix.com/zabbix-official-repo.key',
-          default => "${repo_gpg_key_location}/zabbix-official-repo.key",
-        }
-
-        apt::key { 'zabbix-FBABD5F':
-          id     => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
-          source => $_gpgkey_zabbix,
-        }
-        apt::key { 'zabbix-A1848F5':
-          id     => 'A1848F5352D022B9471D83D0082AB56BA14FE591',
-          source => $_gpgkey_zabbix,
-        }
-        apt::key { 'zabbix-4C3D6F2':
-          id     => '4C3D6F2CC75F5146754FC374D913219AB5333005',
-          source => $_gpgkey_zabbix,
-        }
-
         # Debian 11 provides Zabbix 5.0 by default. This can cause problems for 4.0 versions
         $pinpriority = $facts['os']['release']['major'] ? {
           '11'    => 1000,
           default => undef,
         }
-        apt::source { 'zabbix':
-          location => $_repo_location,
-          repos    => 'main',
-          release  => $releasename,
-          pin      => $pinpriority,
-          require  => [
-            Apt_key['zabbix-FBABD5F'],
-            Apt_key['zabbix-A1848F5'],
-            Apt_key['zabbix-4C3D6F2'],
-          ],
+
+        $_gpgkey_zabbix = $repo_gpg_key_location ? {
+          undef   => 'https://repo.zabbix.com/zabbix-official-repo.key',
+          default => "${repo_gpg_key_location}/zabbix-official-repo.key",
+        }
+
+        if (fact('os.name') == 'Ubuntu' and versioncmp(fact('os.release.major'), '22.04') >=0 or
+            fact('os.name') == 'Debian' and versioncmp(fact('os.release.major'), '12') >= 0) {
+          apt::source { 'zabbix':
+            location => $_repo_location,
+            repos    => 'main',
+            release  => $releasename,
+            pin      => $pinpriority,
+            key      => {
+              name   => 'zabbix-official-repo.asc',
+              source => $_gpgkey_zabbix,
+            },
+          }
+        } else {
+          apt::key { 'zabbix-FBABD5F':
+            id     => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
+            source => $_gpgkey_zabbix,
+          }
+          apt::key { 'zabbix-A1848F5':
+            id     => 'A1848F5352D022B9471D83D0082AB56BA14FE591',
+            source => $_gpgkey_zabbix,
+          }
+          apt::key { 'zabbix-4C3D6F2':
+            id     => '4C3D6F2CC75F5146754FC374D913219AB5333005',
+            source => $_gpgkey_zabbix,
+          }
+          apt::source { 'zabbix':
+            location => $_repo_location,
+            repos    => 'main',
+            release  => $releasename,
+            pin      => $pinpriority,
+            require  => [
+              Apt::Key['zabbix-FBABD5F'],
+              Apt::Key['zabbix-A1848F5'],
+              Apt::Key['zabbix-4C3D6F2'],
+            ]
+          }
         }
 
         Apt::Source['zabbix'] -> Package<|tag == 'zabbix'|>

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -129,8 +129,7 @@ class zabbix::repo (
           default => "${repo_gpg_key_location}/zabbix-official-repo.key",
         }
 
-        if (fact('os.name') == 'Ubuntu' and versioncmp(fact('os.release.major'), '22.04') >=0 or
-            fact('os.name') == 'Debian' and versioncmp(fact('os.release.major'), '12') >= 0) {
+        if (fact('os.name') == 'Ubuntu' and versioncmp(fact('os.release.major'), '22.04') >= 0 or fact('os.name') == 'Debian' and versioncmp(fact('os.release.major'), '12') >= 0) {
           apt::source { 'zabbix':
             location => $_repo_location,
             repos    => 'main',
@@ -163,7 +162,7 @@ class zabbix::repo (
               Apt::Key['zabbix-FBABD5F'],
               Apt::Key['zabbix-A1848F5'],
               Apt::Key['zabbix-4C3D6F2'],
-            ]
+            ],
           }
         }
 

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+include Puppet::Util
 
 describe 'zabbix::agent' do
   let :node do
@@ -62,8 +63,16 @@ describe 'zabbix::agent' do
 
       context 'with all defaults' do
         it { is_expected.to contain_selinux__module('zabbix-agent') }            if facts[:os]['family'] == 'RedHat'
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }                 if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                 if facts[:os]['family'] == 'Debian'
+        case facts[:os]['name']
+        when 'Debian'
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
+        when 'Ubuntu'
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
+        end
         it { is_expected.to contain_file(include_dir).with_ensure('directory') }
 
         # Make sure package will be installed, service running and ensure of directory.

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-Package = Puppet::Util::Package
 
 describe 'zabbix::agent' do
   let :node do
@@ -63,9 +62,9 @@ describe 'zabbix::agent' do
 
       context 'with all defaults' do
         it { is_expected.to contain_selinux__module('zabbix-agent') }          if facts[:os]['family'] == 'RedHat'
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
         it { is_expected.to contain_file(include_dir).with_ensure('directory') }
 
         # Make sure package will be installed, service running and ensure of directory.

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-include Puppet::Util
+Package = Puppet::Util::Package
 
 describe 'zabbix::agent' do
   let :node do
@@ -62,17 +62,10 @@ describe 'zabbix::agent' do
       # service = facts[:os]['family'] == 'Gentoo' ? 'zabbix-agentd' : 'zabbix-agent'
 
       context 'with all defaults' do
-        it { is_expected.to contain_selinux__module('zabbix-agent') }            if facts[:os]['family'] == 'RedHat'
-        case facts[:os]['name']
-        when 'Debian'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
-        when 'Ubuntu'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
-        end
+        it { is_expected.to contain_selinux__module('zabbix-agent') }          if facts[:os]['family'] == 'RedHat'
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
         it { is_expected.to contain_file(include_dir).with_ensure('directory') }
 
         # Make sure package will be installed, service running and ensure of directory.

--- a/spec/classes/javagateway_spec.rb
+++ b/spec/classes/javagateway_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+include Puppet::Util
 
 describe 'zabbix::javagateway' do
   let :node do
@@ -27,8 +28,16 @@ describe 'zabbix::javagateway' do
         it { is_expected.to contain_service('zabbix-java-gateway').with_enable('true') }
         it { is_expected.to contain_service('zabbix-java-gateway').with_require(['Package[zabbix-java-gateway]', 'File[/etc/zabbix/zabbix_java_gateway.conf]']) }
 
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }          if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }          if facts[:os]['family'] == 'Debian'
+        case facts[:os]['name']
+        when 'Debian'
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
+        when 'Ubuntu'
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
+        end
       end
 
       context 'when declaring manage_repo is true' do

--- a/spec/classes/javagateway_spec.rb
+++ b/spec/classes/javagateway_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-include Puppet::Util
+Package = Puppet::Util::Package
 
 describe 'zabbix::javagateway' do
   let :node do
@@ -28,16 +28,9 @@ describe 'zabbix::javagateway' do
         it { is_expected.to contain_service('zabbix-java-gateway').with_enable('true') }
         it { is_expected.to contain_service('zabbix-java-gateway').with_require(['Package[zabbix-java-gateway]', 'File[/etc/zabbix/zabbix_java_gateway.conf]']) }
 
-        case facts[:os]['name']
-        when 'Debian'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
-        when 'Ubuntu'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
-        end
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
       end
 
       context 'when declaring manage_repo is true' do

--- a/spec/classes/javagateway_spec.rb
+++ b/spec/classes/javagateway_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-Package = Puppet::Util::Package
 
 describe 'zabbix::javagateway' do
   let :node do
@@ -28,9 +27,9 @@ describe 'zabbix::javagateway' do
         it { is_expected.to contain_service('zabbix-java-gateway').with_enable('true') }
         it { is_expected.to contain_service('zabbix-java-gateway').with_require(['Package[zabbix-java-gateway]', 'File[/etc/zabbix/zabbix_java_gateway.conf]']) }
 
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
       end
 
       context 'when declaring manage_repo is true' do

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -2,7 +2,6 @@
 
 require 'deep_merge'
 require 'spec_helper'
-Package = Puppet::Util::Package
 
 describe 'zabbix::repo' do
   on_supported_os.each do |os, facts|
@@ -21,9 +20,9 @@ describe 'zabbix::repo' do
         it { is_expected.to contain_class('zabbix::params') }
         it { is_expected.to contain_class('zabbix::repo') }
 
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
 
         context 'when repo_location is "https://example.com/foo"' do
           let :params do

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -2,7 +2,7 @@
 
 require 'deep_merge'
 require 'spec_helper'
-include Puppet::Util
+Package = Puppet::Util::Package
 
 describe 'zabbix::repo' do
   on_supported_os.each do |os, facts|
@@ -20,16 +20,10 @@ describe 'zabbix::repo' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('zabbix::params') }
         it { is_expected.to contain_class('zabbix::repo') }
-        case facts[:os]['name']
-        when 'Debian'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
-        when 'Ubuntu'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
-        end
+
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
 
         context 'when repo_location is "https://example.com/foo"' do
           let :params do

--- a/spec/classes/sender_spec.rb
+++ b/spec/classes/sender_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-Package = Puppet::Util::Package
 
 describe 'zabbix::sender' do
   let :node do
@@ -48,9 +47,9 @@ describe 'zabbix::sender' do
         when 'Debian'
           it { is_expected.to contain_apt__source('zabbix') }
 
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
         end
       end
     end

--- a/spec/classes/sender_spec.rb
+++ b/spec/classes/sender_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+include Puppet::Util
 
 describe 'zabbix::sender' do
   let :node do
@@ -46,8 +47,16 @@ describe 'zabbix::sender' do
           it { is_expected.to contain_yumrepo('zabbix') }
         when 'Debian'
           it { is_expected.to contain_apt__source('zabbix') }
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }
+          case facts[:os]['name']
+          when 'Debian'
+            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
+          when 'Ubuntu'
+            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
+          end
         end
       end
     end

--- a/spec/classes/sender_spec.rb
+++ b/spec/classes/sender_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-include Puppet::Util
+Package = Puppet::Util::Package
 
 describe 'zabbix::sender' do
   let :node do
@@ -47,16 +47,10 @@ describe 'zabbix::sender' do
           it { is_expected.to contain_yumrepo('zabbix') }
         when 'Debian'
           it { is_expected.to contain_apt__source('zabbix') }
-          case facts[:os]['name']
-          when 'Debian'
-            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
-          when 'Ubuntu'
-            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
-          end
+
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
         end
       end
     end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'deep_merge'
-Package = Puppet::Util::Package
 
 describe 'zabbix::server' do
   let :node do
@@ -25,9 +24,9 @@ describe 'zabbix::server' do
         it { is_expected.not_to contain_zabbix__startup('zabbix-server') }
 
         it { is_expected.to contain_apt__source('zabbix') } if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }                 if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                 if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') }   if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }                 if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                 if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') }   if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
       end
 
       if facts[:os]['family'] == 'RedHat'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'deep_merge'
-include Puppet::Util
+Package = Puppet::Util::Package
 
 describe 'zabbix::server' do
   let :node do
@@ -24,17 +24,10 @@ describe 'zabbix::server' do
         it { is_expected.to contain_service('zabbix-server').with_ensure('running') }
         it { is_expected.not_to contain_zabbix__startup('zabbix-server') }
 
-        it { is_expected.to contain_apt__source('zabbix') }      if facts[:os]['family'] == 'Debian'
-        case facts[:os]['name']
-        when 'Debian'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
-        when 'Ubuntu'
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
-        end
+        it { is_expected.to contain_apt__source('zabbix') } if facts[:os]['family'] == 'Debian'
+        it { is_expected.to contain_apt__key('zabbix-A1848F5') }                 if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                 if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+        it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') }   if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
       end
 
       if facts[:os]['family'] == 'RedHat'

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'deep_merge'
+include Puppet::Util
 
 describe 'zabbix::server' do
   let :node do
@@ -24,8 +25,16 @@ describe 'zabbix::server' do
         it { is_expected.not_to contain_zabbix__startup('zabbix-server') }
 
         it { is_expected.to contain_apt__source('zabbix') }      if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') } if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') } if facts[:os]['family'] == 'Debian'
+        case facts[:os]['name']
+        when 'Debian'
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
+        when 'Ubuntu'
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
+        end
       end
 
       if facts[:os]['family'] == 'RedHat'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'deep_merge'
-Package = Puppet::Util::Package
 
 describe 'zabbix::web' do
   let :node do
@@ -41,9 +40,9 @@ describe 'zabbix::web' do
           it { is_expected.to contain_class('Zabbix::Repo') }
           it { is_expected.to contain_file('/etc/zabbix/web').with_ensure('directory') }
 
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }                         if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                         if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
-          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') }           if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }                         if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                         if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') }           if (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
           it { is_expected.to contain_apt__source('zabbix') }                              if facts[:os]['family'] == 'Debian'
           it { is_expected.to contain_yumrepo('zabbix') }                                  if facts[:os]['family'] == 'RedHat'
           it { is_expected.to contain_yumrepo('zabbix-nonsupported') }                     if facts[:os]['family'] == 'RedHat'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'deep_merge'
+include Puppet::Util
 
 describe 'zabbix::web' do
   let :node do
@@ -40,8 +41,16 @@ describe 'zabbix::web' do
           it { is_expected.to contain_class('Zabbix::Repo') }
           it { is_expected.to contain_file('/etc/zabbix/web').with_ensure('directory') }
 
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }                         if facts[:os]['family'] == 'Debian'
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                         if facts[:os]['family'] == 'Debian'
+          case facts[:os]['name']
+          when 'Debian'
+            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
+            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
+          when 'Ubuntu'
+            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
+            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
+          end
           it { is_expected.to contain_apt__source('zabbix') }                              if facts[:os]['family'] == 'Debian'
           it { is_expected.to contain_yumrepo('zabbix') }                                  if facts[:os]['family'] == 'RedHat'
           it { is_expected.to contain_yumrepo('zabbix-nonsupported') }                     if facts[:os]['family'] == 'RedHat'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 require 'deep_merge'
-include Puppet::Util
+Package = Puppet::Util::Package
 
 describe 'zabbix::web' do
   let :node do
@@ -41,16 +41,9 @@ describe 'zabbix::web' do
           it { is_expected.to contain_class('Zabbix::Repo') }
           it { is_expected.to contain_file('/etc/zabbix/web').with_ensure('directory') }
 
-          case facts[:os]['name']
-          when 'Debian'
-            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '12') < 0
-            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '12') >= 0
-          when 'Ubuntu'
-            it { is_expected.to contain_apt__key('zabbix-A1848F5') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-            it { is_expected.to contain_apt__key('zabbix-FBABD5F') }               if Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0
-            it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') } if Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0
-          end
+          it { is_expected.to contain_apt__key('zabbix-A1848F5') }                         if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                         if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') < 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') < 0)
+          it { is_expected.to contain_apt__keyring('zabbix-official-repo.asc') }           if (facts[:os]['name'] == 'Debian' && Package.versioncmp(facts[:os]['release']['major'], '12') >= 0) || (facts[:os]['name'] == 'Ubuntu' && Package.versioncmp(facts[:os]['release']['major'], '22.04') >= 0)
           it { is_expected.to contain_apt__source('zabbix') }                              if facts[:os]['family'] == 'Debian'
           it { is_expected.to contain_yumrepo('zabbix') }                                  if facts[:os]['family'] == 'RedHat'
           it { is_expected.to contain_yumrepo('zabbix-nonsupported') }                     if facts[:os]['family'] == 'RedHat'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Newer apt based distros have deprecated apt keys stored in /etc/apt/trusted.gpg: installing zabbix agent with this module will result in the following warning:

```shell
root@ubuntu:~# apt update
Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease    
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease      
Hit:4 http://apt.puppet.com jammy InRelease                         
Hit:5 http://repo.zabbix.com/zabbix/6.0/ubuntu jammy InRelease
Hit:6 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
51 packages can be upgraded. Run 'apt list --upgradable' to see them.
W: http://repo.zabbix.com/zabbix/6.0/ubuntu/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
root@ubuntu:~# 
root@ubuntu:~# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 22.04 LTS
Release:	22.04
Codename:	jammy
root@ubuntu:~# 
```

AFAIK this started happening in Debian >= 12 and Ubuntu >= 22.04

Using `apt::keyring` instead of `apt::key` seems to silence the warning.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
