### PR TITLE
Add Authorization header if needed to Apache vhost

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -343,6 +343,14 @@ class zabbix::web (
       default => $zabbix_api_access.map |$host| { "host ${host}" },
     }
 
+    if versioncmp($zabbix_version, '6.4') >= 0 {
+      $setenvif_auth = [
+        'Authorization "(.*)" HTTP_AUTHORIZATION=$1'
+      ]
+    } else {
+      $setenvif_auth = undef
+    }
+
     apache::vhost { $zabbix_url:
       docroot         => '/usr/share/zabbix',
       ip              => $apache_listen_ip,
@@ -387,6 +395,7 @@ class zabbix::web (
         {
         rewrite_rule => ['^$ /index.php [L]'] }
       ],
+      setenvif        => $setenvif_auth,
       ssl             => $apache_use_ssl,
       ssl_cert        => $apache_ssl_cert,
       ssl_key         => $apache_ssl_key,

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -345,7 +345,7 @@ class zabbix::web (
 
     if versioncmp($zabbix_version, '6.4') >= 0 {
       $setenvif_auth = [
-        'Authorization "(.*)" HTTP_AUTHORIZATION=$1'
+        'Authorization "(.*)" HTTP_AUTHORIZATION=$1',
       ]
     } else {
       $setenvif_auth = undef


### PR DESCRIPTION
#### Pull Request (PR) description
On Zabbix version 6.4 and newer there has been a change in the way
authentication is done. Using a bearer token would lead to issues with
authenticating using the API as the header did not seem the get passed to
the application.

This seems to have been known since the release of 6.4 and a bug report
is still open. But the bug report also already contained a
workaround/fix (https://support.zabbix.com/browse/ZBX-22952).

#### This Pull Request (PR) fixes the following issues
n/a
