### PR TITLE
puppetlabs/mysql: allow 16.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/mysql",
-      "version_requirement": ">= 6.0.0 < 16.0.0"
+      "version_requirement": ">= 6.0.0 < 17.0.0"
     },
     {
       "name": "puppetlabs/apache",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Allow the mysql module v16. 

The [changelog](https://forge.puppet.com/modules/puppetlabs/mysql/changelog) don't show anything relevant.

#### This Pull Request (PR) fixes the following issues

None.
