### PR TITLE
fix java gateway on Zabbix 7

### DIFF
--- a/manifests/javagateway.pp
+++ b/manifests/javagateway.pp
@@ -27,7 +27,7 @@ class zabbix::javagateway (
   # Fix for pid file. Is different in Zabbix (4, 5) and 6
   $real_pidfile = $zabbix_version ? {
     /^[45]\.[024]/ => pick($pidfile, '/var/run/zabbix/zabbix_java.pid'),
-    /^[6]\.[024]/  => pick($pidfile, '/var/run/zabbix/zabbix_java_gateway.pid'),
+    /^[67]\.[024]/  => pick($pidfile, '/var/run/zabbix/zabbix_java_gateway.pid'),
   }
   # Only include the repo class if it has not yet been included
   unless defined(Class['Zabbix::Repo']) {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Slight oversight when adding support for Zabbix 7: java gateway was not updated accordingly, resulting in the following error:

```
Server Error: Evaluation Error: No matching entry for selector parameter with value '7.0'
(file: /etc/puppetlabs/code/environments/myenv/modules/zabbix/manifests/javagateway.pp, line: 28, column: 19)
```

This PR solves this issue.

#### This Pull Request (PR) fixes the following issues

