### PR TITLE
Use modern apt keyring instead of deprecated apt-key

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -197,7 +197,7 @@ class zabbix::database (
             require    => [
               Class['mysql::server'],
               Mysql::Db[$database_name],
-              Mysql_user["${database_user}@${zabbix_web}"]
+              Mysql_user["${database_user}@${zabbix_web}"],
             ],
           }
         } # END if $zabbix_web != $zabbix_server

--- a/manifests/javagateway.pp
+++ b/manifests/javagateway.pp
@@ -64,7 +64,7 @@ class zabbix::javagateway (
     hasrestart => true,
     require    => [
       Package['zabbix-java-gateway'],
-      File['/etc/zabbix/zabbix_java_gateway.conf']
+      File['/etc/zabbix/zabbix_java_gateway.conf'],
     ],
   }
 

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -436,13 +436,13 @@ class zabbix::proxy (
       enable     => true,
       subscribe  => [
         File[$proxy_configfile_path],
-        Class['zabbix::database']
+        Class['zabbix::database'],
       ],
       require    => [
         Package["zabbix-proxy-${db}"],
         File[$include_dir],
         File[$proxy_configfile_path],
-        Class['zabbix::database']
+        Class['zabbix::database'],
       ],
     }
   }
@@ -450,7 +450,7 @@ class zabbix::proxy (
   $before_database = $manage_service ? {
     true  => [
       Service[$proxy_service_name],
-      Class["zabbix::database::${database_type}"]
+      Class["zabbix::database::${database_type}"],
     ],
     false => Class["zabbix::database::${database_type}"],
   }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -123,19 +123,6 @@ class zabbix::repo (
           default => "${repo_gpg_key_location}/zabbix-official-repo.key",
         }
 
-        apt::key { 'zabbix-FBABD5F':
-          id     => 'FBABD5FB20255ECAB22EE194D13D58E479EA5ED4',
-          source => $_gpgkey_zabbix,
-        }
-        apt::key { 'zabbix-A1848F5':
-          id     => 'A1848F5352D022B9471D83D0082AB56BA14FE591',
-          source => $_gpgkey_zabbix,
-        }
-        apt::key { 'zabbix-4C3D6F2':
-          id     => '4C3D6F2CC75F5146754FC374D913219AB5333005',
-          source => $_gpgkey_zabbix,
-        }
-
         # Debian 11 provides Zabbix 5.0 by default. This can cause problems for 4.0 versions
         $pinpriority = $facts['os']['release']['major'] ? {
           '11'    => 1000,
@@ -146,11 +133,10 @@ class zabbix::repo (
           repos    => 'main',
           release  => $releasename,
           pin      => $pinpriority,
-          require  => [
-            Apt_key['zabbix-FBABD5F'],
-            Apt_key['zabbix-A1848F5'],
-            Apt_key['zabbix-4C3D6F2'],
-          ],
+          key      => {
+            name   => 'zabbix.asc',
+            source => $_gpgkey_zabbix,
+          },
         }
 
         Apt::Source['zabbix'] -> Package<|tag == 'zabbix'|>

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -330,7 +330,7 @@ class zabbix::web (
             comment      => 'redirect all to https',
             rewrite_cond => ['%{SERVER_PORT} !^443$'],
             rewrite_rule => ["^/(.*)$ https://${zabbix_url}/\$1 [L,R]"],
-          }
+          },
         ],
       }
     } else {
@@ -385,7 +385,7 @@ class zabbix::web (
       custom_fragment => $apache_vhost_custom_fragment,
       rewrites        => [
         {
-        rewrite_rule => ['^$ /index.php [L]'] }
+        rewrite_rule => ['^$ /index.php [L]'] },
       ],
       ssl             => $apache_use_ssl,
       ssl_cert        => $apache_ssl_cert,

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.1.0 < 11.0.0"
+      "version_requirement": ">= 2.1.0 < 12.0.0"
     },
     {
       "name": "puppet/systemd",

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -61,9 +61,7 @@ describe 'zabbix::agent' do
       # service = facts[:os]['family'] == 'Gentoo' ? 'zabbix-agentd' : 'zabbix-agent'
 
       context 'with all defaults' do
-        it { is_expected.to contain_selinux__module('zabbix-agent') }            if facts[:os]['family'] == 'RedHat'
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }                 if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                 if facts[:os]['family'] == 'Debian'
+        it { is_expected.to contain_selinux__module('zabbix-agent') } if facts[:os]['family'] == 'RedHat'
         it { is_expected.to contain_file(include_dir).with_ensure('directory') }
 
         # Make sure package will be installed, service running and ensure of directory.

--- a/spec/classes/javagateway_spec.rb
+++ b/spec/classes/javagateway_spec.rb
@@ -26,9 +26,6 @@ describe 'zabbix::javagateway' do
         it { is_expected.to contain_service('zabbix-java-gateway').with_ensure('running') }
         it { is_expected.to contain_service('zabbix-java-gateway').with_enable('true') }
         it { is_expected.to contain_service('zabbix-java-gateway').with_require(['Package[zabbix-java-gateway]', 'File[/etc/zabbix/zabbix_java_gateway.conf]']) }
-
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') }          if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') }          if facts[:os]['family'] == 'Debian'
       end
 
       context 'when declaring manage_repo is true' do

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -20,9 +20,6 @@ describe 'zabbix::repo' do
         it { is_expected.to contain_class('zabbix::params') }
         it { is_expected.to contain_class('zabbix::repo') }
 
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') } if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') } if facts[:os]['family'] == 'Debian'
-
         context 'when repo_location is "https://example.com/foo"' do
           let :params do
             {

--- a/spec/classes/sender_spec.rb
+++ b/spec/classes/sender_spec.rb
@@ -46,8 +46,6 @@ describe 'zabbix::sender' do
           it { is_expected.to contain_yumrepo('zabbix') }
         when 'Debian'
           it { is_expected.to contain_apt__source('zabbix') }
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }
         end
       end
     end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -23,9 +23,7 @@ describe 'zabbix::server' do
         it { is_expected.to contain_service('zabbix-server').with_ensure('running') }
         it { is_expected.not_to contain_zabbix__startup('zabbix-server') }
 
-        it { is_expected.to contain_apt__source('zabbix') }      if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-A1848F5') } if facts[:os]['family'] == 'Debian'
-        it { is_expected.to contain_apt__key('zabbix-FBABD5F') } if facts[:os]['family'] == 'Debian'
+        it { is_expected.to contain_apt__source('zabbix') } if facts[:os]['family'] == 'Debian'
       end
 
       if facts[:os]['family'] == 'RedHat'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -40,8 +40,6 @@ describe 'zabbix::web' do
           it { is_expected.to contain_class('Zabbix::Repo') }
           it { is_expected.to contain_file('/etc/zabbix/web').with_ensure('directory') }
 
-          it { is_expected.to contain_apt__key('zabbix-A1848F5') }                         if facts[:os]['family'] == 'Debian'
-          it { is_expected.to contain_apt__key('zabbix-FBABD5F') }                         if facts[:os]['family'] == 'Debian'
           it { is_expected.to contain_apt__source('zabbix') }                              if facts[:os]['family'] == 'Debian'
           it { is_expected.to contain_yumrepo('zabbix') }                                  if facts[:os]['family'] == 'RedHat'
           it { is_expected.to contain_yumrepo('zabbix-nonsupported') }                     if facts[:os]['family'] == 'RedHat'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Use modern apt keyring instead of the deprecated apt-key.
apt-key is not present on Debian 13 anymore, so using the module on recent versions of Debian fails with an error related to apt-key.

#### This Pull Request (PR) fixes the following issues
Fixes #1016
