### PR TITLE
feat: add Zabbix 7 API compatibility and proxy group support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1376,6 +1376,7 @@ The following parameters are available in the `zabbix::agent` class:
 * [`zabbix_package_source`](#-zabbix--agent--zabbix_package_source)
 * [`manage_resources`](#-zabbix--agent--manage_resources)
 * [`monitored_by_proxy`](#-zabbix--agent--monitored_by_proxy)
+* [`monitored_by_group`](#-zabbix--agent--monitored_by_group)
 * [`agent_use_ip`](#-zabbix--agent--agent_use_ip)
 * [`zbx_groups`](#-zabbix--agent--zbx_groups)
 * [`zbx_group_create`](#-zabbix--agent--zbx_group_create)
@@ -1534,6 +1535,14 @@ When this is monitored by an proxy, please fill in the name of this proxy.
 If the proxy is also installed via this module, please fill in the FQDN
 
 Default value: `$zabbix::params::monitored_by_proxy`
+
+##### <a name="-zabbix--agent--monitored_by_group"></a>`monitored_by_group`
+
+Data type: `Any`
+
+When this is monitored by a proxy group, please fill in the name of this proxy group.
+
+Default value: `$zabbix::params::monitored_by_group`
 
 ##### <a name="-zabbix--agent--agent_use_ip"></a>`agent_use_ip`
 
@@ -3677,6 +3686,7 @@ The following parameters are available in the `zabbix::resources::agent` class:
 * [`templates`](#-zabbix--resources--agent--templates)
 * [`macros`](#-zabbix--resources--agent--macros)
 * [`proxy`](#-zabbix--resources--agent--proxy)
+* [`proxygroup`](#-zabbix--resources--agent--proxygroup)
 * [`interfacetype`](#-zabbix--resources--agent--interfacetype)
 * [`interfacedetails`](#-zabbix--resources--agent--interfacedetails)
 * [`tls_connect`](#-zabbix--resources--agent--tls_connect)
@@ -3753,6 +3763,14 @@ Default value: `undef`
 Data type: `Any`
 
 Whether it is monitored by an proxy or not.
+
+Default value: `undef`
+
+##### <a name="-zabbix--resources--agent--proxygroup"></a>`proxygroup`
+
+Data type: `Any`
+
+Whether it is monitored by a proxy group or not.
 
 Default value: `undef`
 
@@ -6123,6 +6141,10 @@ The port that the zabbix agent is listening on.
 ##### `proxy`
 
 Whether it is monitored by an proxy or not.
+
+##### `proxygroup`
+
+Whether it is monitored by a proxy group or not.
 
 ##### `templates`
 

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -7,6 +7,8 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
 
   def self.instances
     proxies = zbx.proxies.all
+    proxygroups = zbx.proxygroup.all
+
     api_hosts = zbx.query(
       method: 'host.get',
       params: {
@@ -14,7 +16,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         selectInterfaces: %w[interfaceid type main ip port useip details],
         selectGroups: ['name'],
         selectMacros: %w[macro value],
-        output: %w[host proxy_hostid tls_accept tls_connect tls_issuer tls_subject]
+        output: %w[host proxyid proxy_groupid tls_accept tls_connect tls_issuer tls_subject]
       }
     )
 
@@ -23,8 +25,10 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       # there is only 1 interface that can be default
       interface = h['interfaces'].select { |i| i['main'].to_i == 1 }.first
       use_ip = !interface['useip'].to_i.zero?
-      proxy_select = proxies.select { |_name, id| id == h['proxy_hostid'] }.keys.first
+      proxy_select = proxies.select { |_name, id| id == h['proxyid'] }.keys.first
       proxy_select = '' if proxy_select.nil?
+      proxygroup_select = proxygroups.select { |_name, id| id == h['proxy_groupid'] }.keys.first
+      proxygroup_select = '' if proxygroup_select.nil?
       new(
         ensure: :present,
         id: h['hostid'].to_i,
@@ -38,6 +42,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         templates: h['parentTemplates'].map { |x| x['host'] },
         macros: h['macros'].map { |macro| { macro['macro'] => macro['value'] } },
         proxy: proxy_select,
+        proxygroup: proxygroup_select,
         interfacetype: interface['type'].to_i,
         interfacedetails: interface['details'],
         tls_accept: h['tls_accept'].to_i,
@@ -63,15 +68,18 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     gids = get_groupids(@resource[:groups], @resource[:group_create])
     groups = transform_to_array_hash('groupid', gids)
 
-    proxy_hostid = @resource[:proxy].nil? || @resource[:proxy].empty? ? nil : zbx.proxies.get_id(host: @resource[:proxy])
+    proxyid = @resource[:proxy].nil? || @resource[:proxy].empty? ? nil : zbx.proxies.get_id(name: @resource[:proxy])
+    proxy_groupid = @resource[:proxygroup].nil? || @resource[:proxygroup].empty? ? nil : zbx.proxygroup.get_id(name: @resource[:proxygroup])
+    monitored_by = proxy_groupid && proxyid.nil? ? 2 : 1
 
     tls_accept = @resource[:tls_accept].nil? ? 1 : @resource[:tls_accept]
     tls_connect = @resource[:tls_connect].nil? ? 1 : @resource[:tls_connect]
 
-    # Now we create the host
-    zbx.hosts.create(
+    host_params = {
       host: @resource[:hostname],
-      proxy_hostid: proxy_hostid,
+      proxyid: proxyid,
+      proxy_groupid: proxy_groupid,
+      monitored_by: monitored_by,
       interfaces: [
         {
           type: @resource[:interfacetype].nil? ? 1 : @resource[:interfacetype],
@@ -89,7 +97,13 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       tls_accept: tls_accept,
       tls_issuer: @resource[:tls_issuer].nil? ? '' : @resource[:tls_issuer],
       tls_subject: @resource[:tls_subject].nil? ? '' : @resource[:tls_subject]
-    )
+    }
+
+    host_params.delete(:proxyid) if host_params[:proxy_groupid] || host_params[:proxyid].nil?
+    host_params.delete(:proxy_groupid) if host_params[:proxy_groupid].nil?
+
+    # Now we create the host
+    zbx.hosts.create(host_params)
   end
 
   def exists?
@@ -233,7 +247,16 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
   def proxy=(string)
     zbx.hosts.create_or_update(
       host: @resource[:hostname],
-      proxy_hostid: zbx.proxies.get_id(host: string)
+      monitored_by: '1',
+      proxyid: zbx.proxies.get_id(name: string)
+    )
+  end
+
+  def proxygroup=(string)
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      monitored_by: '2',
+      proxy_groupid: zbx.proxygroup.get_id(name: string)
     )
   end
 

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -5,9 +5,20 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
   desc 'Puppet provider for managing Zabbix hosts. It uses the Zabbix API to create, read, update and delete hosts.'
   confine feature: :zabbixapi
 
+  def self.supports_proxy_groups?
+    Gem::Version.new(zbx.client.api_version) >= Gem::Version.new('7.0.0')
+  end
+
+  def supports_proxy_groups?
+    self.class.supports_proxy_groups?
+  end
+
   def self.instances
     proxies = zbx.proxies.all
-    proxygroups = zbx.proxygroup.all
+    proxygroups = supports_proxy_groups? ? zbx.proxygroup.all : {}
+
+    output_fields = %w[host proxyid tls_accept tls_connect tls_issuer tls_subject]
+    output_fields << 'proxy_groupid' if supports_proxy_groups?
 
     api_hosts = zbx.query(
       method: 'host.get',
@@ -16,7 +27,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
         selectInterfaces: %w[interfaceid type main ip port useip details],
         selectGroups: ['name'],
         selectMacros: %w[macro value],
-        output: %w[host proxyid proxy_groupid tls_accept tls_connect tls_issuer tls_subject]
+        output: output_fields
       }
     )
 
@@ -27,8 +38,13 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       use_ip = !interface['useip'].to_i.zero?
       proxy_select = proxies.select { |_name, id| id == h['proxyid'] }.keys.first
       proxy_select = '' if proxy_select.nil?
-      proxygroup_select = proxygroups.select { |_name, id| id == h['proxy_groupid'] }.keys.first
-      proxygroup_select = '' if proxygroup_select.nil?
+
+      proxygroup_select = ''
+      if supports_proxy_groups?
+        proxygroup_select = proxygroups.select { |_name, id| id == h['proxy_groupid'] }.keys.first
+        proxygroup_select = '' if proxygroup_select.nil?
+      end
+
       new(
         ensure: :present,
         id: h['hostid'].to_i,
@@ -69,7 +85,10 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
     groups = transform_to_array_hash('groupid', gids)
 
     proxyid = @resource[:proxy].nil? || @resource[:proxy].empty? ? nil : zbx.proxies.get_id(name: @resource[:proxy])
-    proxy_groupid = @resource[:proxygroup].nil? || @resource[:proxygroup].empty? ? nil : zbx.proxygroup.get_id(name: @resource[:proxygroup])
+    proxy_groupid = nil
+    if supports_proxy_groups?
+      proxy_groupid = @resource[:proxygroup].nil? || @resource[:proxygroup].empty? ? nil : zbx.proxygroup.get_id(name: @resource[:proxygroup])
+    end
     monitored_by = proxy_groupid && proxyid.nil? ? 2 : 1
 
     tls_accept = @resource[:tls_accept].nil? ? 1 : @resource[:tls_accept]
@@ -99,6 +118,10 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       tls_subject: @resource[:tls_subject].nil? ? '' : @resource[:tls_subject]
     }
 
+    unless supports_proxy_groups?
+      host_params.delete(:proxy_groupid)
+      host_params.delete(:monitored_by)
+    end
     host_params.delete(:proxyid) if host_params[:proxy_groupid] || host_params[:proxyid].nil?
     host_params.delete(:proxy_groupid) if host_params[:proxy_groupid].nil?
 
@@ -245,14 +268,17 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
   end
 
   def proxy=(string)
-    zbx.hosts.create_or_update(
+    params = {
       host: @resource[:hostname],
-      monitored_by: '1',
       proxyid: zbx.proxies.get_id(name: string)
-    )
+    }
+    params[:monitored_by] = '1' if supports_proxy_groups?
+    zbx.hosts.create_or_update(params)
   end
 
   def proxygroup=(string)
+    raise Puppet::Error, 'Proxy groups are only supported in Zabbix >= 7.0' unless supports_proxy_groups?
+
     zbx.hosts.create_or_update(
       host: @resource[:hostname],
       monitored_by: '2',

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -65,7 +65,7 @@ Puppet::Type.newtype(:zabbix_host) do
     desc 'Additional interface details.'
 
     def insync?(is)
-      is.to_s == should.to_s
+      is.sort.to_s == should.sort.to_s
     end
   end
 
@@ -119,6 +119,10 @@ Puppet::Type.newtype(:zabbix_host) do
 
   newproperty(:proxy) do
     desc 'Whether it is monitored by an proxy or not.'
+  end
+
+  newproperty(:proxygroup) do
+    desc 'Whether it is monitored by a proxy group or not.'
   end
 
   newproperty(:tls_connect) do

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -20,6 +20,8 @@
 # @param monitored_by_proxy
 #   When this is monitored by an proxy, please fill in the name of this proxy.
 #   If the proxy is also installed via this module, please fill in the FQDN
+# @param monitored_by_group
+#   When this is monitored by a proxy group, please fill in the name of this proxy group.
 # @param agent_use_ip
 #   When true, when creating hosts via the zabbix-api, it will configure that
 #   connection should me made via ip, not fqdn.
@@ -157,6 +159,7 @@ class zabbix::agent (
   Boolean $manage_repo                                 = $zabbix::params::manage_repo,
   Boolean $manage_resources                            = $zabbix::params::manage_resources,
   $monitored_by_proxy                                  = $zabbix::params::monitored_by_proxy,
+  $monitored_by_group                                  = $zabbix::params::monitored_by_group,
   $agent_use_ip                                        = $zabbix::params::agent_use_ip,
   Variant[String[1],Array[String[1]]] $zbx_groups      = $zabbix::params::agent_zbx_groups,
   $zbx_group_create                                    = $zabbix::params::agent_zbx_group_create,
@@ -266,6 +269,7 @@ class zabbix::agent (
       interfacetype    => $zbx_interface_type,
       interfacedetails => $zbx_interface_details,
       proxy            => $use_proxy,
+      proxygroup       => $monitored_by_group,
       tls_accept       => $tlsaccept,
       tls_connect      => $tlsconnect,
       tls_issuer       => $tlscertissuer,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -350,6 +350,7 @@ class zabbix::params {
   $agent_zbx_templates                      = ['Template OS Linux', 'Template App SSH Service']
   $apache_status                            = false
   $monitored_by_proxy                       = undef
+  $monitored_by_group                       = undef
   # provided by puppet/systemd
   if $facts['systemd'] {
     $agent_logtype                          = 'system'

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -8,6 +8,7 @@
 # @param templates List of templates which should be attached to this host.
 # @param macros Array of hashes (macros) which should be attached to this host.
 # @param proxy Whether it is monitored by an proxy or not.
+# @param proxygroup Whether it is monitored by a proxy group or not.
 # @param interfacetype Internally used identifier for the host interface.
 # @param interfacedetails Hash with interface details for SNMP when interface type is 2.
 # @param tls_connect How the server must connect to the agent
@@ -24,6 +25,7 @@ class zabbix::resources::agent (
   $templates                          = undef,
   $macros                             = undef,
   $proxy                              = undef,
+  $proxygroup                         = undef,
   $interfacetype                      = 1,
   Variant[Array, Hash] $interfacedetails = [],
   Optional[Enum['unencrypted','psk','cert']] $tls_connect = undef,
@@ -40,6 +42,7 @@ class zabbix::resources::agent (
     templates        => $templates,
     macros           => $macros,
     proxy            => $proxy,
+    proxygroup       => $proxygroup,
     interfacetype    => $interfacetype,
     interfacedetails => $interfacedetails,
     tls_connect      => $tls_connect,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Update the zabbix_host provider to use the new Zabbix 7 API fields:
- Replace deprecated proxy_hostid with proxyid
- Add proxy_groupid and monitored_by fields for proxy group support
- Add proxygroup property to zabbix_host type
- Fix interfacedetails insync? comparison to use sorted comparison
- Add monitored_by_group parameter to agent class and resources
