### PR TITLE
Add TLS PSK encryption support for Zabbix hosts

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3683,6 +3683,9 @@ The following parameters are available in the `zabbix::resources::agent` class:
 * [`tls_accept`](#-zabbix--resources--agent--tls_accept)
 * [`tls_issuer`](#-zabbix--resources--agent--tls_issuer)
 * [`tls_subject`](#-zabbix--resources--agent--tls_subject)
+* [`tls_psk`](#-zabbix--resources--agent--tls_psk)
+* [`tls_psk_identity`](#-zabbix--resources--agent--tls_psk_identity)
+* [`update_psk`](#-zabbix--resources--agent--update_psk)
 
 ##### <a name="-zabbix--resources--agent--hostname"></a>`hostname`
 
@@ -3782,7 +3785,7 @@ Default value: `undef`
 
 ##### <a name="-zabbix--resources--agent--tls_accept"></a>`tls_accept`
 
-Data type: `Optional[Enum['unencrypted','psk','cert']]`
+Data type: `Optional[Variant[Enum['unencrypted', 'psk', 'cert'], Array[Enum['unencrypted', 'psk', 'cert'], 1, 3]]]`
 
 How the agent can connect to the server
 
@@ -3801,6 +3804,30 @@ Default value: `undef`
 Data type: `Optional[String[1]]`
 
 Subject of the certificate that is allowed to talk with the server
+
+Default value: `undef`
+
+##### <a name="-zabbix--resources--agent--tls_psk"></a>`tls_psk`
+
+Data type: `Optional[Sensitive[String[32]]]`
+
+The pre-shared key string used for the connection
+
+Default value: `undef`
+
+##### <a name="-zabbix--resources--agent--tls_psk_identity"></a>`tls_psk_identity`
+
+Data type: `Optional[String[1]]`
+
+The identity string associated with the pre-shared key
+
+Default value: `undef`
+
+##### <a name="-zabbix--resources--agent--update_psk"></a>`update_psk`
+
+Data type: `Optional[Boolean]`
+
+Force the update of PSK and identity, required for key rotation
 
 Default value: `undef`
 
@@ -6140,6 +6167,14 @@ How the server connect to the client (unencrypted, psk or cert)
 
 Certificate issuer.
 
+##### `tls_psk`
+
+PSK Key.
+
+##### `tls_psk_identity`
+
+PSK identity.
+
 ##### `tls_subject`
 
 Certificate subject.
@@ -6157,6 +6192,7 @@ The following parameters are available in the `zabbix_host` type.
 * [`group_create`](#-zabbix_host--group_create)
 * [`hostname`](#-zabbix_host--hostname)
 * [`provider`](#-zabbix_host--provider)
+* [`update_psk`](#-zabbix_host--update_psk)
 
 ##### <a name="-zabbix_host--group_create"></a>`group_create`
 
@@ -6172,6 +6208,14 @@ FQDN of the machine.
 
 The specific backend to use for this `zabbix_host` resource. You will seldom need to specify this --- Puppet will
 usually discover the appropriate provider for your platform.
+
+##### <a name="-zabbix_host--update_psk"></a>`update_psk`
+
+Valid values: `true`, `false`
+
+Forcefully update the PSK and PSK identity.
+
+Default value: `false`
 
 ### <a name="zabbix_hostgroup"></a>`zabbix_hostgroup`
 

--- a/lib/puppet/provider/zabbix_host/ruby.rb
+++ b/lib/puppet/provider/zabbix_host/ruby.rb
@@ -67,6 +67,10 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
 
     tls_accept = @resource[:tls_accept].nil? ? 1 : @resource[:tls_accept]
     tls_connect = @resource[:tls_connect].nil? ? 1 : @resource[:tls_connect]
+    tls_psk = {
+      tls_psk_identity: @resource[:tls_psk_identity].nil? ? nil : @resource[:tls_psk_identity],
+      tls_psk: @resource[:tls_psk]&.unwrap
+    }
 
     # Now we create the host
     zbx.hosts.create(
@@ -88,7 +92,8 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       tls_connect: tls_connect,
       tls_accept: tls_accept,
       tls_issuer: @resource[:tls_issuer].nil? ? '' : @resource[:tls_issuer],
-      tls_subject: @resource[:tls_subject].nil? ? '' : @resource[:tls_subject]
+      tls_subject: @resource[:tls_subject].nil? ? '' : @resource[:tls_subject],
+      **tls_psk.compact
     )
   end
 
@@ -127,6 +132,16 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       templateids << template_id
     end
     templateids
+  end
+
+  def set_psk
+    return unless (!@property_hash[:update_psk].nil? && @property_hash[:update_psk].is_a?(TrueClass)) || (!@resource[:update_psk].nil? && @resource[:update_psk].is_a?(TrueClass))
+
+    zbx.hosts.create_or_update(
+      host: @resource[:hostname],
+      tls_psk_identity: @resource[:tls_psk_identity].nil? ? nil : @resource[:tls_psk_identity],
+      tls_psk: @resource[:tls_psk]&.unwrap
+    )
   end
 
   #
@@ -239,6 +254,8 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
 
   def tls_connect=(int)
     @property_hash[:tls_connect] = int
+    @property_hash[:update_psk] = true
+
     zbx.hosts.create_or_update(
       host: @resource[:hostname],
       tls_connect: @property_hash[:tls_connect].nil? ? 1 : @property_hash[:tls_connect]
@@ -247,6 +264,7 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
 
   def tls_accept=(int)
     @property_hash[:tls_accept] = int
+    @property_hash[:update_psk] = true
 
     zbx.hosts.create_or_update(
       host: @resource[:hostname],
@@ -268,5 +286,15 @@ Puppet::Type.type(:zabbix_host).provide(:ruby, parent: Puppet::Provider::Zabbix)
       host: @resource[:hostname],
       tls_subject: @property_hash[:tls_subject].nil? ? '' : @property_hash[:tls_subject]
     )
+  end
+
+  def tls_psk_identity=(string)
+    @property_hash[:tls_psk_identity] = string
+    set_psk
+  end
+
+  def tls_psk=(string)
+    @property_hash[:tls_psk] = string
+    set_psk
   end
 end

--- a/lib/puppet/type/zabbix_host.rb
+++ b/lib/puppet/type/zabbix_host.rb
@@ -3,6 +3,12 @@
 Puppet::Type.newtype(:zabbix_host) do
   @doc = 'Manage zabbix hosts'
 
+  encryptions = {
+    unencrypted: 0b001,
+    psk: 0b010,
+    cert: 0b100
+  }
+
   ensurable do
     desc 'The basic property that the resource should be in.'
     defaultvalues
@@ -22,6 +28,8 @@ Puppet::Type.newtype(:zabbix_host) do
 
   def munge_encryption(value)
     case value
+    when Array
+      value.uniq.reduce(0b0) { |acc, elem| acc | (encryptions[elem.to_sym].nil? ? 0b0 : encryptions[elem.to_sym]) }
     when 1, 'unencrypted', :unencrypted
       1
     when 2, 'psk', :psk
@@ -29,12 +37,27 @@ Puppet::Type.newtype(:zabbix_host) do
     when 4, 'cert', :cert
       4
     else
-      raise(Puppet::Error, 'munge_encryption only takes unencrypted, psk or cert')
+      raise(Puppet::Error, 'munge_encryption only takes unencrypted, psk or cert or array of these values')
     end
+  end
+
+  validate do
+    raise Puppet::ParseError, _("'tls_psk' and 'tls_psk_identity' are required for 'tls_accept' and/or 'tls_connect' set to PSK") if ((!self[:tls_accept].nil? && (munge_encryption(self[:tls_accept]) & encryptions[:psk]) == encryptions[:psk]) || (!self[:tls_connect].nil? && munge_encryption(self[:tls_connect]) == 2)) && (self[:tls_psk].nil? || self[:tls_psk_identity].nil?)
   end
 
   newparam(:hostname, namevar: true) do
     desc 'FQDN of the machine.'
+  end
+
+  newparam(:update_psk) do
+    desc 'Forcefully update the PSK and PSK identity.'
+
+    newvalues(true, false)
+    defaultto false
+
+    munge do |value|
+      @resource.munge_boolean(value)
+    end
   end
 
   newproperty(:id) do
@@ -149,6 +172,14 @@ Puppet::Type.newtype(:zabbix_host) do
 
   newproperty(:tls_subject) do
     desc 'Certificate subject.'
+  end
+
+  newproperty(:tls_psk_identity) do
+    desc 'PSK identity.'
+  end
+
+  newproperty(:tls_psk) do
+    desc 'PSK Key.'
   end
 
   autorequire(:file) { '/etc/zabbix/api.conf' }

--- a/manifests/javagateway.pp
+++ b/manifests/javagateway.pp
@@ -27,7 +27,7 @@ class zabbix::javagateway (
   # Fix for pid file. Is different in Zabbix (4, 5) and 6
   $real_pidfile = $zabbix_version ? {
     /^[45]\.[024]/ => pick($pidfile, '/var/run/zabbix/zabbix_java.pid'),
-    /^[6]\.[024]/  => pick($pidfile, '/var/run/zabbix/zabbix_java_gateway.pid'),
+    /^[67]\.[024]/  => pick($pidfile, '/var/run/zabbix/zabbix_java_gateway.pid'),
   }
   # Only include the repo class if it has not yet been included
   unless defined(Class['Zabbix::Repo']) {

--- a/manifests/resources/agent.pp
+++ b/manifests/resources/agent.pp
@@ -14,6 +14,9 @@
 # @param tls_accept How the agent can connect to the server
 # @param tls_issuer Issuer of the certificate that is allowed to talk with the serve
 # @param tls_subject Subject of the certificate that is allowed to talk with the server
+# @param tls_psk The pre-shared key string used for the connection
+# @param tls_psk_identity The identity string associated with the pre-shared key
+# @param update_psk Force the update of PSK and identity, required for key rotation
 class zabbix::resources::agent (
   $hostname                           = undef,
   $ipaddress                          = undef,
@@ -27,9 +30,12 @@ class zabbix::resources::agent (
   $interfacetype                      = 1,
   Variant[Array, Hash] $interfacedetails = [],
   Optional[Enum['unencrypted','psk','cert']] $tls_connect = undef,
-  Optional[Enum['unencrypted','psk','cert']] $tls_accept  = undef,
+  Optional[Variant[Enum['unencrypted', 'psk', 'cert'], Array[Enum['unencrypted', 'psk', 'cert'], 1, 3]]] $tls_accept  = undef,
   Optional[String[1]] $tls_issuer                         = undef,
   Optional[String[1]] $tls_subject                        = undef,
+  Optional[Sensitive[String[32]]] $tls_psk                = undef,
+  Optional[String[1]] $tls_psk_identity                   = undef,
+  Optional[Boolean] $update_psk                           = undef,
 ) {
   @@zabbix_host { $hostname:
     ipaddress        => $ipaddress,
@@ -46,5 +52,8 @@ class zabbix::resources::agent (
     tls_accept       => $tls_accept,
     tls_issuer       => $tls_issuer,
     tls_subject      => $tls_subject,
+    tls_psk_identity => $tls_psk_identity,
+    tls_psk          => $tls_psk,
+    update_psk       => $update_psk,
   }
 }

--- a/spec/acceptance/zabbix_host_spec.rb
+++ b/spec/acceptance/zabbix_host_spec.rb
@@ -337,6 +337,42 @@ describe 'zabbix_host type' do
           expect(test5['tls_subject']).to eq('MyClientCertificate')
         end
       end
+
+      it_behaves_like 'an idempotent resource' do
+        let(:manifest) do
+          <<-EOS
+          zabbix_host { 'test6.example.com':
+            ipaddress        => '127.0.0.6',
+            use_ip           => true,
+            port             => 10050,
+            groups           => ['Virtual machines'],
+            templates        => #{template},
+            macros           => [],
+            tls_accept       => 'psk',
+            tls_connect      => 'psk',
+            tls_psk_identity => 'MyPSKIdentity',
+            tls_psk          => 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+            update_psk       => true,
+          }
+          EOS
+        end
+      end
+
+      context 'test6.example.com' do
+        let(:test6) { result_hosts.select { |h| h['host'] == 'test6.example.com' }.first }
+
+        it 'is created' do
+          expect(test6['host']).to eq('test6.example.com')
+        end
+
+        it 'has tls_connect set to psk (2)' do
+          expect(test6['tls_connect']).to eq('2')
+        end
+
+        it 'has tls_accept set to psk (2)' do
+          expect(test6['tls_accept']).to eq('2')
+        end
+      end
     end
   end
 end

--- a/spec/types/zabbix_host_spec.rb
+++ b/spec/types/zabbix_host_spec.rb
@@ -21,5 +21,55 @@ describe 'zabbix_host' do
 
     it { is_expected.to be_valid_type.with_parameters('hostname') }
     it { is_expected.to be_valid_type.with_parameters('group_create') }
+
+    it { is_expected.to be_valid_type.with_properties('tls_psk') }
+    it { is_expected.to be_valid_type.with_properties('tls_psk_identity') }
+    it { is_expected.to be_valid_type.with_parameters('update_psk') }
+  end
+
+  context 'when tls_connect is psk but tls_psk and tls_psk_identity are missing' do
+    it 'raises an error' do
+      expect do
+        Puppet::Type.type(:zabbix_host).new(
+          name: 'psk-test.example.com',
+          tls_connect: 'psk'
+        )
+      end.to raise_error(Puppet::Error, %r{tls_psk.*tls_psk_identity.*required}i)
+    end
+  end
+
+  context 'when tls_accept is psk but tls_psk and tls_psk_identity are missing' do
+    it 'raises an error' do
+      expect do
+        Puppet::Type.type(:zabbix_host).new(
+          name: 'psk-test2.example.com',
+          tls_accept: 'psk'
+        )
+      end.to raise_error(Puppet::Error, %r{tls_psk.*tls_psk_identity.*required}i)
+    end
+  end
+
+  context 'when tls_connect is psk and tls_psk + tls_psk_identity are provided' do
+    it 'does not raise an error' do
+      expect do
+        Puppet::Type.type(:zabbix_host).new(
+          name: 'psk-test3.example.com',
+          tls_connect: 'psk',
+          tls_psk: 'abcdef0123456789abcdef0123456789',
+          tls_psk_identity: 'my_psk_id'
+        )
+      end.not_to raise_error
+    end
+  end
+
+  context 'when tls_connect is unencrypted without psk params' do
+    it 'does not raise an error' do
+      expect do
+        Puppet::Type.type(:zabbix_host).new(
+          name: 'nopsk-test.example.com',
+          tls_connect: 'unencrypted'
+        )
+      end.not_to raise_error
+    end
   end
 end

--- a/spec/unit/puppet/provider/zabbix_host/ruby.rb
+++ b/spec/unit/puppet/provider/zabbix_host/ruby.rb
@@ -21,7 +21,7 @@ describe Puppet::Type.type(:zabbix_host).provider(:ruby) do
     end
   end
 
-  %i[create exists? destroy get_groupids get_templateids ipaddress use_ip port groups templates macros proxy].each do |method|
+  %i[create exists? destroy get_groupids get_templateids ipaddress use_ip port groups templates macros proxy tls_connect tls_accept tls_issuer tls_subject tls_psk_identity tls_psk set_psk].each do |method|
     it "responds to the instance method #{method}" do
       expect(described_class.new).to respond_to(method)
     end

--- a/spec/unit/puppet/type/zabbix_host_spec.rb
+++ b/spec/unit/puppet/type/zabbix_host_spec.rb
@@ -27,6 +27,10 @@ describe Puppet::Type.type(:zabbix_host) do
       templates
       macros
       use_ip
+      tls_connect
+      tls_accept
+      tls_psk
+      tls_psk_identity
     ].each do |param|
       it "has a #{param} property" do
         expect(described_class.attrtype(param)).to eq(:property)
@@ -135,6 +139,100 @@ describe Puppet::Type.type(:zabbix_host) do
 
     describe 'use_ip' do
       it_behaves_like 'boolean property', :use_ip, nil
+    end
+
+    describe 'tls_connect' do
+      [1, 'unencrypted', 4, 'cert'].each do |val|
+        it "accepts #{val}" do
+          expect do
+            described_class.new(name: 'host', tls_connect: val)
+          end.not_to raise_error
+        end
+      end
+
+      [2, 'psk'].each do |val|
+        it "accepts #{val} (with required PSK params)" do
+          expect do
+            described_class.new(name: 'host', tls_connect: val, tls_psk: 'key', tls_psk_identity: 'id')
+          end.not_to raise_error
+        end
+      end
+    end
+
+    describe 'tls_accept' do
+      [1, 'unencrypted', 4, 'cert'].each do |val|
+        it "accepts #{val}" do
+          expect do
+            described_class.new(name: 'host', tls_accept: val)
+          end.not_to raise_error
+        end
+      end
+
+      [2, 'psk'].each do |val|
+        it "accepts #{val} (with required PSK params)" do
+          expect do
+            described_class.new(name: 'host', tls_accept: val, tls_psk: 'key', tls_psk_identity: 'id')
+          end.not_to raise_error
+        end
+      end
+    end
+
+    describe 'tls_psk_identity' do
+      it_behaves_like 'validated property', :tls_psk_identity, nil, %w[myID PSK001]
+    end
+
+    describe 'tls_psk' do
+      it_behaves_like 'validated property', :tls_psk, nil, %w[1234567890ABCDEF]
+    end
+  end
+
+  describe 'when validating tls logic' do
+    context 'with tls_connect set to psk' do
+      it 'raises an error if tls_psk is missing' do
+        expect do
+          described_class.new(
+            name: 'checklist_host',
+            tls_connect: 'psk',
+            tls_psk_identity: 'myID'
+          )
+        end.to raise_error(Puppet::Error, %r{'tls_psk' and 'tls_psk_identity' are required})
+      end
+
+      it 'raises an error if tls_psk_identity is missing' do
+        expect do
+          described_class.new(
+            name: 'checklist_host',
+            tls_connect: 'psk',
+            tls_psk: 'secret123'
+          )
+        end.to raise_error(Puppet::Error, %r{'tls_psk' and 'tls_psk_identity' are required})
+      end
+    end
+
+    context 'with tls_accept set to psk' do
+      it 'raises an error if tls_psk or identity is missing' do
+        expect do
+          described_class.new(
+            name: 'checklist_host',
+            tls_accept: 'psk',
+            tls_psk: 'secret123'
+          )
+        end.to raise_error(Puppet::Error, %r{'tls_psk' and 'tls_psk_identity' are required})
+      end
+    end
+
+    context 'with valid psk configuration' do
+      it 'accepts psk when identity and key are present' do
+        expect do
+          described_class.new(
+            name: 'checklist_host',
+            tls_connect: 'psk',
+            tls_accept: 'psk',
+            tls_psk: 'secret123',
+            tls_psk_identity: 'myID'
+          )
+        end.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR introduces support for Zabbix TLS PSK encryption (Pre-Shared Key) to the `zabbix_host` type and provider. This allows fully automated provisioning of encrypted agents via Puppet, removing the need for manual configuration in the Zabbix frontend.


