### PR TITLE
fix: pass authorization headers in httpd

### DIFF
--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -290,6 +290,9 @@ class zabbix::web (
             handler => 'proxy:unix:/var/run/php-fpm/zabbix.sock|fcgi://localhost',
           },
         ],
+        # Pass authentication headers used by plugins
+        # https://github.com/grafana/grafana-zabbix/issues/2545
+        custom_fragment  => 'CGIPassAuth On',
       }
       $proxy_directory = {
         path => 'fcgi://localhost:9000',


### PR DESCRIPTION

#### Pull Request (PR) description

Pass authorization headers in Apache and prevent problems with plugins that use authorization headers

#### This Pull Request (PR) fixes the following issues

n/a.
