### PR TITLE
feat: manage PHP dependencies when necessary

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,6 +14,7 @@
 * [`zabbix::database::sqlite`](#zabbix--database--sqlite): Class to handle sqlite database installations zabbix will automatically create a sqlite schema if one does not already exist.
 * [`zabbix::javagateway`](#zabbix--javagateway): This will install and configure the zabbix-agent deamon
 * [`zabbix::params`](#zabbix--params): This class manages zabbix server parameters
+* [`zabbix::php`](#zabbix--php): Install a version of PHP supported by Zabbix on system where the default one is too old
 * [`zabbix::proxy`](#zabbix--proxy): This will install and configure the zabbix-proxy deamon
 * [`zabbix::repo`](#zabbix--repo): If enabled, this will install the repository used for installing zabbix
 * [`zabbix::resources::agent`](#zabbix--resources--agent): This will create resources into puppetdb for automatically configuring agent into zabbix front-end.
@@ -95,6 +96,7 @@ The following parameters are available in the `zabbix` class:
 * [`database_type`](#-zabbix--database_type)
 * [`database_path`](#-zabbix--database_path)
 * [`manage_database`](#-zabbix--manage_database)
+* [`manage_php`](#-zabbix--manage_php)
 * [`manage_repo`](#-zabbix--manage_repo)
 * [`manage_firewall`](#-zabbix--manage_firewall)
 * [`manage_service`](#-zabbix--manage_service)
@@ -326,6 +328,14 @@ Data type: `Any`
 When true, it will configure the database and execute the sql scripts.
 
 Default value: `$zabbix::params::manage_database`
+
+##### <a name="-zabbix--manage_php"></a>`manage_php`
+
+Data type: `Optional[String]`
+
+If set, version of PHP to install on systems where default one is not supported by Zabbix (actually only EL8).
+
+Default value: `undef`
 
 ##### <a name="-zabbix--manage_repo"></a>`manage_repo`
 
@@ -2451,6 +2461,24 @@ Default value: `$zabbix::params::javagateway_timeout`
 
 This class manages zabbix server parameters
 
+### <a name="zabbix--php"></a>`zabbix::php`
+
+Install a version of PHP supported by Zabbix on system where the default one is too old
+
+#### Parameters
+
+The following parameters are available in the `zabbix::php` class:
+
+* [`manage_php`](#-zabbix--php--manage_php)
+
+##### <a name="-zabbix--php--manage_php"></a>`manage_php`
+
+Data type: `Optional[String]`
+
+If set, version of PHP to install on systems where default one is not supported by Zabbix (actually only EL8).
+
+Default value: `undef`
+
 ### <a name="zabbix--proxy"></a>`zabbix::proxy`
 
 This will install and configure the zabbix-proxy deamon
@@ -3969,6 +3997,7 @@ The following parameters are available in the `zabbix::server` class:
 * [`database_type`](#-zabbix--server--database_type)
 * [`database_path`](#-zabbix--server--database_path)
 * [`zabbix_version`](#-zabbix--server--zabbix_version)
+* [`manage_php`](#-zabbix--server--manage_php)
 * [`manage_repo`](#-zabbix--server--manage_repo)
 * [`manage_database`](#-zabbix--server--manage_database)
 * [`zabbix_package_state`](#-zabbix--server--zabbix_package_state)
@@ -4107,6 +4136,14 @@ Data type: `Any`
 This is the zabbix version. Example: 7.0
 
 Default value: `$zabbix::params::zabbix_version`
+
+##### <a name="-zabbix--server--manage_php"></a>`manage_php`
+
+Data type: `Optional[String]`
+
+If set, version of PHP to install on systems where default one is not supported by Zabbix (actually only EL8).
+
+Default value: `undef`
 
 ##### <a name="-zabbix--server--manage_repo"></a>`manage_repo`
 

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -1,0 +1,4 @@
+---
+# https://www.zabbix.com/documentation/6.0/en/manual/installation/upgrade_notes_6045
+# "(...) requires PHP 7.3 or later, regardless of whether you are using SAML authentication."
+zabbix::manage_php: '8.2'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,16 @@
+---
+version: 5
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+hierarchy:
+  - name: "OS version"
+    path: "os/%{facts.os.family}/%{facts.os.name}/%{facts.os.release.major}.yaml"
+  - name: "OS variant"
+    path: "os/%{facts.os.family}/%{facts.os.name}.yaml"
+  - name: "OS family/major"
+    path: "os/%{facts.os.family}/%{facts.os.release.major}.yaml"
+  - name: "OS family"
+    path: "os/%{facts.os.family}.yaml"
+  - name: "common"
+    path: "common.yaml"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,8 @@
 #   you can use this parameter to add the database_path to the above mentioned
 #   path.
 # @param manage_database When true, it will configure the database and execute the sql scripts.
+# @param manage_php
+#   If set, version of PHP to install on systems where default one is not supported by Zabbix (actually only EL8).
 # @param manage_repo When true (default) this module will manage the Zabbix repository.
 # @param manage_firewall When true, it will create iptables rules.
 # @param manage_service
@@ -230,6 +232,7 @@ class zabbix (
   $default_vhost                                                              = $zabbix::params::default_vhost,
   $manage_vhost                                                               = $zabbix::params::manage_vhost,
   $manage_firewall                                                            = $zabbix::params::manage_firewall,
+  Optional[String] $manage_php                                                = undef,
   $manage_repo                                                                = $zabbix::params::manage_repo,
   $manage_resources                                                           = $zabbix::params::manage_resources,
   $manage_service                                                             = $zabbix::params::manage_service,
@@ -406,6 +409,7 @@ class zabbix (
     zabbix_version            => $zabbix_version,
     zabbix_package_state      => $zabbix_package_state,
     manage_firewall           => $manage_firewall,
+    manage_php                => $manage_php,
     manage_repo               => $manage_repo,
     manage_database           => $manage_database,
     manage_service            => $manage_service,

--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -1,0 +1,27 @@
+# @summary
+#   Install a version of PHP supported by Zabbix on system where the default one is too old
+# @param manage_php
+#   If set, version of PHP to install on systems where default one is not supported by Zabbix (actually only EL8).
+#
+class zabbix::php (
+  Optional[String] $manage_php = undef
+) {
+  if $manage_php {
+    case $facts['os']['family'] {
+      'RedHat': {
+        case $facts['os']['release']['major'] {
+          '8': {
+            package { 'php':
+              ensure   => $manage_php,
+              provider => 'dnfmodule',
+            }
+          }
+          default: {
+          }
+        }
+      }
+      default: {
+      }
+    }
+  }
+}

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,6 +9,8 @@
 #   you can use this parameter to add the database_path to the above mentioned
 #   path.
 # @param zabbix_version This is the zabbix version. Example: 7.0
+# @param manage_php
+#   If set, version of PHP to install on systems where default one is not supported by Zabbix (actually only EL8).
 # @param manage_repo When true (default) this module will manage the Zabbix repository.
 # @param manage_database When true, it will configure the database and execute the sql scripts.
 # @param zabbix_package_state The state of the package that needs to be installed: present or latest.
@@ -175,6 +177,7 @@ class zabbix::server (
   $zabbix_version                                                             = $zabbix::params::zabbix_version,
   $zabbix_package_state                                                       = $zabbix::params::zabbix_package_state,
   Boolean $manage_firewall                                                    = $zabbix::params::manage_firewall,
+  Optional[String] $manage_php                                                = undef,
   Boolean $manage_repo                                                        = $zabbix::params::manage_repo,
   Boolean $manage_database                                                    = $zabbix::params::manage_database,
   Boolean $manage_service                                                     = $zabbix::params::manage_service,
@@ -347,10 +350,15 @@ class zabbix::server (
     }
   }
 
+  # If necessary, install correct PHP version
+  class { 'zabbix::php':
+    manage_php => $manage_php,
+  }
+
   # Installing the packages
   package { "zabbix-server-${db}":
     ensure  => $zabbix_package_state,
-    require => Class['zabbix::repo'],
+    require => [Class['zabbix::repo'], Class['zabbix::php']],
     tag     => 'zabbix',
   }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Zabbix >= 6.0.47 requires PHP 7.3, default on EL8 is PHP 7.2

Reference: https://www.zabbix.com/rn/rn6.0.47

Manage it in a separate class that can be later removed (or kept for when it'll happen on EL9)

#### This Pull Request (PR) fixes the following issues

Fixes #974 
